### PR TITLE
Update d3 dependency to version 3.4.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "vg2svg": "./bin/vg2svg"
   },
   "dependencies": {
-    "d3": "3.4.10",
+    "d3": "3.4.12",
     "canvas": "1.1.3",
     "optimist": "0.6.1",
     "topojson": "1.6.14",


### PR DESCRIPTION
The newer version uses jsdom@1.0.0, a change which landed in
https://github.com/mbostock/d3/commit/b5ddd2 to address the fact
that the older version of jsdom does not work with bluebird
(see https://github.com/petkaantonov/bluebird/issues/291)
