### PR TITLE
additionalProperties should not be false in propset def

### DIFF
--- a/src/parse/properties.js
+++ b/src/parse/properties.js
@@ -565,8 +565,9 @@ properties.schema = {
         "fontWeight": {"$ref": "#/refs/stringValue"},
         "fontStyle": {"$ref": "#/refs/stringValue"}
       },
-
-      "additionalProperties": false
+      "additionalProperties": {
+        "$ref": "#/refs/value"
+      }
     }
   }
 };


### PR DESCRIPTION
propset has "additionalProperties" set to false, which causes the linking.json spec to fail validation with:

`node scripts/schema.js > vega-schema.json && z-schema vega-schema.json test/spec/linking.json`