### PR TITLE
Add automatic signals for width, height and padding.

### DIFF
--- a/src/core/Model.js
+++ b/src/core/Model.js
@@ -19,6 +19,10 @@ function Model(cfg) {
 
   this.config(cfg);
   Base.init.call(this);
+
+  // create signals for width and height
+  this.signal('width', -1);
+  this.signal('height', -1);
 }
 
 var prototype = (Model.prototype = Object.create(Base));

--- a/src/core/Model.js
+++ b/src/core/Model.js
@@ -19,10 +19,6 @@ function Model(cfg) {
 
   this.config(cfg);
   Base.init.call(this);
-
-  // create signals for width and height
-  this.signal('width', -1);
-  this.signal('height', -1);
 }
 
 var prototype = (Model.prototype = Object.create(Base));

--- a/src/parse/padding.js
+++ b/src/parse/padding.js
@@ -1,11 +1,10 @@
 var dl = require('datalib');
 
 function parsePadding(pad) {
-  if (pad == null) return "auto";
-  else if (dl.isString(pad)) return pad==="strict" ? "strict" : "auto";
-  else if (dl.isObject(pad)) return pad;
-  var p = dl.isNumber(pad) ? pad : 20;
-  return {top:p, left:p, right:p, bottom:p};
+  return pad == null ? 'auto' :
+    dl.isObject(pad) ? pad :
+    dl.isNumber(pad) ? {top:pad, left:pad, right:pad, bottom:pad} :
+    pad === 'strict' ? pad : 'auto';
 }
 
 module.exports = parsePadding;

--- a/src/parse/signals.js
+++ b/src/parse/signals.js
@@ -2,7 +2,7 @@ var dl = require('datalib'),
     SIGNALS = require('vega-dataflow').Dependencies.SIGNALS,
     expr = require('./expr');
 
