### PR TITLE
[WIP] Update & Transition Control

### DIFF
--- a/src/core/Model.js
+++ b/src/core/Model.js
@@ -4,6 +4,7 @@ var dl = require('datalib'),
     Base = df.Graph.prototype,
     Node  = df.Node, // jshint ignore:line
     GroupBuilder = require('../scene/GroupBuilder'),
+    Transition = require('../scene/Transition'),
     visit = require('../scene/visit'),
     config = require('./config');
 
@@ -92,6 +93,30 @@ prototype.predicate = function(name, predicate) {
 };
 
 prototype.predicates = function() { return this._predicates; };
+
+prototype.update = function(cs, opt) {
+  if (!opt) return cs;
+
+  // set up transition, if requested
+  var d = opt.duration || this._defs.duration, t;
+  if (d) {
+    t = new Transition(d, opt.ease || this._defs.ease);
+    cs.trans = t;
+  }
+
+  // set up special property set, if requested
+  if (opt.props !== undefined) {
+    if (dl.keys(cs.data).length > 0) {
+      throw Error(
+        'New data values are not reflected in the visualization.' +
+        ' Please call view.update() before updating a specified property set.'
+      );
+    }
+    cs.reflow  = true;
+    cs.request = opt.props;
+  }
+  return cs;
+};
 
 prototype.scene = function(renderer) {
   if (!arguments.length) return this._scene;

--- a/src/core/View.js
+++ b/src/core/View.js
@@ -5,8 +5,7 @@ var d3 = require('d3'),
     log = require('vega-logging'),
     Deps = df.Dependencies,
     parseStreams = require('../parse/streams'),
-    Encoder = require('../scene/Encoder'),
-    Transition = require('../scene/Transition');
+    Encoder = require('../scene/Encoder');
 
 function View(el, width, height) {
   this._el    = null;
@@ -311,23 +310,10 @@ function build() {
 prototype.update = function(opt) {
   opt = opt || {};
   var v = this,
-      trans = opt.duration ? new Transition(opt.duration, opt.ease) : null;
+      cs = v._changeset,
+      built = v._build;
 
-  var cs = v._changeset;
-  if (trans) cs.trans = trans;
-  if (opt.props !== undefined) {
-    if (dl.keys(cs.data).length > 0) {
-      throw Error(
-        'New data values are not reflected in the visualization.' +
-        ' Please call view.update() before updating a specified property set.'
-      );
-    }
-
-    cs.reflow  = true;
-    cs.request = opt.props;
-  }
-
-  var built = v._build;
+  v._model.update(cs, opt);
   v._build = v._build || build.call(this);
 
   // If specific items are specified, short-circuit dataflow graph.

--- a/src/parse/spec.js
+++ b/src/parse/spec.js
@@ -16,12 +16,16 @@ function parseSpec(spec, callback) {
     var parsers = require('./'),
         width = spec.width || 500,
         height = spec.height || 500,
-        viewport = spec.viewport || null;
+        viewport = spec.viewport || null,
+        duration = spec.duration || null,
+        ease = spec.ease || null;
 
     model.defs({
       width: width,
       height: height,
       viewport: viewport,
+      duration: duration,
+      ease: ease,
       background: parsers.background(spec.background),
       padding: parsers.padding(spec.padding),
       signals: parsers.signals(model, spec.signals),
@@ -69,6 +73,9 @@ parseSpec.schema = {
             "items": {"type": "number"},
             "maxItems": 2
           },
+
+          "duration": {"type": "number"},
+          "ease": {"type": "string"},
 
           "background": {"$ref": "#/defs/background"},
           "padding": {"$ref": "#/defs/padding"},

--- a/src/parse/streams.js
+++ b/src/parse/streams.js
@@ -123,7 +123,7 @@ function parseStreams(view) {
         node = registry.nodes[type],
         cs = df.ChangeSet.create(null, true),
         filtered = false,
-        val, i, n, h;
+        val, i, n, h, opt;
 
     function invoke(f) {
       return !f.fn(datum, evt, model.values(SIGNALS, f.globals));
@@ -142,10 +142,11 @@ function parseStreams(view) {
       if (val !== h.signal.value() || h.signal.verbose()) {
         h.signal.value(val);
         cs.signals[h.signal.name()] = 1;
+        opt = h.spec.update || opt;
       }
     }
 
-    model.propagate(cs, node);
+    model.propagate(model.update(cs, opt), node);
   }
 
   function mergedStream(sig, selector, exp, spec) {
@@ -237,7 +238,15 @@ parseStreams.schema = {
         "properties": {
           "type": {"type": "string"},
           "expr": {"type": "string"},
-          "scale": {"$ref": "#/refs/scopedScale"}
+          "scale": {"$ref": "#/refs/scopedScale"},
+          "update": {
+            "type": "object",
+            "properties": {
+              "duration": {"type": "number"},
+              "ease": {"type": "string"},
+              "props": {"type": "string"}
+            }
+          }
         },
 
         "additionalProperties": false,

--- a/src/scene/Encoder.js
+++ b/src/scene/Encoder.js
@@ -45,29 +45,15 @@ proto.evaluate = function(input) {
   var graph = this._graph,
       props = this._mark.def.properties || {},
       items = this._mark.items,
+      req   = input.request,
       enter  = props.enter,
-      update = props.update,
+      // TODO falls back to update if no req props.
+      // Is this the desired behavior?
+      update = (req && props[req]) || props.update,
       exit   = props.exit,
       dirty  = input.dirty,
       preds  = graph.predicates(),
-      req = input.request,
-      group = this._mark.group,
-      guide = group && (group.mark.axis || group.mark.legend),
       db = EMPTY, sg = EMPTY, i, len, item, prop;
-
-  if (req && !guide) {
-    if ((prop = props[req]) && input.mod.length) {
-      db = prop.data ? graph.values(Deps.DATA, prop.data) : null;
-      sg = prop.signals ? graph.values(Deps.SIGNALS, prop.signals) : null;
-
-      for (i=0, len=input.mod.length; i<len; ++i) {
-        item = input.mod[i];
-        encode.call(this, prop, item, input.trans, db, sg, preds, dirty);
-      }
-    }
-
-    return input; // exit early if given request
-  }
 
   db = values(Deps.DATA, graph, input, props);
   sg = values(Deps.SIGNALS, graph, input, props);


### PR DESCRIPTION
Experimental branch for adding more control over animated transitions and update property sets.
- Adds top-level `duration` and `ease` property to Vega spec.
- Adds `update` hash property to signal stream handlers. These hashes may include the properties `duration`, `ease` and `props` (for indicating a property set to invoke instead of `"update"`).

One open question for stream handlers is how to handle event cascades implicating multiple `update` hashes. The current strategy is to use the most recent hash, though an alternative would be to use the very first. Either way, this could lead to program behaviors that users have trouble reasoning about.

This also introduces new logic for requested property sets. If a request is included, the normal enter/update/exit cycle still applies. However, if a property set with a name matching the request is found, it will be evaluated in lieu of the update set. If not found, the normal update set is run. 