### PR TITLE
Group sub-marks and sub-scales are not validated against the schema

### DIFF
--- a/src/parse/mark.js
+++ b/src/parse/mark.js
@@ -43,7 +43,6 @@ parseMark.schema = {
             "mark": {"type": "string"},
             "transform": {"$ref": "#/defs/transform"}
           },
-          "oneOf":[{"required": ["data"]}, {"required": ["mark"]}],
           "additionalProperties": false
         },
 

--- a/src/parse/marks.js
+++ b/src/parse/marks.js
@@ -52,9 +52,11 @@ parseRootMark.schema = {
 
     "nonGroupMark": {
       "allOf": [
-        {"$ref": "#/defs/mark"},
-        { "not": {"$ref": "#/defs/groupMark"} }
-      ]
+        {
+          "not": { "properties": { "type": {"enum": ["group"]} } },
+        },
+        {"$ref": "#/defs/mark"}
+      ]   
     }
   }
 };

--- a/src/parse/marks.js
+++ b/src/parse/marks.js
@@ -33,7 +33,7 @@ parseRootMark.schema = {
         },
         "marks": {
           "type": "array",
-          "items": {"oneOf":[{"$ref": "#/defs/groupMark"}, {"$ref": "#/defs/nonGroupMark"}]}
+          "items": {"oneOf":[{"$ref": "#/defs/groupMark"}, {"$ref": "#/defs/visualMark"}]}
         }
       }
     },
@@ -50,7 +50,7 @@ parseRootMark.schema = {
       ]
     },
 
-    "nonGroupMark": {
+    "visualMark": {
       "allOf": [
         {
           "not": { "properties": { "type": {"enum": ["group"]} } },

--- a/src/parse/marks.js
+++ b/src/parse/marks.js
@@ -33,18 +33,28 @@ parseRootMark.schema = {
         },
         "marks": {
           "type": "array",
-          "items": {"anyOf":[{"$ref": "#/defs/groupMark"}, {"$ref": "#/defs/mark"}]}
+          "items": {"oneOf":[{"$ref": "#/defs/groupMark"}, {"$ref": "#/defs/nonGroupMark"}]}
         }
       }
     },
 
+
     "groupMark": {
-      "allOf": [{"$ref": "#/defs/mark"}, {"$ref": "#/defs/container"}, {
-        "properties": {
-          "type": {"enum": ["group"]}
+      "allOf": [
+        {
+          "properties": { "type": {"enum": ["group"]} },
+          "required": ["type"]
         },
-        "required": ["type"]
-      }]
+        {"$ref": "#/defs/mark"},
+        {"$ref": "#/defs/container"}
+      ]
+    },
+
+    "nonGroupMark": {
+      "allOf": [
+        {"$ref": "#/defs/mark"},
+        { "not": {"$ref": "#/defs/groupMark"} }
+      ]
     }
   }
 };

--- a/src/parse/properties.js
+++ b/src/parse/properties.js
@@ -440,7 +440,8 @@ properties.schema = {
           "properties": {
             "name": {"$ref": "#/refs/field"},
             "invert": {"type": "boolean", "default": false}
-          }
+          },
+          "required": ["name"]
         }
       ]
     },

--- a/src/scene/Scale.js
+++ b/src/scene/Scale.js
@@ -547,7 +547,7 @@ Scale.schema = {
           "type": {
             "enum": [Types.LINEAR, Types.ORDINAL, Types.TIME, Types.TIME_UTC, Types.LOG, 
               Types.POWER, Types.SQRT, Types.QUANTILE, Types.QUANTIZE, Types.THRESHOLD],
-            "default": "linear"
+            "default": Types.LINEAR
           },
 
           "domain": {
@@ -623,7 +623,8 @@ Scale.schema = {
             "bandWidth": {"oneOf": [{"type": "number"}, {"$ref": "#/refs/signal"}]},
 
             "sort": sortDef
-          }
+          },
+          "required": ["type"]
         }, {
           "properties": {
             "type": {"enum": [Types.TIME, Types.TIME_UTC]},
@@ -631,7 +632,8 @@ Scale.schema = {
             "clamp": {"oneOf": [{"type": "boolean"}, {"$ref": "#/refs/signal"}]},
             "nice": {"oneOf": [{"enum": ["second", "minute", "hour", 
               "day", "week", "month", "year"]}, {"$ref": "#/refs/signal"}]}
-          }
+          },
+          "required": ["type"]
         }, {
           "anyOf": [{
             "properties": {
@@ -646,12 +648,14 @@ Scale.schema = {
             "properties": {
               "type": {"enum": [Types.POWER]},
               "exponent": {"oneOf": [{"type": "number"}, {"$ref": "#/refs/signal"}]}
-            }
+            },
+            "required": ["type"]
           }, {
             "properties": {
               "type": {"enum": [Types.QUANTILE]},
               "sort": sortDef
-            }
+            },
+            "required": ["type"]
           }]
         }]
       }]

--- a/src/scene/Scale.js
+++ b/src/scene/Scale.js
@@ -598,7 +598,12 @@ Scale.schema = {
             ]
           },
 
-          "reverse": {"type": "boolean"},
+          "reverse": {
+            "oneOf": [
+              {"type": "boolean"},
+              {"$ref": "#/refs/data"}
+            ],
+          },
           "round": {"type": "boolean"}
         },
 


### PR DESCRIPTION
The "anyOf" schema for the "marks" array is problematic since "anyOf" implies that a conforming object will be one *or more* schemas, which means that a group mark would be both a group and a non-group mark. Since a group itself has a mark field, that means that the mark information (e.g., properties) would be duplicated.

A more correct implementation is for the "marks" array to contain items that are *either* a group mark or a non-group mark. This PR implements that change by making the "marks" array contain "oneOf" a group mark or a mark that doesn't conform to group.