### PR TITLE
Call `View` with `this` instead of `null`

### DIFF
--- a/src/core/HeadlessView.js
+++ b/src/core/HeadlessView.js
@@ -4,7 +4,7 @@ var sg = require('vega-scenegraph').render,
     View = require('./View');
 
 function HeadlessView(width, height, model) {
-  View.call(null, width, height, model);
+  View.call(this, width, height, model);
   this._type = 'canvas';
   this._renderers = {canvas: canvas, svg: svg};
 }


### PR DESCRIPTION
This call was blowing up in the browser when used. I'm not sure how it wasn't causing an issue in node.

`View` is expecting to set properties on the `this` context,
and you can't set properties on `null`.

I apologize for not performing a proper fork and testing and whatnot, but I cannot for the life of me get `vega` to build locally, so I cannot run the tests.