### PR TITLE
Improve barley example

### DIFF
--- a/examples/vega/barley.json
+++ b/examples/vega/barley.json
@@ -78,27 +78,16 @@
         "update": {
           "x": {"value": 0.5},
           "y": {"scale": "g", "field": "key", "offset": 15.5},
-          "width": {"value": 200},
+          "width": {"group": "width"},
           "height": {"value": 103},
           "stroke": {"value": "#ccc"},
           "strokeWidth": {"value": 1}
         }
       },
+      "axes": [
+        {"type": "y", "scale": "y"}
+      ],
       "marks": [
-        {
-          "type": "text",
-          "from": {"data": "variety"},
-          "properties": {
-            "update": {
-              "x": {"value": -4},
-              "y": {"scale": "y", "field": "key"},
-              "text": {"field": "key"},
-              "align": {"value": "right"},
-              "baseline": {"value": "middle"},
-              "fill": {"value": "#000"}
-            }
-          }
-        },
         {
           "type": "symbol",
           "properties": {


### PR DESCRIPTION
A couple of small improvements/simplifications to the barley example, using new vega features.

Surprisingly it didn't work when I replaced {"value": 103} with {"group": "height"} - and I'm not yet familiar enough with the source to see why.

I think it's also possible to replace the use of the first text mark by an {"scale": "g", "type": "y"} plus some tweaking - maybe this is a sufficiently common use case (labelling facets) that it deserves it's own axis type?
