### PR TITLE
Fix SVGRenderer errors when calling View.padding("auto")

### DIFF
--- a/src/core/View.js
+++ b/src/core/View.js
@@ -166,8 +166,8 @@ prototype.padding = function(pad) {
       this._padding = pad;
       this._strict = false;
     }
-    if (this._renderer) this._renderer.resize(this._width, this._height, pad);
-    if (this._handler)  this._handler.padding(pad);
+    if (this._renderer) this._renderer.resize(this._width, this._height, this._padding);
+    if (this._handler)  this._handler.padding(this._padding);
   }
   return (this._repaint = true, this);
 };
@@ -351,11 +351,6 @@ prototype.update = function(opt) {
   }
 
   v._changeset = df.ChangeSet.create();
-
-  if (opt.autopad){
-    v._autopad = 1;
-    opt.autopad = false; // To avoid an infinite loop.
-  }
 
   return v.autopad(opt);
 };

--- a/src/core/View.js
+++ b/src/core/View.js
@@ -352,6 +352,11 @@ prototype.update = function(opt) {
 
   v._changeset = df.ChangeSet.create();
 
+  if (opt.autopad){
+    v._autopad = 1;
+    opt.autopad = false; // To avoid an infinite loop.
+  }
+
   return v.autopad(opt);
 };
 


### PR DESCRIPTION
[EDIT: title has changed, see 3rd comment]

Adds a new option `autopad` to the `opt` argument of `View.update()`. If it is `true`-ish, Vega will re-run the `autopad` routine. This is useful if the size of the visualisation changes after the `update()` call.