### PR TITLE
Report parsing errors to the caller

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,5 +15,6 @@ module.exports = {
   schema: require('./src/core/schema'),
   config: require('./src/core/config'),
   util:  require('datalib'),
+  logging: require('vega-logging'),
   debug: require('vega-logging').debug
 };

--- a/src/parse/data.js
+++ b/src/parse/data.js
@@ -7,6 +7,12 @@ function parseData(model, spec, callback) {
   var config = model.config(),
       count = 0;
 
+  function done(err) {
+    if (callback) {
+      callback(err);
+      callback = undefined;
+    }
+  }
   function loaded(d) {
     return function(error, data) {
       try {
@@ -19,10 +25,9 @@ function parseData(model, spec, callback) {
             log.error('PARSING FAILED: ' + d.url + ' ' + error);
           }
         }
-        if (--count === 0) callback();
+        if (--count === 0) done();
       } catch(error) {
-        count = -1; // prevent success callback
-        callback(error);
+        done(error);
       }
     };
   }
@@ -36,7 +41,7 @@ function parseData(model, spec, callback) {
     parseData.datasource(model, d);
   });
 
-  if (count === 0) setTimeout(callback, 1);
+  if (count === 0) setTimeout(done, 1);
   return spec;
 }
 

--- a/src/parse/data.js
+++ b/src/parse/data.js
@@ -9,12 +9,21 @@ function parseData(model, spec, callback) {
 
   function loaded(d) {
     return function(error, data) {
-      if (error) {
-        log.error('LOADING FAILED: ' + d.url + ' ' + error);
-      } else {
-        model.data(d.name).values(dl.read(data, d.format));
+      try {
+        if (error) {
+          log.error('LOADING FAILED: ' + d.url + ' ' + error);
+        } else if (count >= 0) {
+          try {
+            model.data(d.name).values(dl.read(data, d.format));
+          } catch (error) {
+            log.error('PARSING FAILED: ' + d.url + ' ' + error);
+          }
+        }
+        if (--count === 0) callback();
+      } catch(error) {
+        count = -1; // prevent success callback
+        callback(error);
       }
-      if (--count === 0) callback();
     };
   }
 

--- a/src/parse/spec.js
+++ b/src/parse/spec.js
@@ -3,7 +3,27 @@ var dl = require('datalib'),
     Model = require('../core/Model'),
     View = require('../core/View');
 
+/**
+ * Backward compatibility wrapper that accepts callback without error handler
+ * @param spec
+ * @param callback
+ * @param config (optional)
+ * @param viewFactory (optional)
+ * @returns {*}
+ */
 function parseSpec(spec, callback) {
+  var cb = callback;
+  arguments[1] = function(err, model) {
+    // For backward compatibility, the error is thrown even though it might never be caught
+    if (err) throw err;
+    cb(model);
+  };
+  return module.exports.parse.apply(this, arguments);
+}
+
+module.exports = parseSpec;
+
+parseSpec.parse = function (spec, callback /* config */  /* viewFactory */) {
   var vf = arguments[arguments.length-1],
       viewFactory = arguments.length > 2 && dl.isFunction(vf) ? vf : View.factory,
       config = arguments[2] !== viewFactory ? arguments[2] : {},
@@ -28,7 +48,7 @@ function parseSpec(spec, callback) {
       predicates: parsers.predicates(model, spec.predicates),
       marks: parsers.marks(model, spec, width, height),
       data: parsers.data(model, spec.data, function() {
-        callback(viewFactory(model));
+        if (callback) callback(undefined, viewFactory(model));
       })
     });
   }
@@ -38,22 +58,31 @@ function parseSpec(spec, callback) {
   } else if (dl.isString(spec)) {
     var opts = dl.extend({url: spec}, model.config().load);
     dl.load(opts, function(err, data) {
-      if (err) {
-        log.error('LOADING SPECIFICATION FAILED: ' + err.statusText);
-      } else {
-        try {
-          parse(JSON.parse(data));
-        } catch (e) {
-          log.error('INVALID SPECIFICATION: Must be a valid JSON object. '+e);
+      try {
+        if (err) {
+          log.error('LOADING SPECIFICATION FAILED: ' + err.statusText);
+        } else {
+          try {
+            parse(JSON.parse(data));
+          } catch (e) {
+            log.error('INVALID SPECIFICATION: Must be a valid JSON object. ' + e);
+          }
         }
+      } catch (err) {
+        if (callback) callback(err);
+        callback = false;
       }
     });
   } else {
-    log.error('INVALID SPECIFICATION: Must be a valid JSON object or URL.');
+    try {
+      log.error('INVALID SPECIFICATION: Must be a valid JSON object or URL.');
+    } catch (err) {
+      if (callback) callback(err);
+      callback = false;
+    }
   }
-}
+};
 
-module.exports = parseSpec;
 parseSpec.schema = {
   "defs": {
     "spec": {

--- a/src/parse/spec.js
+++ b/src/parse/spec.js
@@ -39,6 +39,13 @@ parseSpec.parse = function (spec, /* [config,] [viewFactory,] */ callback) {
       model, argInd = 2,
       viewFactory = View.factory;
 
+  function done(err, value) {
+    if (cb) {
+      cb(err, value);
+      cb = undefined;
+    }
+  }
+
   if (arguments.length > argInd && dl.isFunction(arguments[arguments.length - argInd])) {
     viewFactory = arguments[arguments.length - argInd];
     argInd++;
@@ -68,7 +75,7 @@ parseSpec.parse = function (spec, /* [config,] [viewFactory,] */ callback) {
       predicates: parsers.predicates(model, spec.predicates),
       marks: parsers.marks(model, spec, width, height),
       data: parsers.data(model, spec.data, function() {
-        if (cb) cb(undefined, viewFactory(model));
+        done(undefined, viewFactory(model));
       })
     });
   }
@@ -89,16 +96,14 @@ parseSpec.parse = function (spec, /* [config,] [viewFactory,] */ callback) {
           }
         }
       } catch (err) {
-        if (cb) cb(err);
-        cb = false;
+        done(err);
       }
     });
   } else {
     try {
       log.error('INVALID SPECIFICATION: Must be a valid JSON object or URL.');
     } catch (err) {
-      if (cb) cb(err);
-      cb = false;
+      done(err);
     }
   }
 };

