### PR TITLE
Self-cross transforms should process right changes

### DIFF
--- a/src/transforms/Cross.js
+++ b/src/transforms/Cross.js
@@ -105,7 +105,7 @@ prototype.batchTransform = function(input, data) {
   input.rem.forEach(r);
   input.add.forEach(add.bind(this, output, true, wdata, diag, test));
 
-  if (!selfCross && woutput.stamp > this._lastWith) {
+  if (woutput.stamp > this._lastWith) {
     woutput.rem.forEach(r);
     woutput.add.forEach(add.bind(this, output, false, data, diag, test));
     woutput.mod.forEach(mod.bind(this, output, false));

--- a/src/transforms/Cross.js
+++ b/src/transforms/Cross.js
@@ -114,7 +114,7 @@ prototype.batchTransform = function(input, data) {
   }
 
   // Mods need to come after all removals have been run.
-  input.mod.forEach(mod.bind(this, output, true, data, diag, test));
+  input.mod.forEach(mod.bind(this, output, true, wdata, diag, test));
   upFields.call(this, input, output);
 
   return output;

--- a/src/transforms/Cross.js
+++ b/src/transforms/Cross.js
@@ -56,10 +56,10 @@ function add(output, left, data, diag, test, x) {
   }
 }
 
-function mod(output, left, x) {
+function mod(output, left, data, diag, test, x) {
   var cross = this,
       c = this._cache[x._id];
-  if (!c) return;
+  if (!c) return add(output, left, data, diag, test, x);
   
   if (this._lastRem > c.s) {  // Removed tuples haven't been filtered yet
     c.c = c.c.filter(function(y) {
@@ -105,16 +105,16 @@ prototype.batchTransform = function(input, data) {
   input.rem.forEach(r);
   input.add.forEach(add.bind(this, output, true, wdata, diag, test));
 
-  if (woutput.stamp > this._lastWith) {
+  if (!selfCross && woutput.stamp > this._lastWith) {
     woutput.rem.forEach(r);
     woutput.add.forEach(add.bind(this, output, false, data, diag, test));
-    woutput.mod.forEach(mod.bind(this, output, false));
+    woutput.mod.forEach(mod.bind(this, output, false, data, diag, test));
     upFields.call(this, woutput, output);
     this._lastWith = woutput.stamp;
   }
 
   // Mods need to come after all removals have been run.
-  input.mod.forEach(mod.bind(this, output, true));
+  input.mod.forEach(mod.bind(this, output, true, data, diag, test));
   upFields.call(this, input, output);
 
   return output;

--- a/src/transforms/Cross.js
+++ b/src/transforms/Cross.js
@@ -59,7 +59,7 @@ function add(output, left, data, diag, test, x) {
 function mod(output, left, data, diag, test, x) {
   var cross = this,
       c = this._cache[x._id];
-  if (!c) return add(output, left, data, diag, test, x);
+  if (!c) return add.call(this, output, left, data, diag, test, x);
   
   if (this._lastRem > c.s) {  // Removed tuples haven't been filtered yet
     c.c = c.c.filter(function(y) {


### PR DESCRIPTION
If you cross data, that was filtered using a signal value, with itself (i.e. `"transform": [{"type": "cross"}]`), the `cross` transform did not behave correctly when more data passes the filter after the value of the signal changes. The new data objects were only crossed 'from the left' and would never appear on the right, except for the element on the diagonal.