### PR TITLE
Add axis title auto-offset.

### DIFF
--- a/src/core/config.js
+++ b/src/core/config.js
@@ -45,7 +45,10 @@ config.axis = {
   titleFont: 'sans-serif',
   titleFontSize: 11,
   titleFontWeight: 'bold',
-  titleOffset: 35
+  titleOffset: 'auto',
+  titleOffsetAutoMin: 30,
+  titleOffsetAutoMax: Infinity,
+  titleOffsetAutoMargin: 4
 };
 
 // default legend properties


### PR DESCRIPTION
- Add auto-offset calculation for axis titles, based on axis label + domain bounding boxes.
- Change default `titleOffset` axis config param to `'auto'`.
- Add new config params `titleOffsetAutoMin`, `titleOffsetAutoMax`, `titleOffsetAutoMargin`
- Clean up axis config references in `axis.js` to shorten lookups and decrease file size.