-var RESERVED = ['datum', 'event', 'signals', 'width', 'height']
+var RESERVED = ['datum', 'event', 'signals', 'width', 'height', 'padding']
   .concat(dl.keys(expr.codegen.functions));
 
 function parseSignals(model, spec) {

--- a/src/parse/signals.js
+++ b/src/parse/signals.js
@@ -2,7 +2,7 @@ var dl = require('datalib'),
     SIGNALS = require('vega-dataflow').Dependencies.SIGNALS,
     expr = require('./expr');
 
-var RESERVED = ['datum', 'event', 'signals']
+var RESERVED = ['datum', 'event', 'signals', 'width', 'height']
   .concat(dl.keys(expr.codegen.functions));
 
 function parseSignals(model, spec) {

--- a/src/parse/spec.js
+++ b/src/parse/spec.js
@@ -14,18 +14,23 @@ function parseSpec(spec, callback) {
     spec = dl.duplicate(spec);
 
     var parsers = require('./'),
-        width  = spec.width || 500,
-        height = spec.height || 500,
-        create = function() { callback(viewFactory(model)); };
+        create  = function() { callback(viewFactory(model)); },
+        width   = spec.width || 500,
+        height  = spec.height || 500,
+        padding = parsers.padding(spec.padding);
 
-    model.signal('width').value(width);
-    model.signal('height').value(height);
+    // create signals for width, height and padding
+    model.signal('width', width);
+    model.signal('height', height);
+    model.signal('padding', padding);
+
+    // initialize model
     model.defs({
       width:      width,
       height:     height,
+      padding:    padding,
       viewport:   spec.viewport || null,
       background: parsers.background(spec.background),
-      padding:    parsers.padding(spec.padding),
       signals:    parsers.signals(model, spec.signals),
       predicates: parsers.predicates(model, spec.predicates),
       marks:      parsers.marks(model, spec, width, height),

--- a/src/parse/spec.js
+++ b/src/parse/spec.js
@@ -18,6 +18,8 @@ function parseSpec(spec, callback) {
         height = spec.height || 500,
         create = function() { callback(viewFactory(model)); };
 
+    model.signal('width').value(width);
+    model.signal('height').value(height);
     model.defs({
       width:      width,
       height:     height,

--- a/src/transforms/Force.js
+++ b/src/transforms/Force.js
@@ -16,7 +16,7 @@ function Force(graph) {
   this._layout = d3.layout.force();
 
   Transform.addParameters(this, {
-    size: {type: 'array<value>', default: [500, 500]},
+    size: {type: 'array<value>', default: require('./screen').size},
     bound: {type: 'value', default: true},
     links: {type: 'data'},
 

--- a/src/transforms/Geo.js
+++ b/src/transforms/Geo.js
@@ -22,7 +22,7 @@ function Geo(graph) {
 Geo.Parameters = {
   projection: {type: 'value', default: 'mercator'},
   center:     {type: 'array<value>'},
-  translate:  {type: 'array<value>'},
+  translate:  {type: 'array<value>', default: require('./screen').center},
   rotate:     {type: 'array<value>'},
   scale:      {type: 'value'},
   precision:  {type: 'value'},

--- a/src/transforms/Hierarchy.js
+++ b/src/transforms/Hierarchy.js
@@ -15,7 +15,7 @@ function Hierarchy(graph) {
     field: {type: 'value', default: null},
     // layout parameters
     mode: {type: 'value', default: 'tidy'}, // tidy, cluster, partition
-    size: {type: 'array<value>', default: [500, 500]},
+    size: {type: 'array<value>', default: require('./screen').size},
     nodesize: {type: 'array<value>', default: null},
     orient: {type: 'value', default: 'cartesian'}
   });

--- a/src/transforms/Parameter.js
+++ b/src/transforms/Parameter.js
@@ -98,8 +98,7 @@ prototype.set = function(value) {
       p._accessors[i] = dl.accessor(v.field);
       p._transform.dependency(Deps.FIELDS, dl.field(v.field));
       return v.field;
-    }
-    else if (v.signal !== undefined) {
+    } else if (v.signal !== undefined) {
       p._resolution = true;
       p._transform.dependency(Deps.SIGNALS, v.signal);
       p._signals.push({
@@ -107,15 +106,14 @@ prototype.set = function(value) {
         value: function(graph) { return graph.signalRef(v.signal); }
       });
       return v.signal;
-    }
-    else if (v.expr !== undefined) {
+    } else if (v.expr !== undefined) {
       p._resolution = true;
       e = expr(v.expr);
       p._transform.dependency(Deps.SIGNALS, e.globals);
       p._signals.push({
         index: i,
         value: function(graph) {
-          return e.fn(null, null, graph.signalValues());
+          return e.fn(null, null, graph.values(Deps.SIGNALS, e.globals));
         }
       });
       return v.expr;

--- a/src/transforms/Parameter.js
+++ b/src/transforms/Parameter.js
@@ -18,7 +18,7 @@ function Parameter(name, type, transform) {
   this._value = [];
   this._accessors = [];
   this._resolution = false;
-  this._signals = {};
+  this._signals = [];
 }
 
 var prototype = Parameter.prototype;
@@ -43,7 +43,7 @@ prototype.get = function() {
   var graph = this._transform._graph,
       isData  = dataType.test(this._type),
       isField = fieldType.test(this._type),
-      s, idx, val;
+      i, n, sig, idx, val;
 
   // If we don't require resolution, return the value immediately.
   if (!this._resolution) return get.call(this);
@@ -53,9 +53,10 @@ prototype.get = function() {
     return get.call(this); // TODO: support signal as dataTypes
   }
 
-  for (s in this._signals) {
-    idx = this._signals[s];
-    val = graph.signalRef(s);
+  for (i=0, n=this._signals.length; i<n; ++i) {
+    sig = this._signals[i];
+    idx = sig.index;
+    val = sig.value(graph);
 
     if (isField) {
       this._accessors[idx] = this._value[idx] != val ?
@@ -74,10 +75,12 @@ prototype.set = function(value) {
       isData  = dataType.test(this._type),
       isField = fieldType.test(this._type);
 
+  p._signals = [];
   this._value = dl.array(value).map(function(v, i) {
+    var e;
     if (dl.isString(v)) {
       if (isExpr) {
-        var e = expr(v);
+        e = expr(v);
         p._transform.dependency(Deps.FIELDS,  e.fields);
         p._transform.dependency(Deps.SIGNALS, e.globals);
         return e.fn;
@@ -95,11 +98,27 @@ prototype.set = function(value) {
       p._accessors[i] = dl.accessor(v.field);
       p._transform.dependency(Deps.FIELDS, dl.field(v.field));
       return v.field;
-    } else if (v.signal !== undefined) {
+    }
+    else if (v.signal !== undefined) {
       p._resolution = true;
-      p._signals[v.signal] = i;
       p._transform.dependency(Deps.SIGNALS, v.signal);
+      p._signals.push({
+        index: i,
+        value: function(graph) { return graph.signalRef(v.signal); }
+      });
       return v.signal;
+    }
+    else if (v.expr !== undefined) {
+      p._resolution = true;
+      e = expr(v.expr);
+      p._transform.dependency(Deps.SIGNALS, e.globals);
+      p._signals.push({
+        index: i,
+        value: function(graph) {
+          return e.fn(null, null, graph.signalValues());
+        }
+      });
+      return v.expr;
     }
 
     return v;

--- a/src/transforms/Treemap.js
+++ b/src/transforms/Treemap.js
@@ -16,7 +16,7 @@ function Treemap(graph) {
     parent: {type: 'field', default: 'parent'},
     field: {type: 'field', default: 'value'},
     // treemap parameters
-    size: {type: 'array<value>', default: [500, 500]},
+    size: {type: 'array<value>', default: require('./screen').size},
     round: {type: 'value', default: true},
     sticky: {type: 'value', default: false},
     ratio: {type: 'value', default: defaultRatio},

--- a/src/transforms/Voronoi.js
+++ b/src/transforms/Voronoi.js
@@ -7,7 +7,7 @@ var d3 = require('d3'),
 function Voronoi(graph) {
   BatchTransform.prototype.init.call(this, graph);
   Transform.addParameters(this, {
-    clipExtent: {type: 'array<value>', default: [[-1e5,-1e5],[1e5,1e5]]},
+    clipExtent: {type: 'array<value>', default: require('./screen').extent},
     x: {type: 'field', default: 'layout_x'},
     y: {type: 'field', default: 'layout_y'}
   });

--- a/src/transforms/Wordcloud.js
+++ b/src/transforms/Wordcloud.js
@@ -10,7 +10,7 @@ var dl = require('datalib'),
 function Wordcloud(graph) {
   BatchTransform.prototype.init.call(this, graph);
   Transform.addParameters(this, {
-    size: {type: 'array<value>', default: [900, 500]},
+    size: {type: 'array<value>', default: require('./screen').size},
     text: {type: 'field', default: 'data'},
     rotate: {type: 'field|value', default: 0},
     font: {type: 'field|value', default: {value: 'sans-serif'}},

--- a/src/transforms/screen.js
+++ b/src/transforms/screen.js
@@ -1,0 +1,5 @@
+module.exports = {
+  size:  [{signal: 'width'}, {signal: 'height'}],
+  mid:   [{expr: 'width/2'}, {expr: 'height/2'}],
+  extent: [[0,0], {expr: '[width,height]'}]
+};

--- a/src/transforms/screen.js
+++ b/src/transforms/screen.js
@@ -1,5 +1,8 @@
 module.exports = {
-  size:  [{signal: 'width'}, {signal: 'height'}],
-  mid:   [{expr: 'width/2'}, {expr: 'height/2'}],
-  extent: [[0,0], {expr: '[width,height]'}]
+  size:   [{signal: 'width'}, {signal: 'height'}],
+  mid:    [{expr: 'width/2'}, {expr: 'height/2'}],
+  extent: [
+    {expr: '[-padding.left, -padding.top]'},
+    {expr: '[width+padding.right, height+padding.bottom]'}
+  ]
 };

--- a/test/spec/panzoom_points.json
+++ b/test/spec/panzoom_points.json
@@ -11,8 +11,6 @@
   ],
 
   "signals": [
-    {"name": "width", "init": 800},
-    {"name": "height", "init": 500},
     {
       "name": "point",
       "init": 0,

--- a/test/transforms/voronoi.test.js
+++ b/test/transforms/voronoi.test.js
@@ -11,7 +11,13 @@ describe('Voronoi', function() {
     data: [{
       name: "table",
       values: values,
-      transform: [{type: 'voronoi', x: 'x', y: 'y', output: {path: 'p'}}]
+      transform: [{
+        type: 'voronoi',
+        x: 'x',
+        y: 'y',
+        clipExtent: [[-1e5,-1e5], [1e5,1e5]],
+        output: {path: 'p'}
+      }]
     }]
   };
 
@@ -35,7 +41,7 @@ describe('Voronoi', function() {
     expect(validate({ "type": "voronoi", "y": "field" })).to.be.true;
     expect(validate({ "type": "voronoi", "clipExtent": [[-1e5,-1e5],[1e5,1e5]] })).to.be.true;
     expect(validate({ "type": "voronoi", "output": {"path": "path"} })).to.be.true;
-    
+
     expect(validate({ "type": "foo" })).to.be.false;
     expect(validate({ "type": "voronoi", "x": 1 })).to.be.false;
     expect(validate({ "type": "voronoi", "y": 2 })).to.be.false;


### PR DESCRIPTION
- Add named signals for the View `width`, `height` and `padding`.
- Add `"width"`, `"height"` and `"padding"` to the list of reserved signal names. Note that the `horizon` and `panzoom_points` examples require removal of explicit width/height signals to work.
- Add expression support (`{"expr": "..."}`) to transform parameters.
- Update layouts to use size signals as defaults for `size`, `translate` and `clipExtent` parameters.

The new signals have been added in a minimal fashion, with all existing width/height/padding processing otherwise unchanged. It may be that the use of signals allows for more elegant handling across the View, Model and scenegraph, but for now this PR focuses solely on adding the new functionality.