### PR TITLE
Update d3-cloud.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,9 +32,10 @@
     "vg2svg": "./bin/vg2svg"
   },
   "dependencies": {
+    "canvas-browserify": "^1.1.3",
     "d3": "^3.5.6",
     "d3-geo-projection": "^0.2.15",
-    "d3.layout.cloud": "^1.1.1",
+    "d3-cloud": "^1.2.0",
     "datalib": "^1.4.6",
     "topojson": "^1.6.19",
     "vega-dataflow": "^1.2.5",
@@ -92,7 +93,6 @@
   },
   "browserify-shim": {
     "d3": "global:d3",
-    "d3.layout.cloud": "global:d3.layout.cloud",
     "canvas": "global:canvas",
     "topojson": "global:topojson"
   }

--- a/src/transforms/Wordcloud.js
+++ b/src/transforms/Wordcloud.js
@@ -1,6 +1,7 @@
 var dl = require('datalib'),
     d3 = require('d3'),
-    d3_cloud = require('d3.layout.cloud'),
+    d3_cloud = require('d3-cloud'),
+    Canvas = require('canvas-browserify'),
     Tuple = require('vega-dataflow/src/Tuple'),
     log = require('vega-logging'),
     Transform = require('./Transform'),
@@ -21,7 +22,7 @@ function Wordcloud(graph) {
     spiral: {type: 'value', default: 'archimedean'}
   });
 
-  this._layout = d3_cloud();
+  this._layout = d3_cloud().canvas(function() { return new Canvas(1, 1); });
 
   this._output = {
     'x':          'layout_x',


### PR DESCRIPTION
This includes a fix for using d3-cloud in “headless” mode with Node.js.  Related: #369.