### PR TITLE
Report parsing errors to the caller

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,5 +15,6 @@ module.exports = {
   schema: require('./src/core/schema'),
   config: require('./src/core/config'),
   util:  require('datalib'),
+  logging: require('vega-logging'),
   debug: require('vega-logging').debug
 };

--- a/src/parse/data.js
+++ b/src/parse/data.js
@@ -9,12 +9,21 @@ function parseData(model, spec, callback) {
 
   function loaded(d) {
     return function(error, data) {
-      if (error) {
-        log.error('LOADING FAILED: ' + d.url + ' ' + error);
-      } else {
-        model.data(d.name).values(dl.read(data, d.format));
+      try {
+        if (error) {
+          log.error('LOADING FAILED: ' + d.url + ' ' + error);
+        } else if (count >= 0) {
+          try {
+            model.data(d.name).values(dl.read(data, d.format));
+          } catch (error) {
+            log.error('PARSING FAILED: ' + d.url + ' ' + error);
+          }
+        }
+        if (--count === 0) callback();
+      } catch(error) {
+        count = -1; // prevent success callback
+        callback(error);
       }
-      if (--count === 0) callback();
     };
   }
 

--- a/src/parse/spec.js
+++ b/src/parse/spec.js
@@ -3,11 +3,58 @@ var dl = require('datalib'),
     Model = require('../core/Model'),
     View = require('../core/View');
 
-function parseSpec(spec, callback) {
-  var vf = arguments[arguments.length-1],
+/**
+ * Backward compatibility wrapper that accepts callback without error handler
+ * @param spec (object)
+ * @param callback (model)
+ * @param config (optional object)
+ * @param viewFactory (optional callback)
+ * @returns {*}
+ */
+function parseSpec(spec, callback /* [, config] [, viewFactory] */) {
+  var cb = callback,
+      vf = arguments[arguments.length-1],
       viewFactory = arguments.length > 2 && dl.isFunction(vf) ? vf : View.factory,
-      config = arguments[2] !== viewFactory ? arguments[2] : {},
-      model = new Model(config);
+      config = arguments[2] !== viewFactory ? arguments[2] : {};
+
+  return module.exports.parse(spec, config, viewFactory, function(err, model) {
+    // For backward compatibility, the error is thrown even though it might never be caught
+    if (err) throw err;
+    cb(model);
+  });
+}
+
+module.exports = parseSpec;
+
+/**
+ * Parse graph specification
+ * @param spec (object)
+ * @param config (optional object)
+ * @param viewFactory (optional function)
+ * @param callback (error, model)
+ */
+parseSpec.parse = function (spec, /* [config,] [viewFactory,] */ callback) {
+  // do not assign any values to callback, as it will change arguments
+  var cb = arguments[arguments.length - 1],
+      model, argInd = 2,
+      viewFactory = View.factory;
+
+  function done(err, value) {
+    if (cb) {
+      cb(err, value);
+      cb = undefined;
+    }
+  }
+
+  if (arguments.length > argInd && dl.isFunction(arguments[arguments.length - argInd])) {
+    viewFactory = arguments[arguments.length - argInd];
+    argInd++;
+  }
+  if (arguments.length > argInd && dl.isObject(arguments[arguments.length - argInd])) {
+    model = new Model(arguments[arguments.length - argInd]);
+  } else {
+    model = new Model();
+  }
 
   function parse(spec) {
     // protect against subsequent spec modification
@@ -16,8 +63,8 @@ function parseSpec(spec, callback) {
     var parsers = require('./'),
         width  = spec.width || 500,
         height = spec.height || 500,
-        create = function() { callback(viewFactory(model)); };
-
+        create = function(err) { done(err, err ? undefined : viewFactory(model));
+      }
     model.defs({
       width:      width,
       height:     height,
@@ -36,22 +83,29 @@ function parseSpec(spec, callback) {
   } else if (dl.isString(spec)) {
     var opts = dl.extend({url: spec}, model.config().load);
     dl.load(opts, function(err, data) {
-      if (err) {
-        log.error('LOADING SPECIFICATION FAILED: ' + err.statusText);
-      } else {
-        try {
-          parse(JSON.parse(data));
-        } catch (e) {
-          log.error('INVALID SPECIFICATION: Must be a valid JSON object. '+e);
+      try {
+        if (err) {
+          log.error('LOADING SPECIFICATION FAILED: ' + err.statusText);
+        } else {
+          try {
+            parse(JSON.parse(data));
+          } catch (e) {
+            log.error('INVALID SPECIFICATION: Must be a valid JSON object. ' + e);
+          }
         }
+      } catch (err) {
+        done(err);
       }
     });
   } else {
-    log.error('INVALID SPECIFICATION: Must be a valid JSON object or URL.');
+    try {
+      log.error('INVALID SPECIFICATION: Must be a valid JSON object or URL.');
+    } catch (err) {
+      done(err);
+    }
   }
-}
+};
 
-module.exports = parseSpec;
 parseSpec.schema = {
   "defs": {
     "spec": {


### PR DESCRIPTION
This is the replacement pull request instead of https://github.com/vega/vega/pull/402

It exposes the logging interface to allow for complex error processing, and an alternative spec.parse() with error handling.

Handle the case when a user-overriden logger throws an error. In case of an internal error, report it via callback(error, model)

TODO:
* This is a fairly bad workaround, and could really use promises.
* The error messages should be replaced with objects to allow
complex error processing.
* There are 3 usage models: (1) ignore errors, (2) stop on the first error, and (3) report all errors. The (1) is the default, the (2) can be implemented by throwing an error on log.error() call or with a new  "config.throwOnError" parameter, but the (3)  requires that each log.error() call is accompanied by the context object, so that logging knows which graph is causing an error.