### PR TITLE
Update formatting, add locale support.

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,12 +34,12 @@
   "dependencies": {
     "d3": "^3.5.6",
     "d3-geo-projection": "^0.2.15",
-    "datalib": "^1.3.2",
+    "datalib": "^1.4.2",
     "topojson": "^1.6.19",
-    "vega-dataflow": "^1.0.4",
+    "vega-dataflow": "^1.1.0",
     "vega-expression": "^1.0.2",
     "vega-logging": "^1.0.1",
-    "vega-scenegraph": "^1.0.5",
+    "vega-scenegraph": "^1.0.6",
     "yargs": "^3.15.0"
   },
   "devDependencies": {

--- a/src/parse/axes.js
+++ b/src/parse/axes.js
@@ -41,6 +41,7 @@ function parseAxis(config, def, index, axis, group) {
   axis.tickValues(def.values || null);
   // axis label formatting
   axis.tickFormat(def.format || null);
+  axis.tickFormatType(def.formatType || null);
   // axis tick subdivision
   axis.tickSubdivide(def.subdivide || 0);
   // axis tick padding

--- a/src/parse/spec.js
+++ b/src/parse/spec.js
@@ -1,6 +1,6 @@
 var dl = require('datalib'),
     log = require('vega-logging'),
-    Model = require('../core/Model'), 
+    Model = require('../core/Model'),
     View = require('../core/View');
 
 function parseSpec(spec, callback) {

--- a/src/scene/legend.js
+++ b/src/scene/legend.js
@@ -41,7 +41,7 @@ function lgnd(model) {
     var scale = size || shape || fill || stroke;
     
     format = !formatString ? null : ((scale.type === 'time') ?
-      d3.time.format(formatString) : d3.format(formatString));
+      dl.format.time(formatString) : dl.format.number(formatString));
     
     if (!legendDef.type) {
       legendDef = (scale===fill || scale===stroke) && !discrete(scale.type) ?


### PR DESCRIPTION
This PR updates all axis, legend and template formatting to pass through datalib's formatting support (^1.4.2). As a result Vega/Datalib now control all automatic formatting decisions, with no reliance on (inconsistent) D3 scale `tickFormat` methods. Most importantly, these facilities support runtime changes to current number and time locale formatting.

For example, to change the number formatting to German (DE-DE):
```javascript
vg.util.format.numberLocale({
  decimal: ",",
  thousands: ".",
  grouping: [3],
  currency: ["", "\xa0€"]
});
```

To change the time formatting to German (DE-DE):
```javascript
vg.util.format.timeLocale({
  dateTime: "%A, der %e. %B %Y, %X",
  date: "%d.%m.%Y",
  time: "%H:%M:%S",
  periods: ["AM", "PM"], // unused
  days: ["Sonntag", "Montag", "Dienstag", "Mittwoch", "Donnerstag", "Freitag", "Samstag"],
  shortDays: ["So", "Mo", "Di", "Mi", "Do", "Fr", "Sa"],
  months: ["Januar", "Februar", "März", "April", "Mai", "Juni", "Juli", "August", "September", "Oktober", "November", "Dezember"],
  shortMonths: ["Jan", "Feb", "Mrz", "Apr", "Mai", "Jun", "Jul", "Aug", "Sep", "Okt", "Nov", "Dez"]
});
```

For more about locale settings, see the [d3-format](https://github.com/d3/d3-format) and [d3-time-format](https://github.com/d3/d3-time-format) module repositories.