### PR TITLE
fixed bug in assign option to stats

### DIFF
--- a/src/data/stats.js
+++ b/src/data/stats.js
@@ -65,14 +65,18 @@ vg.data.stats = function() {
       for (i=0, len=list.length; i<len; ++i) {
         list[i].stats = v;
       }
+      o = list;
     }
     
     return o;
   }
   
   function stats(data) {
-    return (vg.isArray(data) ? [data] : data.values || [])
-      .map(reduce); // no pun intended
+    if (vg.isArray(data)) {
+      return reduce(data);
+    } else {
+      return (data.values || []).map(reduce);
+    }
   }
   
   stats.median = function(bool) {


### PR DESCRIPTION
Code was assigning extra properties to `list` but not returning the output. Also, data were being wrapped in a list to use `reduce` but not unwrapped on return. This buried the data an extra level deep in `items` when `assign: true` was set, resulting in failure to render.