--- a/src/parse/spec.js
+++ b/src/parse/spec.js
@@ -34,10 +34,11 @@ module.exports = parseSpec;
  * @param callback (error, model)
  */
 parseSpec.parse = function (spec, /* [config,] [viewFactory,] */ callback) {
-  var model, argInd = 2,
+  // do not assign any values to callback, as it will change arguments
+  var cb = arguments[arguments.length - 1],
+      model, argInd = 2,
       viewFactory = View.factory;
 
-  callback = arguments[arguments.length - 1];
   if (arguments.length > argInd && dl.isFunction(arguments[arguments.length - argInd])) {
     viewFactory = arguments[arguments.length - argInd];
     argInd++;
@@ -67,7 +68,7 @@ parseSpec.parse = function (spec, /* [config,] [viewFactory,] */ callback) {
       predicates: parsers.predicates(model, spec.predicates),
       marks: parsers.marks(model, spec, width, height),
       data: parsers.data(model, spec.data, function() {
-        if (callback) callback(undefined, viewFactory(model));
+        if (cb) cb(undefined, viewFactory(model));
       })
     });
   }
@@ -88,16 +89,16 @@ parseSpec.parse = function (spec, /* [config,] [viewFactory,] */ callback) {
           }
         }
       } catch (err) {
-        if (callback) callback(err);
-        callback = false;
+        if (cb) cb(err);
+        cb = false;
       }
     });
   } else {
     try {
       log.error('INVALID SPECIFICATION: Must be a valid JSON object or URL.');
     } catch (err) {
-      if (callback) callback(err);
-      callback = false;
+      if (cb) cb(err);
+      cb = false;
     }
   }
 };

--- a/src/parse/spec.js
+++ b/src/parse/spec.js
@@ -74,8 +74,8 @@ parseSpec.parse = function (spec, /* [config,] [viewFactory,] */ callback) {
       signals: parsers.signals(model, spec.signals),
       predicates: parsers.predicates(model, spec.predicates),
       marks: parsers.marks(model, spec, width, height),
-      data: parsers.data(model, spec.data, function() {
-        done(undefined, viewFactory(model));
+      data: parsers.data(model, spec.data, function(err) {
+        done(err, err ? undefined : viewFactory(model));
       })
     });
   }


### PR DESCRIPTION
This PR includes the cleanup PR https://github.com/vega/vega/compare/master...nyurik:cleanup?expand=1

It exposes the logging interface to allow for complex error processing

Alternative spec.parse() with error handling
* Handle the case when a user-overriden logger throws an error
* In case of an internal error, report it via callback(error, model)

TODO:
This is a fairly bad workaround, and could really use promises.
The error messages should be replaced with objects to allow
complex error processing.