### PR TITLE
Skip area/line bounds calculation when there is no data

### DIFF
--- a/src/scene/bounds.js
+++ b/src/scene/bounds.js
@@ -275,6 +275,7 @@ vg.scene.bounds = (function() {
         item, i, len;
         
     if (type==="area" || type==="line") {
+      if (!items.length) return;
       items[0].bounds = func(items[0], bounds);
     } else {
       for (i=0, len=items.length; i<len; ++i) {


### PR DESCRIPTION
If a line mark has no data to work with, the bounds calculation will throw an error.

This [vega spec](https://gist.github.com/maspwr/e149710b102e7b8a608b) can be pasted into http://trifacta.github.io/vega/editor/ to demonstrate the issue.
