### PR TITLE
CountPattern and Lookup are not intrinsically batch operations.

### DIFF
--- a/src/transforms/CountPattern.js
+++ b/src/transforms/CountPattern.js
@@ -21,25 +21,21 @@ function CountPattern(graph) {
 var prototype = (CountPattern.prototype = Object.create(Transform.prototype));
 prototype.constructor = CountPattern;
 
-prototype.transform = function(input) {
+prototype.transform = function(input, reset) {
   log.debug(input, ['countpattern']);
 
   var get = this.param('field'),
       pattern = this.param('pattern'),
-      tcase = this.param('case'),
       stop = this.param('stopwords'),
-      reset = false, run = false;
+      run = false;
 
   // update parameters
-  if (this._case !== tcase) {
-    this._case = tcase;
-    reset = true;
-  }
   if (this._stop !== stop) {
     this._stop = stop;
     this._stop_re = new RegExp('^' + stop + '$', 'i');
     reset = true;
   }
+
   if (this._pattern !== pattern) {
     this._pattern = pattern;
     this._match = new RegExp(this._pattern, 'g');
@@ -88,7 +84,7 @@ prototype._changeset = function(input) {
 };
 
 prototype._tokenize = function(text) {
-  switch (this._case) {
+  switch (this.param('case')) {
     case 'upper': text = text.toUpperCase(); break;
     case 'lower': text = text.toLowerCase(); break;
   }

--- a/src/transforms/Lookup.js
+++ b/src/transforms/Lookup.js
@@ -18,7 +18,7 @@ function Lookup(graph) {
 var prototype = (Lookup.prototype = Object.create(Transform.prototype));
 prototype.constructor = Lookup;
 
-prototype.transform = function(input) {
+prototype.transform = function(input, reset) {
   log.debug(input, ['lookup']);
 
   var on = this.param('on'),
@@ -31,7 +31,7 @@ prototype.transform = function(input) {
       as = this.param('as'),
       defaultValue = this.param('default'),
       lut = this._lut,
-      reset = false, i, v;
+      i, v;
 
   // build lookup table on init, withKey modified, or tuple add/rem
   if (lut == null || this._on !== onF || onF && onLast.fields[onF] ||

--- a/src/transforms/Lookup.js
+++ b/src/transforms/Lookup.js
@@ -1,10 +1,9 @@
 var Tuple = require('vega-dataflow').Tuple,
     log = require('vega-logging'),
-    Transform = require('./Transform'),
-    BatchTransform = require('./BatchTransform');
+    Transform = require('./Transform');
 
 function Lookup(graph) {
-  BatchTransform.prototype.init.call(this, graph);
+  Transform.prototype.init.call(this, graph);
   Transform.addParameters(this, {
     on:      {type: 'data'},
     onKey:   {type: 'field', default: null},
@@ -16,10 +15,10 @@ function Lookup(graph) {
   return this.revises(true).mutates(true);
 }
 
-var prototype = (Lookup.prototype = Object.create(BatchTransform.prototype));
+var prototype = (Lookup.prototype = Object.create(Transform.prototype));
 prototype.constructor = Lookup;
 
-prototype.batchTransform = function(input, data) {
+prototype.transform = function(input) {
   log.debug(input, ['lookup']);
 
   var on = this.param('on'),
@@ -32,7 +31,7 @@ prototype.batchTransform = function(input, data) {
       as = this.param('as'),
       defaultValue = this.param('default'),
       lut = this._lut,
-      batch = false, i, v;
+      reset = false, i, v;
 
   // build lookup table on init, withKey modified, or tuple add/rem
   if (lut == null || this._on !== onF || onF && onLast.fields[onF] ||
@@ -48,7 +47,7 @@ prototype.batchTransform = function(input, data) {
     }
     this._lut = lut;
     this._on = onF;
-    batch = true;
+    reset = true;
   }
 
   function set(t) {
@@ -58,17 +57,11 @@ prototype.batchTransform = function(input, data) {
     }
   }
 
-  if (batch) {
-    // perform batch update if lookup table has changed
-    data.forEach(set);
-  } else {
-    // otherwise, update changeset data only
-    input.add.forEach(set);
-    var run = keys.field.some(function(f) { return input.fields[f]; });
-    if (run) {
-      input.mod.forEach(set);
-      input.rem.forEach(set); 
-    }
+  input.add.forEach(set);
+  var run = keys.field.some(function(f) { return input.fields[f]; });
+  if (run || reset) {
+    input.mod.forEach(set);
+    input.rem.forEach(set); 
   }
 
   as.forEach(function(k) { input.fields[k] = 1; });


### PR DESCRIPTION
This preserves the logic of the two operators, but removes the BatchTransform requirement. If parameters change in response to signal values, or if the secondary dataset is pulsed, existing tuples reflow as part of `input.mod`. Thus, we should always be able to run the operators on `input.add`, and only run them when appropriate on `input.mod` and `input.rem`.