### PR TITLE
Updated Bin transform.

### DIFF
--- a/src/transforms/Bin.js
+++ b/src/transforms/Bin.js
@@ -19,8 +19,8 @@ function Bin(graph) {
   });
 
   this._output = {
-    bin: 'bin',
-    end: 'bin_end'
+    start: 'bin_start',
+    end:   'bin_end'
   };
   return this.mutates(true);
 }
@@ -65,14 +65,14 @@ prototype.batchTransform = function(input, data) {
     var v = get(d);
     v = v == null ? null
       : b.start + b.step * ~~((v - b.start) / b.step);
-    Tuple.set(d, output.bin, v);
+    Tuple.set(d, output.start, v);
     Tuple.set(d, output.end, v + b.step);
   }
   input.add.forEach(update);
   input.mod.forEach(update);
   input.rem.forEach(update);
 
-  input.fields[output.bin] = 1;
+  input.fields[output.start] = 1;
   input.fields[output.end] = 1;
   return input;
 };
@@ -141,7 +141,7 @@ Bin.schema = {
       "type": "object",
       "description": "Rename the output data fields",
       "properties": {
-        "bin": {"type": "string", "default": "bin"},
+        "start": {"type": "string", "default": "bin_start"},
         "end": {"type": "string", "default": "bin_end"}
       },
       "additionalProperties": false

--- a/src/transforms/Bin.js
+++ b/src/transforms/Bin.js
@@ -1,10 +1,11 @@
-var bins = require('datalib').bins,
+var dl = require('datalib'),
     Tuple = require('vega-dataflow').Tuple,
     log = require('vega-logging'),
-    Transform = require('./Transform');
+    Transform = require('./Transform'),
+    BatchTransform = require('./BatchTransform');
 
 function Bin(graph) {
-  Transform.prototype.init.call(this, graph);
+  BatchTransform.prototype.init.call(this, graph);
   Transform.addParameters(this, {
     field: {type: 'field'},
     min: {type: 'value'},
@@ -17,24 +18,39 @@ function Bin(graph) {
     div: {type: 'array<value>', default: [5, 2]}
   });
 
-  this._output = {bin: 'bin'};
+  this._output = {
+    bin: 'bin',
+    end: 'bin_end'
+  };
   return this.mutates(true);
 }
 
-var prototype = (Bin.prototype = Object.create(Transform.prototype));
+var prototype = (Bin.prototype = Object.create(BatchTransform.prototype));
 prototype.constructor = Bin;
 
-prototype.transform = function(input) {
+prototype.extent = function(data) {
+  // TODO only recompute extent upon data or field change?
+  var e = [this.param('min'), this.param('max')], d;
+  if (e[0] == null || e[1] == null) {
+    d = dl.extent(data, this.param('field').accessor);
+    if (e[0] == null) e[0] = d[0];
+    if (e[1] == null) e[1] = d[1];
+  }
+  return e;
+};
+
+prototype.batchTransform = function(input, data) {
   log.debug(input, ['binning']);
 
-  var output  = this._output.bin,
+  var extent  = this.extent(data),
+      output  = this._output,
       step    = this.param('step'),
       steps   = this.param('steps'),
       minstep = this.param('minstep'),
       get     = this.param('field').accessor,
       opt = {
-        min: this.param('min'),
-        max: this.param('max'),
+        min: extent[0],
+        max: extent[1],
         base: this.param('base'),
         maxbins: this.param('maxbins'),
         div: this.param('div')
@@ -43,19 +59,21 @@ prototype.transform = function(input) {
   if (step) opt.step = step;
   if (steps) opt.steps = steps;
   if (minstep) opt.minstep = minstep;
-  var b = bins(opt);
+  var b = dl.bins(opt);
 
   function update(d) {
     var v = get(d);
     v = v == null ? null
       : b.start + b.step * ~~((v - b.start) / b.step);
-    Tuple.set(d, output, v);
+    Tuple.set(d, output.bin, v);
+    Tuple.set(d, output.end, v + b.step);
   }
   input.add.forEach(update);
   input.mod.forEach(update);
   input.rem.forEach(update);
 
-  input.fields[output] = 1;
+  input.fields[output.bin] = 1;
+  input.fields[output.end] = 1;
   return input;
 };
 
@@ -123,11 +141,12 @@ Bin.schema = {
       "type": "object",
       "description": "Rename the output data fields",
       "properties": {
-        "bin": {"type": "string", "default": "bin"}
+        "bin": {"type": "string", "default": "bin"},
+        "end": {"type": "string", "default": "bin_end"}
       },
       "additionalProperties": false
     }
   },
   "additionalProperties": false,
-  "required":["type", "field", "min", "max"]
+  "required": ["type", "field"]
 };

--- a/test/spec/crossfilter.json
+++ b/test/spec/crossfilter.json
@@ -27,7 +27,8 @@
           "field": "hour",
           "min": 0,
           "max": 24,
-          "step": 1
+          "step": 1,
+          "output": {"start": "bin"}
         },
         {
           "type": "aggregate",
@@ -46,7 +47,8 @@
           "field": "delay",
           "min": -60,
           "max": 140,
-          "step": 10
+          "step": 10,
+          "output": {"start": "bin"}
         },
         {"type": "filter", "test": "datum.bin <= 140"},
         {
@@ -66,7 +68,8 @@
           "field": "distance",
           "min": 0,
           "max": 2000,
-          "step": 50
+          "step": 50,
+          "output": {"start": "bin"}
         },
         {"type": "filter", "test": "datum.bin <= 2000"},
         {

--- a/test/transforms/bin.test.js
+++ b/test/transforms/bin.test.js
@@ -25,6 +25,21 @@ describe('Bin', function() {
     };
   }
 
+  it('should handle extent calculation', function(done) {
+    parseSpec(spec({maxbins: 10}), function(model) {
+      var ds = model.data('table'),
+          data = ds.values(),
+          floored = values.map(function(x) { return ~~x; });
+
+      expect(data.length).to.be.above(0).and.equal(floored.length);
+      for (var i=0, len=data.length; i<len; ++i) {
+        expect(data[i].bin_v).to.equal(floored[i]);
+      }
+  
+      done();
+    }, modelFactory);
+  });
+
   it('should handle step definition', function(done) {
     parseSpec(spec({min:0, max:10, step:1}), function(model) {
       var ds = model.data('table'),
@@ -119,6 +134,9 @@ describe('Bin', function() {
     var schema = schemaPath(transforms.bin.schema),
         validate = validator(schema);
 
+    expect(validate({ "type": "bin", "field": "price" })).to.be.true;
+    expect(validate({ "type": "bin", "field": "price", "min": 1 })).to.be.true;
+    expect(validate({ "type": "bin", "field": "price", "max": 10 })).to.be.true;
     expect(validate({ "type": "bin", "field": "price", "min": 1, "max": 10 })).to.be.true;
     expect(validate({ "type": "bin", "field": "price", "min": 1, "max": 10, "base": 5 })).to.be.true;
     expect(validate({ "type": "bin", "field": "price", "min": 1, "max": 10, "maxbins": 5 })).to.be.true;
@@ -129,8 +147,6 @@ describe('Bin', function() {
 
     expect(validate({ "type": "foo" })).to.be.false;
     expect(validate({ "type": "bin" })).to.be.false;
-    expect(validate({ "type": "bin", "field": "price" })).to.be.false;
-    expect(validate({ "type": "bin", "field": "price", "min": 1 })).to.be.false;
     expect(validate({ "type": "bin", "field": "price", "min": 1, "max": 10, "hello": "world" })).to.be.false;
     expect(validate({ "type": "bin", "field": "price", "min": "1", "max": 10 })).to.be.false;
     expect(validate({ "type": "bin", "field": "price", "min": 1, "max": "10" })).to.be.false;

--- a/test/transforms/bin.test.js
+++ b/test/transforms/bin.test.js
@@ -14,7 +14,7 @@ describe('Bin', function() {
   ];
   
   function spec(opt) {
-    var bin = {"type": "bin", "field": "v", "output": {"bin": "bin_v"}};
+    var bin = {"type": "bin", "field": "v", "output": {"start": "bin_v"}};
     for (var name in opt) bin[name] = opt[name];
     return { 
       "data": [{ 


### PR DESCRIPTION
This PR updates the bin transform in two ways:
 1. Perform automatic calculation of min/max if not specified.
 2. Output both bin start and end values to simplify later operations.

Item 1 is implemented directly using datalib's `extent` method rather than a streaming aggregator. To allow this, `Bin` is now a `BatchTransform` instance. This seems simpler and lower overhead than instantiating an aggregator and all its associated state (which would include another full array with all the tuples in it). Simple min/max scans should be pretty fast, and can also be cached more effectively in future updates.

Item 2 extends the binning output with an `"end"` parameter that defaults to `"bin_end"`. For internal consistency, it would be nice to have `"start"` and `"end"` parameters that default to `"bin_start"` and `"bin_end"`. However, for backwards-compatibility I've left the bin_start parameter as simply `"bin"`. Any thoughts on whether we should make a breaking change here? It appears that the crossfilter example is currently the only public example that uses the bin transform, so that is what we would need to update, but any changes here could adversely impact end users.

