### PR TITLE
Add open hyperlink function to expression lang. (#315)

### DIFF
--- a/src/parse/expr.js
+++ b/src/parse/expr.js
@@ -11,6 +11,7 @@ module.exports = expr.compiler(args, {
     fn.eventGroup = 'event.vg.getGroup';
     fn.eventX = 'event.vg.getX';
     fn.eventY = 'event.vg.getY';
+    fn.open = 'window.open';
     return fn;
   }
 });


### PR DESCRIPTION
Adds an `open` function to expression language, which in turn calls `window.open` to open a hyperlink.