### PR TITLE
added ability to specify text position in polar coordinates

### DIFF
--- a/src/canvas/marks.js
+++ b/src/canvas/marks.js
@@ -292,6 +292,13 @@ vg.canvas.marks = (function() {
       opac = o.opacity == null ? 1 : o.opacity;
       if (opac == 0) continue;
 
+      if (o.radius) {
+        o.x = o.radius * Math.cos(o.ang);
+        o.y = o.radius * Math.sin(o.ang);
+      }
+      if (o.origin_x) { o.x = (o.x || 0) + o.origin_x }
+      if (o.origin_y) { o.y = (o.y || 0) + o.origin_y }
+        
       if (o.angle) {
         g.save();
         g.translate(o.x || 0, o.y || 0);

--- a/src/svg/marks.js
+++ b/src/svg/marks.js
@@ -147,6 +147,13 @@ vg.svg.marks = (function() {
         base = o.baseline==="top" ? ".9em"
              : o.baseline==="middle" ? ".35em" : 0;
   
+    if (o.radius) {
+      x = o.radius * Math.cos(o.ang);
+      y = o.radius * Math.sin(o.ang);
+    }
+    if (o.origin_x) { x = (x || 0) + o.origin_x }
+    if (o.origin_y) { y = (y || 0) + o.origin_y }
+      
     this.setAttribute("x", x + dx);
     this.setAttribute("y", y + dy);
     this.setAttribute("dy", dy);


### PR DESCRIPTION
Two new sets of properties for text marks:
- `origin_x` and `origin_y` allow one to set an alternate coordinate origin relative to which text locations can be specified.
- `radius` and `ang` allow text positions to be specified in polar coordinates. If present, these override `x` and `y`.

Should work in both canvas and svg.
