### PR TITLE
Partial security - data url whitelisting

### DIFF
--- a/src/_config.js
+++ b/src/_config.js
@@ -4,6 +4,17 @@ vg.config = {};
 // via timetler.com/2012/10/13/environment-detection-in-javascript/
 vg.config.isNode = typeof exports !== 'undefined' && this.exports !== exports;
 
+// Allows domain restriction when using data loading via XHR.
+// To enable, set it to a list of allowed domains
+// e.g. ['wikipedia.org', 'eff.org']
+// Domains must not end in a '.'
+vg.config.domainWhitelist = false;
+
+// If true, the data is assumed to be from a trusted source, thus allowing
+// any potentially unsafe operations, such as test="alert(document.cookie)"
+// TODO: handling needs to be implemented in the data layer
+vg.config.trustData = true;
+
 // base url for loading external data files
 // used only for server-side operation
 vg.config.baseURL = "";

--- a/src/data/load.js
+++ b/src/data/load.js
@@ -23,6 +23,26 @@ function vg_load_isFile(url) {
 
 function vg_load_xhr(url, callback) {
   vg.log("LOAD: " + url);
+  if (vg.config.domainWhitelist) {
+    // parse url to get hostname
+    var a = document.createElement('a');
+    a.href = url;
+    var hostname = a.hostname.toLowerCase();
+    if (hostname.charAt(hostname.length-1) === '.') {
+      hostname = hostname.substring(0, hostname.length-1);
+    }
+    if (vg.config.domainWhitelist.every(function(domain) {
+        // returns false if hostname either equals to domain,
+        // or hostname ends with ".domain"
+        var d = domain.toLowerCase(),
+          pos = hostname.length - d.length;
+        return hostname.indexOf(d, pos) === -1 ||  // !hostname.endsWith(d)
+          (pos > 0 && hostname.charAt(pos-1) !== '.'); })
+    ) {
+      vg.error("URL's domain is not white-listed");
+      return;
+    }
+  }
   d3.xhr(url, function(err, resp) {
     if (resp) resp = resp.responseText;
     callback(err, resp);


### PR DESCRIPTION
- Added vg.config.domainWhitelist = ['domain',...]
  If this config value is set, data urls will only work if the domain
  or a subdomain of that URL is listed.
- Added a non-functional vg.config.trustData
  This value should be examined when performing eval()-like operations,
  e.g. test='alert(document.cookie)'
