### PR TITLE
Update parse method signatures and error handling.

### DIFF
--- a/bin/vg2png
+++ b/bin/vg2png
@@ -2,21 +2,20 @@
 // Render a Vega specification to PNG, using node canvas
 
 var helpText =
-  "Render a Vega specification to PNG.\n\n" +
-  "Usage: vg2png vega_json_file [output_png_file]\n" +
-  "  If output_png_file is not provided, writes to stdout.\n\n" +
-  "To load data, you may need to set a base directory:\n" +
-  "  For web retrieval, use `-b http://host/data/`. \n" +
-  "  For files, use `-b file:///dir/data/` (absolute) or `-b data/` (relative).";
+  'Render a Vega specification to PNG.\n\n' +
+  'Usage: vg2png vega_json_file [output_png_file]\n' +
+  '  If output_png_file is not provided, writes to stdout.\n\n' +
+  'To load data, you may need to set a base directory:\n' +
+  '  For web retrieval, use `-b http://host/data/`. \n' +
+  '  For files, use `-b file:///dir/data/` (absolute) or `-b data/` (relative).';
 
 // import required libraries
-var path = require("path"),
-    fs = require("fs"),
-    d3 = require("d3"),
-    vg = require("../index");
+var path = require('path'),
+    fs = require('fs'),
+    vg = require('../index');
 
 // arguments
-var args = require("yargs")
+var args = require('yargs')
   .usage(helpText)
   .demand(1)
   .string('b').alias('b', 'base')
@@ -24,11 +23,11 @@ var args = require("yargs")
   .argv;
 
 // set baseURL if provided on command line
-var base = "file://" + process.cwd() + path.sep;
+var base = 'file://' + process.cwd() + path.sep;
 if (args.b) {
   // if no protocol, assume files, relative to current dir
   base = /^[A-Za-z]+\:\/\//.test(args.b) ? args.b + path.sep
-    : "file://" + process.cwd() + path.sep + args.b + path.sep;
+    : 'file://' + process.cwd() + path.sep + args.b + path.sep;
 }
 vg.config.load.baseURL = base;
 
@@ -37,7 +36,7 @@ var specFile = args._[0],
     outputFile = args._[1] || null;
 
 // load spec, render to png
-fs.readFile(specFile, "utf8", function(err, text) {
+fs.readFile(specFile, 'utf8', function(err, text) {
   if (err) throw err;
   var spec = JSON.parse(text);
   render(spec);
@@ -48,12 +47,14 @@ fs.readFile(specFile, "utf8", function(err, text) {
 function writePNG(canvas, file) {
   var out = file ? fs.createWriteStream(file) : process.stdout;
   var stream = canvas.createPNGStream();
-  stream.on("data", function(chunk) { out.write(chunk); });
+  stream.on('data', function(chunk) { out.write(chunk); });
 }
 
 function render(spec) {
-  vg.parse.spec(spec, function(chart) {
-    var view = chart({ renderer: "canvas" })
+  vg.parse.spec(spec, function(err, chart) {
+    if (err) { throw err; }
+
+    var view = chart({ renderer: 'canvas' })
       .update();
 
     view.canvasAsync(function(canvas) {

--- a/bin/vg2svg
+++ b/bin/vg2svg
@@ -2,12 +2,12 @@
 // Render a Vega specification to SVG
 
 var helpText =
-  "Render a Vega specification to SVG.\n\n" +
-  "Usage: vg2svg vega_json_file [output_svg_file]\n" +
-  "  If output_svg_file is not provided, writes to stdout.\n\n" +
-  "To load data, you may need to set a base directory:\n" +
-  "  For web retrieval, use `-b http://host/data/`. \n" +
-  "  For files, use `-b file:///dir/data/` (absolute) or `-b data/` (relative).";
+  'Render a Vega specification to SVG.\n\n' +
+  'Usage: vg2svg vega_json_file [output_svg_file]\n' +
+  '  If output_svg_file is not provided, writes to stdout.\n\n' +
+  'To load data, you may need to set a base directory:\n' +
+  '  For web retrieval, use `-b http://host/data/`. \n' +
+  '  For files, use `-b file:///dir/data/` (absolute) or `-b data/` (relative).';
 
 var svgHeader =
   '<?xml version="1.0" encoding="utf-8"?>\n' +
@@ -15,13 +15,12 @@ var svgHeader =
   '"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">\n';
 
 // import required libraries
-var path = require("path"),
-    fs = require("fs"),
-    d3 = require("d3"),
-    vg = require("../index");
+var path = require('path'),
+    fs = require('fs'),
+    vg = require('../index');
 
 // arguments
-var args = require("yargs")
+var args = require('yargs')
   .usage(helpText)
   .demand(1)
   .string('b').alias('b', 'base')
@@ -31,21 +30,21 @@ var args = require("yargs")
   .argv;
 
 // set baseURL if provided on command line
-var base = "file://" + process.cwd() + path.sep;
+var base = 'file://' + process.cwd() + path.sep;
 if (args.b) {
   // if no protocol, assume files, relative to current dir
   base = /^[A-Za-z]+\:\/\//.test(args.b) ? args.b + path.sep
-    : "file://" + process.cwd() + path.sep + args.b + path.sep;
+    : 'file://' + process.cwd() + path.sep + args.b + path.sep;
 }
 vg.config.load.baseURL = base;
 
 // input / output files
-var header = args.h ? svgHeader : "",
+var header = args.h ? svgHeader : '',
     specFile = args._[0],
     outputFile = args._[1] || null;
 
 // load spec, render to svg
-fs.readFile(specFile, "utf8", function(err, text) {
+fs.readFile(specFile, 'utf8', function(err, text) {
   if (err) throw err;
   var spec = JSON.parse(text);
   render(spec);
@@ -63,8 +62,10 @@ function writeSVG(svg, file) {
 }
 
 function render(spec) {
-  vg.parse.spec(spec, function(chart) {
-    var view = chart({ renderer: "svg" })
+  vg.parse.spec(spec, function(err, chart) {
+    if (err) { throw err; }
+
+    var view = chart({ renderer: 'svg' })
       .update();
 
     writeSVG(view.svg(), outputFile);

--- a/index.js
+++ b/index.js
@@ -15,5 +15,6 @@ module.exports = {
   schema: require('./src/core/schema'),
   config: require('./src/core/config'),
   util:  require('datalib'),
+  logging: require('vega-logging'),
   debug: require('vega-logging').debug
 };

--- a/package.json
+++ b/package.json
@@ -32,21 +32,22 @@
     "vg2svg": "./bin/vg2svg"
   },
   "dependencies": {
-    "d3": "^3.5.6",
+    "d3": "^3.5.9",
     "d3-geo-projection": "^0.2.15",
-    "d3-cloud": "^1.2.0",
-    "datalib": "^1.4.10",
+    "d3-cloud": "^1.2.1",
+    "datalib": "^1.4.12",
     "topojson": "^1.6.19",
-    "vega-dataflow": "^1.3.0",
+    "vega-dataflow": "^1.3.2",
     "vega-expression": "^1.0.3",
     "vega-logging": "^1.0.1",
-    "vega-scenegraph": "^1.0.11",
-    "yargs": "^3.15.0"
+    "vega-scenegraph": "^1.0.15",
+    "yargs": "^3.30.0"
   },
   "devDependencies": {
     "browserify": "^10.2.6",
     "browserify-shim": "^3.8.9",
     "browserify-versionify": "^1.0.4",
+    "canvas": "^1.3.4",
     "chai": "^3.0.0",
     "chai-spies": "^0.6.0",
     "exorcist": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -43,11 +43,13 @@
     "vega-scenegraph": "^1.0.15",
     "yargs": "^3.30.0"
   },
+  "optionalDependencies": {
+    "canvas": "^1.3.4"
+  },
   "devDependencies": {
     "browserify": "^10.2.6",
     "browserify-shim": "^3.8.9",
     "browserify-versionify": "^1.0.4",
-    "canvas": "^1.3.4",
     "chai": "^3.0.0",
     "chai-spies": "^0.6.0",
     "exorcist": "^0.4.0",

--- a/src/parse/data.js
+++ b/src/parse/data.js
@@ -20,11 +20,11 @@ function parseData(model, spec, callback) {
       } else if (count >= 0) {
         try {
           model.data(d.name).values(dl.read(data, d.format));
+          if (--count === 0) callback();
         } catch (err) {
           onError(err, d);
         }
       }
-      if (--count === 0) callback();
     };
   }
 

--- a/src/parse/data.js
+++ b/src/parse/data.js
@@ -17,7 +17,7 @@ function parseData(model, spec, callback) {
     return function(error, data) {
       if (error) {
         onError(error, d);
-      } else if (count >= 0) {
+      } else if (count > 0) {
         try {
           model.data(d.name).values(dl.read(data, d.format));
           if (--count === 0) callback();

--- a/test/_start.js
+++ b/test/_start.js
@@ -1,7 +1,13 @@
-var Node  = require('vega-dataflow/src/Node'),
+var Node  = require('vega-dataflow').Node,
+    log   = require('vega-logging'),
     chai  = require('chai'),
-    spies = require('chai-spies');
+    spies = require('chai-spies'),
+    tv4   = require('tv4');
 
+// configure logging
+log.error = function() {}; // disable error output during tests
+
+// set globals
 global.d3 = require('d3');
 global.dl = require('datalib');
 global.chai = chai.use(spies);
@@ -9,8 +15,8 @@ global.expect = chai.expect;
 global.transforms = require('../src/transforms/');
 global.parseSpec = require('../src/parse/spec');
 global.schema = require('../src/core/schema')();
+global.tv4 = tv4;
 
-var tv4 = global.tv4 = require('tv4');
 global.validator = function(schema) {
   return function(data) {
     return tv4.validate(data, schema);
@@ -21,8 +27,11 @@ global.schemaPath = function(path) {
   return dl.extend({ refs: schema.refs, defs: schema.defs }, path);
 };
 
-global.modelFactory = function(model) { return (model.fire(), model); };
-global.viewFactory = function(model) { 
+global.modelFactory = function(model) {
+  return (model.fire(), model);
+};
+
+global.viewFactory = function(model) {
   model.scene(new Node(model)).fire();
-  return model; 
+  return model;
 };

--- a/test/parse/spec.test.js
+++ b/test/parse/spec.test.js
@@ -1,0 +1,58 @@
+describe('Spec Parser', function() {
+
+  it('should return error for null input', function(done) {
+    parseSpec(null, function(error, chart) {
+      expect(error).to.exist;
+      done();
+    })
+  });
+
+  it('should return error for undefined input', function(done) {
+    parseSpec(undefined, function(error, chart) {
+      expect(error).to.exist;
+      done();
+    })
+  });
+
+  it('should return error for boolean input', function(done) {
+    parseSpec(false, function(error, chart) {
+      expect(error).to.exist;
+      done();
+    })
+  });
+
+  it('should return error for numeric input', function(done) {
+    parseSpec(1, function(error, chart) {
+      expect(error).to.exist;
+      done();
+    })
+  });
+
+  it('should return error for invalid spec url', function(done) {
+    var spec = 'h!!p://12f.3z';
+    parseSpec(spec, function(error, chart) {
+      expect(error).to.exist;
+      done();
+    })
+  });
+
+  it('should return error for invalid data url', function(done) {
+    var spec = {
+      data: [{name: 'table', url: 'h!!p://12f.3z'}]
+    };
+    parseSpec(spec, function(error, chart) {
+      expect(error).to.exist;
+      done();
+    })
+  });
+
+  it('should return error for invalid data format', function(done) {
+    var spec = {
+      data: [{name: 'table', values: '!#$%^&'}]
+    };
+    parseSpec(spec, function(error, chart) {
+      expect(error).to.exist;
+      done();
+    })
+  });
+});

--- a/test/parse/streams.test.js
+++ b/test/parse/streams.test.js
@@ -6,7 +6,7 @@ var dl = require('datalib'),
 
 describe('Streams', function() {
   function test(spec, interaction) {
-    parseSpec(spec, function(chart) { 
+    parseSpec(spec, function(error, chart) {
       jsdom.env("<html><body></body></html>", function(err, window) {
         var document = window.document,
             body = d3.select(document).select('body').node();
@@ -15,7 +15,7 @@ describe('Streams', function() {
           .update();
 
         interaction(view, d3.select(body).select('.marks').node(), mouseEvt);
-        
+
         function mouseEvt(type, x, y, target) {
           var mm = document.createEvent("MouseEvents");
           mm.initMouseEvent("mousemove", true, true, window, null, x, y, x, y, false, false, false, false, target);
@@ -155,7 +155,7 @@ describe('Streams', function() {
         streams: [{ type: "mousedown", expr: "event" }]
       }, {
         name: "signalB",
-        streams: [{ 
+        streams: [{
           type: "signalA", expr: "signalA.clientX",
           scale: {name: "x", invert: true}
         }]
@@ -205,7 +205,7 @@ describe('Streams', function() {
       mouseEvt('mousedown', 201, 350, svg);
       expect(view.signal('signalA')).to.not.be.undefined;
       done();
-    });    
+    });
   });
 
   it('should propagate ordered streams', function(done) {
@@ -227,8 +227,8 @@ describe('Streams', function() {
       expect(view.signal('signalA')).to.have.property('clientX', 250);
       expect(view.signal('signalA')).to.have.property('clientY', 350);
 
-      mouseEvt('mouseup', 250, 350, svg);  
-      mouseEvt('mousemove', 190, 100, svg);    
+      mouseEvt('mouseup', 250, 350, svg);
+      mouseEvt('mousemove', 190, 100, svg);
       expect(view.signal('signalA')).to.have.property('clientX', 250);
       expect(view.signal('signalA')).to.have.property('clientY', 350);
 
@@ -256,13 +256,13 @@ describe('Streams', function() {
       expect(view.signal('signalA')).to.have.property('clientX', 190);
       expect(view.signal('signalA')).to.have.property('clientY', 100);
 
-      mouseEvt('mouseup', 250, 350, svg);  
-      mouseEvt('mousemove', 190, 100, svg);    
+      mouseEvt('mouseup', 250, 350, svg);
+      mouseEvt('mousemove', 190, 100, svg);
       expect(view.signal('signalA')).to.have.property('clientX', 250);
       expect(view.signal('signalA')).to.have.property('clientY', 350);
 
       done();
-    });    
+    });
   });
 
   it('should populate vg events', function(done) {
@@ -354,7 +354,7 @@ describe('Streams', function() {
       expect(sgA).to.have.deep.property("vg.name.mark2.mark.def.name", "mark2");
       expect(sgA).to.have.deep.property("vg.name.mark2.x", 25);
       expect(sgA).to.have.deep.property("vg.name.mark2.fill", "green");
-      
+
       expect(sgA).to.have.deep.property("vg.name.mark1.mark.marktype", "group");
       expect(sgA).to.have.deep.property("vg.name.mark1.mark.def.name", "mark1");
       expect(sgA).to.have.deep.property("vg.name.mark1.x", 25);

--- a/test/render/canvas.test.js
+++ b/test/render/canvas.test.js
@@ -35,15 +35,13 @@ describe('Canvas', function() {
     });
   });
 
-  // Render the given spec using both the headless string renderer
-  // and the standard SVG renderer (in a fake JSDOM)
-  // and compare that the SVG output is identical
+  // Render the given spec using the headless canvas renderer
   function render(name, specFile, done) {
     fs.readFile(specFile, "utf8", function(err, text) {
       if (err) throw err;
       var spec = JSON.parse(text);
 
-      parseSpec(spec, function(viewFactory) {
+      parseSpec(spec, function(error, viewFactory) {
         var view = viewFactory({ renderer: "canvas" }).update();
         view.canvasAsync(function(canvas) {
           var data = canvas.toDataURL();

--- a/test/render/svg.test.js
+++ b/test/render/svg.test.js
@@ -59,7 +59,7 @@ describe('SVG', function() {
       if (err) throw err;
       var spec = JSON.parse(text);
 
-      parseSpec(spec, function(viewFactory) {
+      parseSpec(spec, function(error, viewFactory) {
         if (headless) {
           var view = viewFactory({ renderer: "svg" }).update();
           var svg  = view.renderer().svg();
@@ -68,7 +68,7 @@ describe('SVG', function() {
         } else {
           jsdom.env("<html><body></body></html>", function(err, window) {
             global.window = window;
-            
+
             var body = d3.select(window.document).select('body').node();
             var view = viewFactory({ renderer: "svg", el: body }).update();
             var svg  = d3.select(body).select('div.vega').node().innerHTML

--- a/test/scene/scale.test.js
+++ b/test/scene/scale.test.js
@@ -15,7 +15,7 @@ describe('Scale', function() {
         ]
       };
 
-      parseSpec(spec, function(model) {
+      parseSpec(spec, viewFactory, function(error, model) {
         var group = model.scene().items[0],
             x = group.scale('x'),
             y = group.scale('y');
@@ -24,7 +24,7 @@ describe('Scale', function() {
         expect(y.domain()).to.eql(lin);
 
         done();
-      }, viewFactory);
+      });
     });
 
     it('should support array<signal>', function(done) {
@@ -33,14 +33,14 @@ describe('Scale', function() {
         "data": [],
         "scales": [
           {
-            "name": "x", "type": "ordinal", 
-            "domain": [1, 2, {"signal": "s1"}, 6, {"signal": "s2"}], 
+            "name": "x", "type": "ordinal",
+            "domain": [1, 2, {"signal": "s1"}, 6, {"signal": "s2"}],
             "range": [0, 1]
           }
         ]
       };
 
-      parseSpec(spec, function(model) {
+      parseSpec(spec, viewFactory, function(error, model) {
         var group = model.scene().items[0],
             x = group.scale('x');
 
@@ -53,7 +53,7 @@ describe('Scale', function() {
         expect(x.domain()).to.eql([1, 2, 3, 6]);
 
         done();
-      }, viewFactory);
+      });
     });
 
     describe('Min/Max', function() {
@@ -65,14 +65,14 @@ describe('Scale', function() {
           ]
         };
 
-        parseSpec(spec, function(model) {
+        parseSpec(spec, viewFactory, function(error, model) {
           var group = model.scene().items[0],
               y = group.scale('y');
 
           expect(y.domain()).to.eql([0, 10]);
 
           done();
-        }, viewFactory);
+        });
       });
 
       it('should support signal values', function(done) {
@@ -85,12 +85,12 @@ describe('Scale', function() {
 
           "scales": [{
             "name": "y", "type": "linear", "range": [0, 1], "zero": false,
-            "domainMin": {"signal": "minDomain"}, 
-            "domainMax": {"signal": "maxDomain"} 
+            "domainMin": {"signal": "minDomain"},
+            "domainMax": {"signal": "maxDomain"}
           }]
         };
 
-        parseSpec(spec, function(model) {
+        parseSpec(spec, viewFactory, function(error, model) {
           var group = model.scene().items[0],
               y = group.scale('y');
 
@@ -103,7 +103,7 @@ describe('Scale', function() {
           expect(y.domain()).to.eql([5, 15]);
 
           done();
-        }, viewFactory);
+        });
       });
 
       it('should override domain values', function(done) {
@@ -116,14 +116,14 @@ describe('Scale', function() {
           }]
         };
 
-        parseSpec(spec, function(model) {
+        parseSpec(spec, viewFactory, function(error, model) {
           var group = model.scene().items[0],
               y = group.scale('y');
 
           expect(y.domain()).to.eql([0, 10]);
 
           done();
-        }, viewFactory);
+        });
       });
 
       it('should support DataRef');
@@ -165,7 +165,7 @@ describe('Scale', function() {
         };
 
         it('should initialize', function(done) {
-          parseSpec(spec, function(model) {
+          parseSpec(spec, viewFactory, function(error, model) {
             var group = model.scene().items[0],
                 x = group.scale('x'),
                 y = group.scale('y'),
@@ -178,11 +178,11 @@ describe('Scale', function() {
             expect(y.domain()).to.eql([15, 91]);
 
             done();
-          }, viewFactory);
+          });
         });
 
         it('should handle streaming adds', function(done) {
-          parseSpec(spec, function(model) {
+          parseSpec(spec, viewFactory, function(error, model) {
             model.data('table').insert([
               {"x": 21, "y": 100}, {"x": 22, "y": 10},
               {"x": 23, "y": 53}
@@ -200,14 +200,14 @@ describe('Scale', function() {
             expect(y.domain()).to.eql([10, 100]);
 
             done();
-          }, viewFactory);
+          });
         });
 
         it('should handle streaming mods', function(done) {
-          parseSpec(spec, function(model) {
+          parseSpec(spec, viewFactory, function(error, model) {
             model.data('table')
               .synchronize()
-              .update(function(x) { return x.x % 2 !== 0 }, "x", 
+              .update(function(x) { return x.x % 2 !== 0 }, "x",
                 function(x) { return x.x * 2 })
               .update(function(x) { return x.x >= 0 }, "y",
                 function(x) { return x.y * 2 })
@@ -228,11 +228,11 @@ describe('Scale', function() {
             expect(y.domain()).to.eql([30, 182]);
 
             done();
-          }, viewFactory);
+          });
         });
 
         it('should handle streaming rems', function(done) {
-          parseSpec(spec, function(model) {
+          parseSpec(spec, viewFactory, function(error, model) {
             model.data('table')
               .synchronize()
               .remove(function(x) { return x.x > 10 })
@@ -250,7 +250,7 @@ describe('Scale', function() {
             expect(y.domain()).to.eql([19, 91]);
 
             done();
-          }, viewFactory);
+          });
         });
       });
 
@@ -298,7 +298,7 @@ describe('Scale', function() {
         };
 
         it('should initialize', function(done) {
-          parseSpec(spec, function(model) {
+          parseSpec(spec, viewFactory, function(error, model) {
             var group = model.scene().items[0],
                 x = group.scale('x'),
                 y = group.scale('y'),
@@ -311,11 +311,11 @@ describe('Scale', function() {
             expect(y.domain()).to.eql([15, 91]);
 
             done();
-          }, viewFactory);
+          });
         });
 
         it('should handle streaming adds', function(done) {
-          parseSpec(spec, function(model) {
+          parseSpec(spec, viewFactory, function(error, model) {
             var group = model.scene().items[0],
                 x = group.scale('x'),
                 y = group.scale('y'),
@@ -346,11 +346,11 @@ describe('Scale', function() {
             expect(y.domain()).to.eql([1, 523]);
 
             done();
-          }, viewFactory);
+          });
         });
 
         it('should handle streaming mods', function(done) {
-          parseSpec(spec, function(model) {
+          parseSpec(spec, viewFactory, function(error, model) {
             var group = model.scene().items[0],
                 x = group.scale('x'),
                 y = group.scale('y'),
@@ -359,7 +359,7 @@ describe('Scale', function() {
 
             model.data('table1')
               .synchronize()
-              .update(function(x) { return x.x % 2 !== 0 }, "x", 
+              .update(function(x) { return x.x % 2 !== 0 }, "x",
                 function(x) { return x.x * 2 })
               .update(function(x) { return x.x >= 0 }, "y",
                 function(x) { return x.y * 2 })
@@ -367,7 +367,7 @@ describe('Scale', function() {
 
             model.data('table2')
               .synchronize()
-              .update(function(x) { return x.a % 2 !== 0 }, "a", 
+              .update(function(x) { return x.a % 2 !== 0 }, "a",
                 function(x) { return x.a * 2 })
               .update(function(x) { return x.b >= 0 }, "b",
                 function(x) { return x.b * 2 })
@@ -382,11 +382,11 @@ describe('Scale', function() {
             expect(y.domain()).to.eql([30, 182]);
 
             done();
-          }, viewFactory);
+          });
         });
 
         it('should handle streaming rems', function(done) {
-          parseSpec(spec, function(model) {
+          parseSpec(spec, viewFactory, function(error, model) {
             model.data('table1')
               .synchronize()
               .remove(function(x) { return x.x > 10 })
@@ -409,7 +409,7 @@ describe('Scale', function() {
             expect(y.domain()).to.eql([19, 91]);
 
             done();
-          }, viewFactory);
+          });
         });
       });
 
@@ -454,7 +454,7 @@ describe('Scale', function() {
         };
 
         it('should initialize', function(done) {
-          parseSpec(spec, function(model) {
+          parseSpec(spec, viewFactory, function(error, model) {
             var groups = model.scene().items[0].items[0].items,
                 i = 0, len = groups.length,
                 num = 4,
@@ -467,11 +467,11 @@ describe('Scale', function() {
             }
 
             done();
-          }, viewFactory);
+          });
         });
 
         it('should handle streaming adds', function(done) {
-          parseSpec(spec, function(model) {
+          parseSpec(spec, viewFactory, function(error, model) {
             model.data('table')
               .insert([
                 {"category": "A", "position": 4},
@@ -492,14 +492,14 @@ describe('Scale', function() {
             }
 
             done();
-          }, viewFactory);
+          });
         });
 
         it('should handle streaming mods', function(done) {
-          parseSpec(spec, function(model) {
+          parseSpec(spec, viewFactory, function(error, model) {
             model.data('table')
               .synchronize()
-              .update(function(x) { return true; }, "position", 
+              .update(function(x) { return true; }, "position",
                 function(x) { return x.position*2; })
               .fire();
 
@@ -515,11 +515,11 @@ describe('Scale', function() {
             }
 
             done();
-          }, viewFactory);
+          });
         });
 
         it('should handle streaming rems', function(done) {
-          parseSpec(spec, function(model) {
+          parseSpec(spec, viewFactory, function(error, model) {
             model.data('table')
               .synchronize()
               .remove(function(x) { return x.position % 2 === 0 })
@@ -536,10 +536,10 @@ describe('Scale', function() {
             }
 
             done();
-          }, viewFactory);
+          });
         });
       });
-    }); 
+    });
   });
 
   describe('Range', function() {
@@ -547,17 +547,17 @@ describe('Scale', function() {
       var spec = {
         "data": [],
         "scales": [{
-          "name": "x", "type": "ordinal", 
-          "domain": [0, 1], 
+          "name": "x", "type": "ordinal",
+          "domain": [0, 1],
           "range": range
         }, {
-          "name": "y", "type": "linear", 
-          "domain": [0, 1], 
+          "name": "y", "type": "linear",
+          "domain": [0, 1],
           "range": range
         }]
       };
 
-      parseSpec(spec, function(model) {
+      parseSpec(spec, viewFactory, function(error, model) {
         var group = model.scene().items[0],
             x = group.scale('x'),
             y = group.scale('y');
@@ -567,7 +567,7 @@ describe('Scale', function() {
         expect(y.range()).to.eql(range);
 
         done();
-      }, viewFactory);
+      });
     });
 
     it('should support array<signal>', function(done) {
@@ -575,17 +575,17 @@ describe('Scale', function() {
         "signals": [{"name": "s1", "init": 5}, {"name": "s2", "init": 7}],
         "data": [],
         "scales": [{
-          "name": "x", "type": "ordinal", 
-          "domain": [0, 1], 
+          "name": "x", "type": "ordinal",
+          "domain": [0, 1],
           "range": [{"signal": "s1"}, 23, {"signal": "s2"}, 51]
         }, {
-          "name": "y", "type": "linear", 
-          "domain": [0, 1], 
+          "name": "y", "type": "linear",
+          "domain": [0, 1],
           "range": [{"signal": "s1"}, 23, {"signal": "s2"}, 51]
         }]
       };
 
-      parseSpec(spec, function(model) {
+      parseSpec(spec, viewFactory, function(error, model) {
         var group = model.scene().items[0],
             x = group.scale('x'),
             y = group.scale('y');
@@ -602,24 +602,24 @@ describe('Scale', function() {
         expect(y.range()).to.eql([10, 23, 37, 51]);
 
         done();
-      }, viewFactory);
+      });
     });
 
     it('should reverse', function(done) {
       var spec = {
         "data": [],
         "scales": [{
-          "name": "x", "type": "ordinal", 
-          "domain": [0, 1], 
+          "name": "x", "type": "ordinal",
+          "domain": [0, 1],
           "range": range, "reverse": true
         }, {
-          "name": "y", "type": "linear", 
-          "domain": [0, 1], 
+          "name": "y", "type": "linear",
+          "domain": [0, 1],
           "range": range, "reverse": true
         }]
       };
 
-      parseSpec(spec, function(model) {
+      parseSpec(spec, viewFactory, function(error, model) {
         var group = model.scene().items[0],
             x = group.scale('x'),
             y = group.scale('y');
@@ -629,7 +629,7 @@ describe('Scale', function() {
         expect(y.range()).to.eql([range[1], range[0]]);
 
         done();
-      }, viewFactory);
+      });
     });
 
     it('should round');
@@ -655,7 +655,7 @@ describe('Scale', function() {
       }
 
       it('should support `width`', function(done) {
-        parseSpec(spec('width'), function(model) {
+        parseSpec(spec('width'), viewFactory, function(error, model) {
           var group = model.scene().items[0],
               linear  = group.scale('lin'),
               ordinal = group.scale('ord');
@@ -664,11 +664,11 @@ describe('Scale', function() {
           expect(ordinal.range()).to.eql([0, 250]);
 
           done();
-        }, viewFactory);
+        });
       });
 
       it('should support `height`', function(done) {
-        parseSpec(spec('height'), function(model) {
+        parseSpec(spec('height'), viewFactory, function(error, model) {
           var group = model.scene().items[0],
               linear  = group.scale('lin'),
               ordinal = group.scale('ord');
@@ -677,11 +677,11 @@ describe('Scale', function() {
           expect(ordinal.range()).to.eql([0, 150]);
 
           done();
-        }, viewFactory);
+        });
       });
 
       it('should support `shapes`', function(done) {
-        parseSpec(spec('shapes'), function(model) {
+        parseSpec(spec('shapes'), viewFactory, function(error, model) {
           var group = model.scene().items[0],
               linear  = group.scale('lin'),
               ordinal = group.scale('ord');
@@ -690,11 +690,11 @@ describe('Scale', function() {
           expect(ordinal.range()).to.eql(config.range.shapes);
 
           done();
-        }, viewFactory);
+        });
       });
 
       it('should support `category10`', function(done) {
-        parseSpec(spec('category10'), function(model) {
+        parseSpec(spec('category10'), viewFactory, function(error, model) {
           var group = model.scene().items[0],
               linear  = group.scale('lin'),
               ordinal = group.scale('ord');
@@ -703,11 +703,11 @@ describe('Scale', function() {
           expect(ordinal.range()).to.eql(config.range.category10);
 
           done();
-        }, viewFactory);
+        });
       });
 
       it('should support `category20`', function(done) {
-        parseSpec(spec('category20'), function(model) {
+        parseSpec(spec('category20'), viewFactory, function(error, model) {
           var group = model.scene().items[0],
               linear  = group.scale('lin'),
               ordinal = group.scale('ord');
@@ -716,7 +716,7 @@ describe('Scale', function() {
           expect(ordinal.range()).to.eql(config.range.category20);
 
           done();
-        }, viewFactory);
+        });
       });
     });
 
@@ -725,17 +725,17 @@ describe('Scale', function() {
         var spec = {
           "data": [],
           "scales": [{
-            "name": "x", "type": "ordinal", 
-            "domain": [0, 1], 
+            "name": "x", "type": "ordinal",
+            "domain": [0, 1],
             "rangeMin": range[0], "rangeMax": range[1]
           }, {
-            "name": "y", "type": "linear", 
-            "domain": [0, 1], 
+            "name": "y", "type": "linear",
+            "domain": [0, 1],
             "rangeMin": range[0], "rangeMax": range[1]
           }]
         };
 
-        parseSpec(spec, function(model) {
+        parseSpec(spec, viewFactory, function(error, model) {
           var group = model.scene().items[0],
               x = group.scale('x'),
               y = group.scale('y');
@@ -745,7 +745,7 @@ describe('Scale', function() {
           expect(y.range()).to.eql(range);
 
           done();
-        }, viewFactory);
+        });
       });
 
       it('should support signal values', function(done) {
@@ -757,17 +757,17 @@ describe('Scale', function() {
           ],
 
           "scales": [{
-            "name": "x", "type": "ordinal", 
-            "domain": [0, 1], 
+            "name": "x", "type": "ordinal",
+            "domain": [0, 1],
             "rangeMin": {"signal": "minRange"}, "rangeMax": {"signal": "maxRange"}
           }, {
-            "name": "y", "type": "linear", 
-            "domain": [0, 1], 
+            "name": "y", "type": "linear",
+            "domain": [0, 1],
             "rangeMin": {"signal": "minRange"}, "rangeMax": {"signal": "maxRange"}
           }]
         };
 
-        parseSpec(spec, function(model) {
+        parseSpec(spec, viewFactory, function(error, model) {
           var group = model.scene().items[0],
               x = group.scale('x'),
               y = group.scale('y');
@@ -787,24 +787,24 @@ describe('Scale', function() {
           expect(y.range()).to.eql([27, 47]);
 
           done();
-        }, viewFactory);
+        });
       });
 
       it('should override range values', function(done) {
         var spec = {
           "data": [],
           "scales": [{
-            "name": "x", "type": "ordinal", 
+            "name": "x", "type": "ordinal",
             "domain": [0, 1],  "range": [0, 1],
             "rangeMin": range[0], "rangeMax": range[1]
           }, {
-            "name": "y", "type": "linear", 
+            "name": "y", "type": "linear",
             "domain": [0, 1], "range": [0, 1],
             "rangeMin": range[0], "rangeMax": range[1]
           }]
         };
 
-        parseSpec(spec, function(model) {
+        parseSpec(spec, viewFactory, function(error, model) {
           var group = model.scene().items[0],
               x = group.scale('x'),
               y = group.scale('y');
@@ -814,7 +814,7 @@ describe('Scale', function() {
           expect(y.range()).to.eql(range);
 
           done();
-        }, viewFactory);
+        });
       });
 
       it('should support DataRef');
@@ -824,7 +824,7 @@ describe('Scale', function() {
       it('should initialize', function(done) {
         var spec = {
           "data": [{
-            "name": "table1", 
+            "name": "table1",
             "values": [{"c": "red"}, {"c": "green"}, {"c": "blue"}]
           }, {
             "name": "table2",
@@ -841,13 +841,13 @@ describe('Scale', function() {
             "range": {
               "fields": [
                 {"data": "table1", "field": "c"},
-                {"data": "table2", "field": "c"}  
+                {"data": "table2", "field": "c"}
               ]
             }
           }]
         };
 
-        parseSpec(spec, function(model) {
+        parseSpec(spec, viewFactory, function(error, model) {
           var group = model.scene().items[0],
             x = group.scale('x'),
             y = group.scale('y');
@@ -856,7 +856,7 @@ describe('Scale', function() {
             expect(y.range()).to.eql(['red', 'green', 'blue', 'cyan', 'yellow', 'magenta']);
 
             done();
-        }, viewFactory);
+        });
       });
 
       it('should handle streaming adds');
@@ -870,17 +870,17 @@ describe('Scale', function() {
       var spec = {
         "data": [],
         "scales": [{
-          "name": "x", "type": "ordinal", 
-          "domain": [0, 1], 
+          "name": "x", "type": "ordinal",
+          "domain": [0, 1],
           "range": range
         }, {
-          "name": "y", "type": "ordinal", 
-          "domain": [0, 1], 
+          "name": "y", "type": "ordinal",
+          "domain": [0, 1],
           "range": range, "points": true
         }]
       };
 
-      parseSpec(spec, function(model) {
+      parseSpec(spec, viewFactory, function(error, model) {
         var group = model.scene().items[0],
             x = group.scale('x'),
             y = group.scale('y');
@@ -890,7 +890,7 @@ describe('Scale', function() {
         expect(y.range()).to.eql(range);
 
         done();
-      }, viewFactory);
+      });
     });
 
     it('should sort domain', function(done) {
@@ -913,21 +913,21 @@ describe('Scale', function() {
           ]
         }],
         "scales": [{
-          "name": "x", "type": "ordinal", 
-          "domain": {"data": "table", "field": "category", "sort": true}, 
+          "name": "x", "type": "ordinal",
+          "domain": {"data": "table", "field": "category", "sort": true},
           "range": "width"
         }, {
-          "name": "y", "type": "ordinal", 
+          "name": "y", "type": "ordinal",
           "domain": {
-            "data": "table", 
+            "data": "table",
             "field": "category",
             "sort": {"field": "value", "op": "average"}
-          }, 
+          },
           "range": "width"
         }]
       };
 
-      parseSpec(spec, function(model) {
+      parseSpec(spec, viewFactory, function(error, model) {
         var group = model.scene().items[0],
             x = group.scale('x'),
             y = group.scale('y');
@@ -936,7 +936,7 @@ describe('Scale', function() {
         expect(y.domain()).to.eql(['C', 'B', 'A']);
 
         done();
-      }, viewFactory);
+      });
     });
 
     it('should support points via signal');
@@ -945,17 +945,17 @@ describe('Scale', function() {
       var spec = {
         "data": [],
         "scales": [{
-          "name": "x", "type": "ordinal", 
-          "domain": [0, 1, 2], 
+          "name": "x", "type": "ordinal",
+          "domain": [0, 1, 2],
           "range": [0, 120], "padding": 0.2,
         }, {
-          "name": "y", "type": "ordinal", 
-          "domain": [0, 1, 2], 
+          "name": "y", "type": "ordinal",
+          "domain": [0, 1, 2],
           "range": [0, 120], "points": true, "padding": 1,
         }]
       };
 
-      parseSpec(spec, function(model) {
+      parseSpec(spec, viewFactory, function(error, model) {
         var group = model.scene().items[0],
             x = group.scale('x'),
             y = group.scale('y');
@@ -965,7 +965,7 @@ describe('Scale', function() {
         expect(y.range()).to.eql([20, 60, 100]);
 
         done();
-      }, viewFactory);
+      });
     });
 
     it('should support padding via signal');
@@ -990,7 +990,7 @@ describe('Scale', function() {
         ]
       };
 
-      parseSpec(spec, function(model) {
+      parseSpec(spec, viewFactory, function(error, model) {
         var group = model.scene().items[0],
             asc  = group.scale('asc'),
             desc = group.scale('desc'),
@@ -1041,7 +1041,7 @@ describe('Scale', function() {
         expect(desc.invert(800, 700)).to.deep.equal(drev.slice(3,4));
 
         done();
-      }, viewFactory);
+      });
     });
   });
 
@@ -1051,17 +1051,17 @@ describe('Scale', function() {
       var spec = {
         "data": [],
         "scales": [{
-          "name": "x", 
-          "domain": [-10, 0], 
+          "name": "x",
+          "domain": [-10, 0],
           "range": ["red", "white", "green"], "clamp": true
         }, {
-          "name": "y", 
-          "domain": [-10, 0, 100], 
+          "name": "y",
+          "domain": [-10, 0, 100],
           "range": ["red", "white"], "clamp": true
         }]
       };
 
-      parseSpec(spec, function(model) {
+      parseSpec(spec, viewFactory, function(error, model) {
         var group = model.scene().items[0],
             x = group.scale('x'),
             y = group.scale('y');
@@ -1073,7 +1073,7 @@ describe('Scale', function() {
         expect(x(50)).to.equal("#ffffff");
 
         done();
-      }, viewFactory);
+      });
     });
 
     it('should nice the domain values', function(done) {
@@ -1082,7 +1082,7 @@ describe('Scale', function() {
         "data": [],
         "scales": [{
           "name": "s1", "zero": false,
-          "domain": [1.1, 10.9], "nice": true 
+          "domain": [1.1, 10.9], "nice": true
         }, {
           "name": "s2", "zero": false,
           "domain": [10.9, 1.1], "nice": true
@@ -1098,7 +1098,7 @@ describe('Scale', function() {
         }]
       };
 
-      parseSpec(spec, function(model) {
+      parseSpec(spec, viewFactory, function(error, model) {
         var group = model.scene().items[0],
             s = group.scale;
 
@@ -1109,7 +1109,7 @@ describe('Scale', function() {
         expect(s('s5').domain()).to.eql([0, .5]);
 
         done();
-      }, viewFactory);
+      });
     });
 
     it('should start at zero', function(done) {
@@ -1124,7 +1124,7 @@ describe('Scale', function() {
         }]
       };
 
-      parseSpec(spec, function(model) {
+      parseSpec(spec, viewFactory, function(error, model) {
         var group = model.scene().items[0],
             s = group.scale;
 
@@ -1132,7 +1132,7 @@ describe('Scale', function() {
         expect(s('s2').domain()).to.eql([0, range[1]]);
 
         done();
-      }, viewFactory);
+      });
     });
 
     it('should support signals for clamp, nice, zero');
@@ -1146,7 +1146,7 @@ describe('Scale', function() {
         "scales": [{
           "name": "s1", "type": "pow",
           "domain": [1, 2], "range": [0, 1], "zero": false,
-          "exponent": 0.5 
+          "exponent": 0.5
         }, {
           "name": "s2", "type": "pow",
           "domain": [1, 2], "range": [0, 1], "zero": false,
@@ -1158,7 +1158,7 @@ describe('Scale', function() {
         }]
       };
 
-      parseSpec(spec, function(model) {
+      parseSpec(spec, viewFactory, function(error, model) {
         var group = model.scene().items[0],
             s1 = group.scale('s1'),
             s2 = group.scale('s2'),
@@ -1180,7 +1180,7 @@ describe('Scale', function() {
         expect(s3.exponent()).to.equal(-1);
 
         done();
-      }, viewFactory);
+      });
     });
 
     it('should support signal exponents');

--- a/test/transforms/aggregate.test.js
+++ b/test/transforms/aggregate.test.js
@@ -21,14 +21,14 @@ describe('Aggregate', function() {
         "name": "table",
         "values": values,
         "transform": [{"type": "aggregate", "summarize": [{
-          "field": "y", 
+          "field": "y",
           "ops": ["count", "sum", "min", "max"]
         }]}]
       }]
     };
 
     it('should compute summaries', function(done) {
-      parseSpec(spec, function(model) {
+      parseSpec(spec, modelFactory, function(error, model) {
         var ds = model.data('table'),
             data = ds.values(),
             count = values.length,
@@ -43,9 +43,8 @@ describe('Aggregate', function() {
         expect(data[0]).to.have.property('min_y', min);
         expect(data[0]).to.have.property('max_y', max);
 
-
         done();
-      }, modelFactory);
+      });
     });
 
     // Assume other measures are being tested in datalib.
@@ -53,7 +52,7 @@ describe('Aggregate', function() {
       var s = dl.duplicate(spec);
       s.data[0].transform[0].summarize[0].as = ["a", "b", "c", "d"];
 
-      parseSpec(s, function(model) {
+      parseSpec(s, modelFactory, function(error, model) {
         var ds = model.data('table'),
             data = ds.values(),
             count = values.length,
@@ -69,11 +68,11 @@ describe('Aggregate', function() {
         expect(data[0]).to.have.property('d', max);
 
         done();
-      }, modelFactory);
+      });
     });
 
     it('should handle streaming adds', function(done) {
-      parseSpec(spec, function(model) {
+      parseSpec(spec, modelFactory, function(error, model) {
         var a1 = {x: 21, y: 21},
             a2 = {x: 22, y: 95},
             a3 = {x: 23, y: 47};
@@ -96,14 +95,14 @@ describe('Aggregate', function() {
         expect(data[0]).to.have.property('max_y', max);
 
         done();
-      }, modelFactory);
+      });
     });
 
     it('should handle streaming mods', function(done) {
-      parseSpec(spec, function(model) {
+      parseSpec(spec, modelFactory, function(error, model) {
         model.data('table')
           .synchronize()
-          .update(function(d) { return d.x % 2 !== 0 }, "y", 
+          .update(function(d) { return d.x % 2 !== 0 }, "y",
             function(d) { return d.y * 2 })
           .fire();
 
@@ -122,11 +121,11 @@ describe('Aggregate', function() {
         expect(data[0]).to.have.property('max_y', max);
 
         done();
-      }, modelFactory);
+      });
     });
 
     it('should handle streaming rems', function(done) {
-      parseSpec(spec, function(model) {        
+      parseSpec(spec, modelFactory, function(error, model) {
         values = values.filter(function(d) { return d.y < 50 });
         model.data('table').synchronize()
           .remove(function(d) { return d.y >= 50 }).fire();
@@ -146,7 +145,7 @@ describe('Aggregate', function() {
         expect(data[0]).to.have.property('max_y', max);
 
         done();
-      }, modelFactory);
+      });
     });
   });
 
@@ -169,7 +168,7 @@ describe('Aggregate', function() {
     };
 
     it('should calculate multiple aggregations', function(done) {
-      parseSpec(spec, function(model) {
+      parseSpec(spec, modelFactory, function(error, model) {
         var ds = model.data('table'),
             data = ds.values();
 
@@ -186,11 +185,11 @@ describe('Aggregate', function() {
         expect(data[1]).to.have.property('sum_population', 6);
 
         done();
-      }, modelFactory);
+      });
     });
 
     it('should handle modified keys', function(done) {
-      parseSpec(spec, function(model) {
+      parseSpec(spec, modelFactory, function(error, model) {
         var ds = model.data('table')
               .synchronize()
               .update(function(d) { return d.country === "Canada" },
@@ -210,7 +209,7 @@ describe('Aggregate', function() {
         expect(data[1]).to.have.property('sum_population', 6);
 
         done();
-      }, modelFactory);
+      });
     });
 
     it('should handle signals', function(done) {
@@ -218,7 +217,7 @@ describe('Aggregate', function() {
       s.signals = [{"name": "field", "init": "area"}, {"name": "ops", "init": ["sum", "count"]}];
       s.data[0].transform[0].summarize = [{"field": {"signal": "field"}, "ops": {"signal": "ops"}}];
 
-      parseSpec(s, function(model) {
+      parseSpec(s, modelFactory, function(error, model) {
         var ds = model.data('table'),
             data = ds.values();
 
@@ -243,10 +242,10 @@ describe('Aggregate', function() {
 
         expect(data[1]).to.have.property('country', 'Canada');
         expect(data[1]).to.have.property('sum_population', 6);
-        expect(data[1]).to.have.property('count_population', 2);        
+        expect(data[1]).to.have.property('count_population', 2);
 
         done();
-      }, modelFactory);
+      });
     });
   });
 
@@ -258,7 +257,7 @@ describe('Aggregate', function() {
 
     expect(validate({ "type": "aggregate" })).to.be.true;
     expect(validate({ "type": "aggregate", "groupby": ["country"] })).to.be.true;
-    expect(validate({ 
+    expect(validate({
       "type": "aggregate",
       "groupby": ["country"],
       "summarize": {
@@ -267,7 +266,7 @@ describe('Aggregate', function() {
       }
     })).to.be.true;
 
-    expect(validate({ 
+    expect(validate({
       "type": "aggregate",
       "groupby": ["country"],
       "summarize": [
@@ -276,7 +275,7 @@ describe('Aggregate', function() {
       ]
     })).to.be.true;
 
-    expect(validate({ 
+    expect(validate({
       "type": "aggregate",
       "groupby": ["country"],
       "summarize": [
@@ -286,7 +285,7 @@ describe('Aggregate', function() {
     })).to.be.true;
 
     expect(validate({ "type": "foo" })).to.be.false;
-    expect(validate({ 
+    expect(validate({
       "type": "aggregate",
       "groupby": "country",
       "summarize": {
@@ -294,7 +293,7 @@ describe('Aggregate', function() {
         "gdp": ["argmin", "argmax"]
       }
     })).to.be.false;
-    expect(validate({ 
+    expect(validate({
       "type": "aggregate",
       "groupby": ["country"],
       "summarize": {
@@ -302,7 +301,7 @@ describe('Aggregate', function() {
         "gdp": ["argmin", "argmax"]
       }
     })).to.be.false;
-    expect(validate({ 
+    expect(validate({
       "type": "aggregate",
       "groupby": ["country"],
       "summarize": {
@@ -310,21 +309,21 @@ describe('Aggregate', function() {
         "gdp": ["argmin", "argmax"]
       }
     })).to.be.false;
-    expect(validate({ 
+    expect(validate({
       "type": "aggregate",
       "groupby": ["country"],
       "summarize": [
         {"field": 1, "ops": ["argmin", "argmax"]}
       ]
     })).to.be.false;
-    expect(validate({ 
+    expect(validate({
       "type": "aggregate",
       "groupby": ["country"],
       "summarize": [
         {"field": "gdp", "ops": ["argmin", "argmax", "foo"]}
       ]
     })).to.be.false;
-    expect(validate({ 
+    expect(validate({
       "type": "aggregate",
       "groupby": ["country"],
       "summarize": [

--- a/test/transforms/bin.test.js
+++ b/test/transforms/bin.test.js
@@ -12,21 +12,21 @@ describe('Bin', function() {
     8.7, 8.8, 8.9,
     9.1, 9.2, 9.3
   ];
-  
+
   function spec(opt) {
     var bin = {"type": "bin", "field": "v", "output": {"start": "bin_v"}};
     for (var name in opt) bin[name] = opt[name];
-    return { 
-      "data": [{ 
-        "name": "table", 
+    return {
+      "data": [{
+        "name": "table",
         "values": values.map(function(x) { return {v:x}; }),
         "transform": [bin]
-      }] 
+      }]
     };
   }
 
   it('should handle extent calculation', function(done) {
-    parseSpec(spec({maxbins: 10}), function(model) {
+    parseSpec(spec({maxbins: 10}), modelFactory, function(error, model) {
       var ds = model.data('table'),
           data = ds.values(),
           floored = values.map(function(x) { return ~~x; });
@@ -35,13 +35,13 @@ describe('Bin', function() {
       for (var i=0, len=data.length; i<len; ++i) {
         expect(data[i].bin_v).to.equal(floored[i]);
       }
-  
+
       done();
-    }, modelFactory);
+    });
   });
 
   it('should handle step definition', function(done) {
-    parseSpec(spec({min:0, max:10, step:1}), function(model) {
+    parseSpec(spec({min:0, max:10, step:1}), modelFactory, function(error, model) {
       var ds = model.data('table'),
           data = ds.values(),
           floored = values.map(function(x) { return ~~x; });
@@ -52,13 +52,13 @@ describe('Bin', function() {
         expect(data[i].bin_end).to.equal(floored[i]+1);
         expect(data[i].bin_mid).to.equal(floored[i]+0.5);
       }
-  
+
       done();
-    }, modelFactory);
+    });
   });
 
   it('should handle maxbins definition', function(done) {
-    parseSpec(spec({min:0, max:10, maxbins: 5}), function(model) {
+    parseSpec(spec({min:0, max:10, maxbins: 5}), modelFactory, function(error, model) {
       var ds = model.data('table'),
           data = ds.values(),
           floored = values.map(function(x) { return ~~x - (~~x % 2); });
@@ -67,16 +67,16 @@ describe('Bin', function() {
       for (var i=0, len=data.length; i<len; ++i) {
         expect(data[i].bin_v).to.equal(floored[i]);
       }
-  
+
       done();
-    }, modelFactory);
+    });
   });
 
   it('should handle nulls', function(done) {
-    parseSpec(spec({min:0, max:10, step: 1}), function(model) {
+    parseSpec(spec({min:0, max:10, step: 1}), modelFactory, function(error, model) {
       var ds = model.data('table').insert([{v: null}, {v: undefined}]);
       model.fire();
-      
+
       var data = ds.values(),
           floored = values.map(function(x) { return ~~x; });
       floored.push(null, null);
@@ -85,19 +85,19 @@ describe('Bin', function() {
       for (var i=0, len=data.length; i<len; ++i) {
         expect(data[i].bin_v).to.equal(floored[i]);
       }
-  
+
       done();
-    }, modelFactory);
+    });
   });
 
   it('should handle streaming adds', function(done) {
-    parseSpec(spec({min:0, max:10, step: 2}), function(model) {
+    parseSpec(spec({min:0, max:10, step: 2}), modelFactory, function(error, model) {
       var ds = model.data('table')
         .insert([{v:1.1}])
         .insert([{v:-2.1}])
         .insert([{v:11.2}]);
       ds.fire();
-      
+
       var data = ds.values(),
           floored = values.map(function(x) { return ~~x - (~~x%2); });
       floored.push(0, -2, 10);
@@ -106,20 +106,20 @@ describe('Bin', function() {
       for (var i=0, len=data.length; i<len; ++i) {
         expect(data[i].bin_v).to.equal(floored[i]);
       }
-  
+
       done();
-    }, modelFactory);
+    });
   });
-  
+
   it('should handle streaming mods', function(done) {
-    parseSpec(spec({min:0, max:10, step: 1}), function(model) {
+    parseSpec(spec({min:0, max:10, step: 1}), modelFactory, function(error, model) {
       var ds = model.data('table').update(
         function(d) { return d.v < 2; },
         "v",
         function(d) { return Math.random(); }
       );
       ds.fire();
-      
+
       var data = ds.values(),
           floored = values.map(function(x) { return x < 2 ? 0 : ~~x; });
 
@@ -127,9 +127,9 @@ describe('Bin', function() {
       for (var i=0, len=data.length; i<len; ++i) {
         expect(data[i].bin_v).to.equal(floored[i]);
       }
-  
+
       done();
-    }, modelFactory);
+    });
   });
 
   it('should validate against the schema', function() {

--- a/test/transforms/countpattern.test.js
+++ b/test/transforms/countpattern.test.js
@@ -32,7 +32,7 @@ describe('CountPattern', function() {
   };
 
   it('should count patterns', function(done) {
-    parseSpec(spec1, function(model) {
+    parseSpec(spec1, modelFactory, function(error, model) {
       var data = model.data('table').values().sort(dl.comparator('-count'));
       expect(data.length).to.equal(3);
       expect(data[0].text).to.equal('a');
@@ -41,16 +41,16 @@ describe('CountPattern', function() {
       expect(data[0].count).to.equal(4);
       expect(data[1].count).to.equal(3);
       expect(data[2].count).to.equal(1);
-      
-      parseSpec(spec2, function(model) {
+
+      parseSpec(spec2, modelFactory, function(error, model) {
         var data = model.data('table').values().sort(dl.comparator('-count'));
         expect(data.length).to.equal(1);
         expect(data[0].text).to.equal(' ');
         expect(data[0].count).to.equal(15);
         done();
-      }, modelFactory);
+      });
 
-    }, modelFactory);
+    });
   });
 
   it('should validate against the schema', function() {
@@ -70,7 +70,7 @@ describe('CountPattern', function() {
     expect(validate({ "type": "countpattern", "stopwords": {"signal": "stop"} })).to.be.true;
     expect(validate({ "type": "countpattern", "output": {"text": "text"} })).to.be.true;
     expect(validate({ "type": "countpattern", "output": {"count": "count"} })).to.be.true;
-    
+
     expect(validate({ "type": "foo" })).to.be.false;
     expect(validate({ "type": "countpattern", "field": 1 })).to.be.false;
     expect(validate({ "type": "countpattern", "pattern": 2 })).to.be.false;

--- a/test/transforms/cross.test.js
+++ b/test/transforms/cross.test.js
@@ -3,7 +3,7 @@ describe('Cross', function() {
       {"x": 1,  "y": 28}, {"x": 2,  "y": 55},
       {"x": 3,  "y": 43}]
   var values2 = [
-      {"x": 4,  "y": 91}, {"x": 5,  "y": 81}, 
+      {"x": 4,  "y": 91}, {"x": 5,  "y": 81},
       {"x": 6,  "y": 53}]
 
   var spec = {
@@ -22,7 +22,7 @@ describe('Cross', function() {
   };
 
   it('should handle initial datasource', function(done) {
-    parseSpec(spec, function(model) {
+    parseSpec(spec, modelFactory, function(error, model) {
       var ds1 = model.data('table1'),
           ds2 = model.data('table2'),
           data1 = ds1.values(),
@@ -35,14 +35,14 @@ describe('Cross', function() {
       expect(ds2._output.fields).to.contain.keys(['a', 'b']);
 
       done();
-    }, modelFactory);
+    });
   });
 
   it('should handle streaming adds', function(done) {
-    parseSpec(spec, function(model) {
+    parseSpec(spec, modelFactory, function(error, model) {
       var ds1 = model.data('table1'),
           ds2 = model.data('table2'),
-          new1 = {"x": 7,  "y": 19}, 
+          new1 = {"x": 7,  "y": 19},
           new2 = {"x": 8,  "y": 87},
           data1 = ds1.values(),
           data2 = ds2.values();
@@ -67,12 +67,12 @@ describe('Cross', function() {
       expect(ds2._output.fields).to.contain.keys(['a', 'b']);
 
       done();
-    }, modelFactory);
+    });
 
   });
 
   it('should handle streaming rems', function(done) {
-    parseSpec(spec, function(model) {
+    parseSpec(spec, modelFactory, function(error, model) {
       var ds1 = model.data('table1'),
           ds2 = model.data('table2'),
           data1 = ds1.values(),
@@ -84,7 +84,7 @@ describe('Cross', function() {
 
       ds1.remove(function(x) { return x.x == 1; }).fire();
       data1 = ds1.values();
-      data2 = ds2.values(); 
+      data2 = ds2.values();
 
       expect(data1).to.have.length(2);
       expect(data2).to.have.length(6);
@@ -92,14 +92,14 @@ describe('Cross', function() {
 
       ds2.remove(function(x) { return x.x == 4; }).fire();
       data1 = ds1.values();
-      data2 = ds2.values(); 
+      data2 = ds2.values();
 
       expect(data1).to.have.length(2);
       expect(data2).to.have.length(4);
       expect(ds2._output.fields).to.contain.keys(['a', 'b']);
 
       // Test that lazy removal is working correctly.
-      ds2.update(function(x) { return x.x == 6; }, 
+      ds2.update(function(x) { return x.x == 6; },
         'y', function(x) { return 600; }).fire();
       data1 = ds1.values(),
       data2 = ds2.values();
@@ -109,12 +109,12 @@ describe('Cross', function() {
       expect(ds2._output.fields).to.contain.keys(['a', 'b']);
 
       done();
-    }, modelFactory);
+    });
 
   });
 
   it('should propegate mod tuples', function(done) {
-    parseSpec(spec, function(model) {
+    parseSpec(spec, modelFactory, function(error, model) {
       var ds1 = model.data('table1'),
           ds2 = model.data('table2'),
           data1 = ds1.values(),
@@ -124,7 +124,7 @@ describe('Cross', function() {
       expect(data2).to.have.length(9);
       expect(ds2._output.fields).to.contain.keys(['a', 'b']);
 
-      ds2.update(function(x) { return x.x == 1; }, 
+      ds2.update(function(x) { return x.x == 1; },
         'y', function(x) { return 100; }).fire();
       data1 = ds1.values(),
       data2 = ds2.values();
@@ -133,7 +133,7 @@ describe('Cross', function() {
       expect(data2).to.have.length(9);
       expect(ds2._output.fields).to.contain.keys(['a', 'b']);
 
-      ds2.update(function(x) { return x.x == 4; }, 
+      ds2.update(function(x) { return x.x == 4; },
         'y', function(x) { return 400; }).fire();
       data1 = ds1.values(),
       data2 = ds2.values();
@@ -143,7 +143,7 @@ describe('Cross', function() {
       expect(ds2._output.fields).to.contain.keys(['a', 'b']);
 
       done();
-    }, modelFactory);
+    });
 
   });
 
@@ -151,7 +151,7 @@ describe('Cross', function() {
     var s = dl.duplicate(spec);
       s.data[1].transform[0].output = {"left": "thing1", "right": "thing2"};
 
-    parseSpec(s, function(model) {
+    parseSpec(s, modelFactory, function(error, model) {
       var ds1 = model.data('table1'),
           ds2 = model.data('table2'),
           data1 = ds1.values(),
@@ -162,23 +162,23 @@ describe('Cross', function() {
       expect(ds2._output.fields).to.contain.keys(['thing1', 'thing2']);
 
       done();
-    }, modelFactory);
+    });
 
   });
 
   it('should self cross', function(done) {
     var spec = {
       "data": [{
-        "name": "table1", 
+        "name": "table1",
         "values": values1,
         "transform": [{"type": "cross"}]
       }]
     };
 
-    parseSpec(spec, function(model) {
+    parseSpec(spec, modelFactory, function(error, model) {
       var ds1 = model.data('table1'),
           data1 = ds1.values(),
-          new1 = {"x": 7,  "y": 19}, 
+          new1 = {"x": 7,  "y": 19},
           new2 = {"x": 8,  "y": 87};
 
       expect(data1).to.have.length(9);
@@ -190,54 +190,54 @@ describe('Cross', function() {
       ds1.update(function() { return true; }, 'x', function(t) { return t.x+1; })
         .fire();
       data1 = ds1.values();
-      expect(data1).to.have.length(25);        
+      expect(data1).to.have.length(25);
 
       ds1.remove(function(t) { return t.x === 8; }).fire();
       data1 = ds1.values();
       expect(data1).to.have.length(16);
 
       done();
-    }, modelFactory);
+    });
   });
 
   it('should exclude diagonal values', function(done) {
     var spec = {
       "data": [{
-        "name": "table1", 
+        "name": "table1",
         "values": values1,
         "transform": [{"type": "cross", "diagonal": false}]
       }]
     };
 
-    parseSpec(spec, function(model) {
+    parseSpec(spec, modelFactory, function(error, model) {
       var ds1 = model.data('table1'),
           data1 = ds1.values();
 
       expect(data1).to.have.length(6);
 
       done();
-    }, modelFactory);
+    });
   });
 
   it('should exclude filtered values', function(done) {
     var spec = {
       "data": [{
-        "name": "table1", 
+        "name": "table1",
         "values": values1,
         "transform": [{"type": "cross", "filter": "datum.a.x >= 2 && datum.b.y < 40"}]
       }]
     };
 
-    parseSpec(spec, function(model) {
+    parseSpec(spec, modelFactory, function(error, model) {
       var ds1 = model.data('table1'),
           data1 = ds1.values(),
-          new1 = {"x": 7,  "y": 19}, 
+          new1 = {"x": 7,  "y": 19},
           new2 = {"x": 8,  "y": 87};
 
       expect(data1).to.have.length(2);
 
       ds1.insert([new1, new2]).fire();
-      data1 = ds1.values();     
+      data1 = ds1.values();
       expect(data1).to.have.length(8);
 
       ds1.update(function(t) { return t.x === 3; }, 'y', function(t) { return 39; })
@@ -248,14 +248,14 @@ describe('Cross', function() {
       ds1.update(function(t) { return t.x === 3; }, 'y', function(t) { return 41; })
         .fire();
       data1 = ds1.values();
-      expect(data1).to.have.length(8);   
+      expect(data1).to.have.length(8);
 
       ds1.remove(function(t) { return t.x >=7; }).fire();
       data1 = ds1.values();
       expect(data1).to.have.length(2);
 
       done();
-    }, modelFactory);
+    });
   });
 
   it('should recross on signal change', function(done) {
@@ -275,7 +275,7 @@ describe('Cross', function() {
       }]
     };
 
-    parseSpec(spec, function(model) {
+    parseSpec(spec, modelFactory, function(error, model) {
       var ds1 = model.data('table1'),
           data1 = ds1.values(),
           out1  = ds1._output;
@@ -298,11 +298,11 @@ describe('Cross', function() {
       out1  = ds1._output;
       expect(data1).to.have.length(2);
       expect(out1.rem).to.have.length(4);
-      expect(out1.add).to.have.length(2);  
-      expect(out1.mod).to.have.length(0);          
+      expect(out1.add).to.have.length(2);
+      expect(out1.mod).to.have.length(0);
 
       done();
-    }, modelFactory);
+    });
   });
 
   it('should validate against the schema', function() {
@@ -312,27 +312,27 @@ describe('Cross', function() {
     expect(validate({ "type": "cross" })).to.be.true;
     expect(validate({ "type": "cross", "with": "table" })).to.be.true;
     expect(validate({ "type": "cross", "with": "table", "diagonal": false })).to.be.true;
-    expect(validate({ 
-      "type": "cross", 
-      "with": "table", 
-      "output": {"left": "foo", "right": "bar"} 
+    expect(validate({
+      "type": "cross",
+      "with": "table",
+      "output": {"left": "foo", "right": "bar"}
     })).to.be.true;
 
     expect(validate({ "type": "foo" })).to.be.false;
     expect(validate({ "type": "cross", "with": 5 })).to.be.false;
     expect(validate({ "type": "cross", "with": "table", "diagonal": 1 })).to.be.false;
-    expect(validate({ 
-      "type": "cross", 
-      "with": "table", 
-      "output": {"left": 1, "right": 2} 
+    expect(validate({
+      "type": "cross",
+      "with": "table",
+      "output": {"left": 1, "right": 2}
     })).to.be.false;
 
-    expect(validate({ 
-      "type": "cross", 
-      "with": "table", 
+    expect(validate({
+      "type": "cross",
+      "with": "table",
       "output": {"left": "foo", "right": "bar"},
       "hello": "world"
     })).to.be.false;
   });
-  
+
 });

--- a/test/transforms/facet.test.js
+++ b/test/transforms/facet.test.js
@@ -30,9 +30,9 @@ describe('Facet', function() {
   }
 
   it('should handle initial datasource', function(done) {
-    parseSpec(spec, function(model) {
+    parseSpec(spec, modelFactory, function(error, model) {
       var ds = model.data('table'),
-          facets = ds.values(), 
+          facets = ds.values(),
           i, len;
 
       expect(facets).to.have.length(2);
@@ -40,13 +40,13 @@ describe('Facet', function() {
       expectFacet(facets, 1, 3, 5); // Canada
 
       done();
-    }, modelFactory);
+    });
   });
 
   it('should handle streaming adds', function(done) {
-    parseSpec(spec, function(model) {
+    parseSpec(spec, modelFactory, function(error, model) {
       var ds = model.data('table'),
-          facets = ds.values(), 
+          facets = ds.values(),
           i, len;
 
       expect(facets).to.have.length(2);
@@ -67,11 +67,11 @@ describe('Facet', function() {
       expectFacet(facets, 2, 8, 8); // Mexico
 
       done();
-    }, modelFactory);
+    });
   });
 
   it('should handle streaming mods', function(done) {
-    parseSpec(spec, function(model) {
+    parseSpec(spec, modelFactory, function(error, model) {
       var ds = model.data('table').synchronize(),
           facets = ds.values(),
           i, len;
@@ -96,7 +96,7 @@ describe('Facet', function() {
 
       // Changing key field
       values[8].country = "India";
-      ds.update(function(x) { return x.country === "Mexico" }, 
+      ds.update(function(x) { return x.country === "Mexico" },
         "country", function(x) { return "India"; }).fire();
       facets = ds.values();
       expect(facets).to.have.length(3);
@@ -105,13 +105,13 @@ describe('Facet', function() {
       expectFacet(facets, 2, 8, 8); // India
 
       done();
-    }, modelFactory);
+    });
   });
 
   it('should handle streaming rems', function(done) {
-    parseSpec(spec, function(model) {
+    parseSpec(spec, modelFactory, function(error, model) {
       var ds = model.data('table').synchronize(),
-          facets = ds.values(), 
+          facets = ds.values(),
           i, len;
 
       expect(facets).to.have.length(3);
@@ -129,16 +129,16 @@ describe('Facet', function() {
       expectFacet(facets, 1, 3, 5); // Canada
 
       done();
-    }, modelFactory);    
+    });
   })
 
   it('should handle signals as keys', function(done) {
     var s = dl.duplicate(spec);
     spec.data[0].transform[0].groupby = [{"signal": "keys"}];
 
-    parseSpec(spec, function(model) {
+    parseSpec(spec, modelFactory, function(error, model) {
       var ds = model.data('table'),
-          facets = ds.values(), 
+          facets = ds.values(),
           i, len;
 
       expect(facets).to.have.length(2);
@@ -158,7 +158,7 @@ describe('Facet', function() {
       expect(facets[2].values).to.have.length(2);
 
       done();
-    }, modelFactory);      
+    });
   });
 
   it('should handle fields+signals as keys', function(done) {
@@ -166,9 +166,9 @@ describe('Facet', function() {
     spec.signals[0].init = 'type';
     spec.data[0].transform[0].groupby = [{"field": "country"}, {"signal": "keys"}];
 
-    parseSpec(spec, function(model) {
+    parseSpec(spec, modelFactory, function(error, model) {
       var ds = model.data('table'),
-          facets = ds.values(), 
+          facets = ds.values(),
           i, len;
 
       expect(facets).to.have.length(6);
@@ -187,7 +187,7 @@ describe('Facet', function() {
       expect(facets[5].values).to.have.length(1);
 
       done();
-    }, modelFactory);      
+    });
   });
 
   it('should compute summaries on facets', function(done) {
@@ -205,7 +205,7 @@ describe('Facet', function() {
       }]
     };
 
-    parseSpec(spec, function(model) {
+    parseSpec(spec, modelFactory, function(error, model) {
       var ds = model.data('table'),
           data = ds.values();
 
@@ -224,7 +224,7 @@ describe('Facet', function() {
       expect(data[1]).to.have.property('max_count', 5);
 
       done();
-    }, modelFactory);
+    });
   });
 
   it('should transform faceted values');
@@ -236,7 +236,7 @@ describe('Facet', function() {
     expect(validate({ "type": "facet" })).to.be.true;
     expect(validate({ "type": "facet", "groupby": ["country"] })).to.be.true;
 
-    expect(validate({ 
+    expect(validate({
       "type": "facet",
       "groupby": ["country"],
       "summarize": {
@@ -245,7 +245,7 @@ describe('Facet', function() {
       }
     })).to.be.true;
 
-    expect(validate({ 
+    expect(validate({
       "type": "facet",
       "groupby": ["country"],
       "summarize": [
@@ -254,7 +254,7 @@ describe('Facet', function() {
       ]
     })).to.be.true;
 
-    expect(validate({ 
+    expect(validate({
       "type": "facet",
       "groupby": ["country"],
       "summarize": [
@@ -264,7 +264,7 @@ describe('Facet', function() {
     })).to.be.true;
 
     expect(validate({ "type": "foo" })).to.be.false;
-    expect(validate({ 
+    expect(validate({
       "type": "facet",
       "groupby": "country",
       "summarize": {
@@ -272,7 +272,7 @@ describe('Facet', function() {
         "gdp": ["argmin", "argmax"]
       }
     })).to.be.false;
-    expect(validate({ 
+    expect(validate({
       "type": "facet",
       "groupby": ["country"],
       "summarize": {
@@ -280,7 +280,7 @@ describe('Facet', function() {
         "gdp": ["argmin", "argmax"]
       }
     })).to.be.false;
-    expect(validate({ 
+    expect(validate({
       "type": "facet",
       "groupby": ["country"],
       "summarize": {
@@ -288,21 +288,21 @@ describe('Facet', function() {
         "gdp": ["argmin", "argmax"]
       }
     })).to.be.false;
-    expect(validate({ 
+    expect(validate({
       "type": "facet",
       "groupby": ["country"],
       "summarize": [
         {"field": 1, "ops": ["argmin", "argmax"]}
       ]
     })).to.be.false;
-    expect(validate({ 
+    expect(validate({
       "type": "facet",
       "groupby": ["country"],
       "summarize": [
         {"field": "gdp", "ops": ["argmin", "argmax", "foo"]}
       ]
     })).to.be.false;
-    expect(validate({ 
+    expect(validate({
       "type": "facet",
       "groupby": ["country"],
       "summarize": [

--- a/test/transforms/filter.test.js
+++ b/test/transforms/filter.test.js
@@ -13,38 +13,38 @@ describe('Filter', function() {
   ];
 
   it('should work w/a static expr', function(done) {
-    parseSpec({ 
-      "data": [{ 
-        "name": "table", 
+    parseSpec({
+      "data": [{
+        "name": "table",
         "values": values,
         "transform": [{"type": "filter", "test": "datum.y > 45"}]
-      }] 
-    }, function(model) {
+      }]
+    }, viewFactory, function(error, model) {
       var ds = model.data('table'),
-          data = ds.values(), 
-          filtered = values.filter(function(d) { return d.y > 45 }), 
+          data = ds.values(),
+          filtered = values.filter(function(d) { return d.y > 45 }),
           i, len;
 
       expect(data.length).to.be.above(0).and.equal(filtered.length);
       for(i=0, len=data.length; i<len; ++i) expect(data[i].y).to.be.above(45);
 
       done();
-    }, viewFactory);
+    });
   });
 
   it('should work w/signals in expr', function(done) {
-    parseSpec({ 
+    parseSpec({
       "signals":[{"name": "above", "init": 45}],
 
-      "data": [{ 
-        "name": "table", 
+      "data": [{
+        "name": "table",
         "values": values,
         "transform": [{"type": "filter", "test": "datum.y > above"}]
-      }] 
-    }, function(model) {
+      }]
+    }, viewFactory, function(error, model) {
       var ds = model.data('table'),
-          data = ds.values(), 
-          filtered = values.filter(function(d) { return d.y > 45 }), 
+          data = ds.values(),
+          filtered = values.filter(function(d) { return d.y > 45 }),
           i, len;
 
       expect(data.length).to.be.above(0).and.equal(filtered.length);
@@ -63,7 +63,7 @@ describe('Filter', function() {
       for(i=0, len=data.length; i<len; ++i) expect(data[i].y).to.be.above(30);
 
       done();
-    }, viewFactory);
+    });
   });
 
   it('should validate against the schema', function() {
@@ -71,7 +71,7 @@ describe('Filter', function() {
         validate = validator(schema);
 
     expect(validate({ "type": "filter", "test": "d.x > 5" })).to.be.true;
-    
+
     expect(validate({ "type": "foo" })).to.be.false;
     expect(validate({ "type": "filter" })).to.be.false;
     expect(validate({ "type": "filter", "test": true })).to.be.false;

--- a/test/transforms/fold.test.js
+++ b/test/transforms/fold.test.js
@@ -5,14 +5,14 @@ describe('Fold', function() {
   ];
 
   var spec = {
-    "data": [{ 
-      "name": "table", 
+    "data": [{
+      "name": "table",
       "values": values,
       "transform": [{
-        "type": "fold", 
+        "type": "fold",
         "fields": [{"field": "gold"}, {"field": "silver"}, {"field": "bronze"}]
       }]
-    }] 
+    }]
   };
 
   function expectFold(val, data, idx, key, value) {
@@ -35,9 +35,9 @@ describe('Fold', function() {
 
 
   it('should handle initial datasource', function(done) {
-    parseSpec(spec, function(model) {
+    parseSpec(spec, modelFactory, function(error, model) {
       var ds = model.data('table'),
-          data = ds.values(), 
+          data = ds.values(),
           i, len, d;
 
       expect(data).to.have.length(6);
@@ -46,15 +46,15 @@ describe('Fold', function() {
       expect(ds._output.fields).to.have.keys(['key', 'value']);
 
       done();
-    }, modelFactory);
+    });
   });
 
   it('should handle streaming adds', function(done) {
-    parseSpec(spec, function(model) {
+    parseSpec(spec, modelFactory, function(error, model) {
       var ds = model.data('table'),
           mex = {"country": "Mexico", "gold": 3, "silver": 3, "bronze": 2},
           bel = {"country": "Belize", "gold": 0, "silver": 0, "bronze": 0},
-          data = ds.values(), 
+          data = ds.values(),
           i, len, d;
 
       expect(data).to.have.length(6);
@@ -72,13 +72,13 @@ describe('Fold', function() {
       expect(ds._output.fields).to.have.keys(['key', 'value']);
 
       done();
-    }, modelFactory);
+    });
   });
 
   it('should handle streaming rems', function(done) {
-    parseSpec(spec, function(model) {
+    parseSpec(spec, modelFactory, function(error, model) {
       var ds = model.data('table'),
-          data = ds.values(), 
+          data = ds.values(),
           i, len, d;
 
       expect(data).to.have.length(6);
@@ -93,13 +93,13 @@ describe('Fold', function() {
       expect(ds._output.fields).to.have.keys(['key', 'value']);
 
       done();
-    }, modelFactory);
+    });
   });
 
   it('should propagate mod tuples if fields updated', function(done) {
-    parseSpec(spec, function(model) {
+    parseSpec(spec, modelFactory, function(error, model) {
       var ds = model.data('table'),
-          data = ds.values(), 
+          data = ds.values(),
           i, len, d;
 
       expect(data).to.have.length(6);
@@ -107,7 +107,7 @@ describe('Fold', function() {
       expectFold(values[1], data);  // Canada
       expect(ds._output.fields).to.have.keys(['key', 'value']);
 
-      ds.update(function(x) { return x.country == "US" }, 
+      ds.update(function(x) { return x.country == "US" },
         'gold', function(x) { return 100; }).fire();
       data = ds.values();
       expect(data).to.have.length(6);
@@ -128,13 +128,13 @@ describe('Fold', function() {
       expect(ds._output.fields).to.have.keys(['gold', 'key', 'value']);
 
       done();
-    }, modelFactory);
+    });
   });
 
   it('should only propagate mod tuples if fields not updated', function(done) {
-    parseSpec(spec, function(model) {
+    parseSpec(spec, modelFactory, function(error, model) {
       var ds = model.data('table'),
-          data = ds.values(), 
+          data = ds.values(),
           i, len, d;
 
       expect(data).to.have.length(6);
@@ -150,16 +150,16 @@ describe('Fold', function() {
       expect(ds._output.fields).to.not.have.keys(['key', 'value']);
 
       done();
-    }, modelFactory);
+    });
   });
 
   it('should allow renamed keys', function(done) {
     var s = dl.duplicate(spec);
     s.data[0].transform[0].output = {key: "type"};
 
-    parseSpec(s, function(model) {
+    parseSpec(s, modelFactory, function(error, model) {
       var ds = model.data('table'),
-          data = ds.values(), 
+          data = ds.values(),
           i, len, d;
 
       expect(data).to.have.length(6);
@@ -168,16 +168,16 @@ describe('Fold', function() {
       expect(ds._output.fields).to.have.keys(['type', 'value']);
 
       done();
-    }, modelFactory);
+    });
   });
 
   it('should allow renamed values', function(done) {
     var s = dl.duplicate(spec);
     s.data[0].transform[0].output = {value: "medals"};
 
-    parseSpec(s, function(model) {
+    parseSpec(s, modelFactory, function(error, model) {
       var ds = model.data('table'),
-          data = ds.values(), 
+          data = ds.values(),
           i, len, d;
 
       expect(data).to.have.length(6);
@@ -186,7 +186,7 @@ describe('Fold', function() {
       expect(ds._output.fields).to.have.keys(['key', 'medals']);
 
       done();
-    }, modelFactory);
+    });
   });
 
   it('should allow array<signal> for fields?');
@@ -196,19 +196,19 @@ describe('Fold', function() {
         validate = validator(schema);
 
     expect(validate({ "type": "fold", "fields": ["gold", "silver"] })).to.be.true;
-    expect(validate({ 
-      "type": "fold", 
-      "fields": ["gold", "silver"], 
-      "output": {"key": "k", "value": "v"} 
+    expect(validate({
+      "type": "fold",
+      "fields": ["gold", "silver"],
+      "output": {"key": "k", "value": "v"}
     })).to.be.true;
-    
+
     expect(validate({ "type": "foo" })).to.be.false;
     expect(validate({ "type": "fold" })).to.be.false;
     expect(validate({ "type": "fold", "foo": "bar" })).to.be.false;
     expect(validate({ "type": "fold", "fields": "gold" })).to.be.false;
     expect(validate({ "type": "fold", "fields": ["gold", 1] })).to.be.false;
-    expect(validate({ 
-      "type": "fold", 
+    expect(validate({
+      "type": "fold",
       "fields": ["gold"],
       "output": {"foo": "bar"}
     })).to.be.false;

--- a/test/transforms/force.test.js
+++ b/test/transforms/force.test.js
@@ -39,8 +39,8 @@ describe('Force', function() {
   }
 
   it('should perform layout', function(done) {
-    parseSpec(spec({}),
-      function(model) {
+    parseSpec(spec({}), modelFactory,
+      function(error, model) {
         var nodes = model.data('vertices').values(),
             links = model.data('edges').values();
 
@@ -51,16 +51,15 @@ describe('Force', function() {
         }
 
         done();
-      },
-      modelFactory);
+      });
   });
 
   it('should respect link distances', function(done) {
     var linkDistances = [20, 100, 200];
-    
+
     linkDistances.forEach(function(dist, i) {
-      parseSpec(spec({linkDistance: dist, iterations: 100}),
-        function(model) {
+      parseSpec(spec({linkDistance: dist, iterations: 100}), modelFactory,
+        function(error, model) {
           var nodes = model.data('vertices').values(),
               links = model.data('edges').values();
 
@@ -75,8 +74,7 @@ describe('Force', function() {
           }
 
           if (i == linkDistances.length - 1) done();
-        },
-        modelFactory);
+        });
     });
   });
 
@@ -99,7 +97,7 @@ describe('Force', function() {
     expect(validate({ "type": "force", "links": "edges", "gravity": 0.4 })).to.be.true;
     expect(validate({ "type": "force", "links": "edges", "alpha": 0.4 })).to.be.true;
     expect(validate({ "type": "force", "links": "edges", "output": {"x": "x", "y": "y"} })).to.be.true;
-    
+
     expect(validate({ "type": "foo" })).to.be.false;
     expect(validate({ "type": "force" })).to.be.false;
     expect(validate({ "type": "force", "links": true })).to.be.false;

--- a/test/transforms/formula.test.js
+++ b/test/transforms/formula.test.js
@@ -13,15 +13,15 @@ describe('Formula', function() {
   ];
 
   it('should work w/a static expr', function(done) {
-    parseSpec({ 
-      "data": [{ 
-        "name": "table", 
+    parseSpec({
+      "data": [{
+        "name": "table",
         "values": values,
         "transform": [{"type": "formula", "field": "z", "expr": "datum.x + datum.y"}]
-      }] 
-    }, function(model) {
+      }]
+    }, modelFactory, function(error, model) {
       var ds = model.data('table'),
-          data = ds.values(), 
+          data = ds.values(),
           i, len, d;
 
       expect(data).to.have.length(20);
@@ -32,21 +32,21 @@ describe('Formula', function() {
       expect(ds._output.fields).to.have.key('z');
 
       done();
-    }, modelFactory);
+    });
   });
 
   it('should work w/signals in expr', function(done) {
-    parseSpec({ 
+    parseSpec({
       "signals":[{"name": "multipler", "init": 2}],
 
-      "data": [{ 
-        "name": "table", 
+      "data": [{
+        "name": "table",
         "values": values,
         "transform": [{"type": "formula", "field": "z", "expr": "multipler * (datum.x + datum.y)"}]
-      }] 
-    }, function(model) {
+      }]
+    }, modelFactory, function(error, model) {
       var ds = model.data('table'),
-          data = ds.values(), 
+          data = ds.values(),
           i, len, d;
 
       expect(data).to.have.length(20);
@@ -75,7 +75,7 @@ describe('Formula', function() {
       expect(ds._output.fields).to.have.key('z');
 
       done();
-    }, modelFactory);
+    });
   });
 
   it('should validate against the schema', function() {
@@ -83,7 +83,7 @@ describe('Formula', function() {
         validate = validator(schema);
 
     expect(validate({ "type": "formula", "expr": "d.x + d.y", "field": "sum" })).to.be.true;
-    
+
     expect(validate({ "type": "foo" })).to.be.false;
     expect(validate({ "type": "formula" })).to.be.false;
     expect(validate({ "type": "formula", "field": "sum" })).to.be.false;

--- a/test/transforms/hierarchy.test.js
+++ b/test/transforms/hierarchy.test.js
@@ -23,8 +23,8 @@ describe('Hierarchy', function() {
   }
 
   it('should perform hierarchy layout', function(done) {
-    parseSpec(spec(),
-      function(model) {
+    parseSpec(spec(), modelFactory,
+      function(error, model) {
         var ds = model.data('table'),
             data = ds.values();
 
@@ -35,8 +35,7 @@ describe('Hierarchy', function() {
         });
 
         done();
-      },
-      modelFactory);
+      });
   });
 
   it('should validate against the schema', function() {

--- a/test/transforms/impute.test.js
+++ b/test/transforms/impute.test.js
@@ -8,7 +8,7 @@ describe('Impute', function() {
     {a: 2, b: 3, c: 5},
     {a: 2, b: 4, c: 11}
   ];
-  
+
   function spec(opt) {
     var impute = {
       type: 'impute',
@@ -18,7 +18,7 @@ describe('Impute', function() {
       method:  opt.method,
       value:   opt.value
     };
-    
+
     return {
       data: [{
         name: "table",
@@ -33,8 +33,8 @@ describe('Impute', function() {
   };
 
   it('should impute values', function(done) {
-    parseSpec(spec({method: 'value', value: -1}),
-      function(model) {
+    parseSpec(spec({method: 'value', value: -1}), modelFactory,
+      function(error, model) {
         var ds = model.data('table'),
             data = ds.values().filter(imputed);
 
@@ -46,13 +46,12 @@ describe('Impute', function() {
         expect(data[1]).to.have.property('b', 2);
         expect(data[1]).to.have.property('c', -1);
         done();
-      },
-      modelFactory);
+      });
   });
 
   it('should impute mean', function(done) {
-    parseSpec(spec({method: 'mean'}),
-      function(model) {
+    parseSpec(spec({method: 'mean'}), modelFactory,
+      function(error, model) {
         var ds = model.data('table'),
             data = ds.values().filter(imputed);
 
@@ -60,13 +59,12 @@ describe('Impute', function() {
         expect(data[0]).to.have.property('c', 3);
         expect(data[1]).to.have.property('c', 6);
         done();
-      },
-      modelFactory);
+      });
   });
 
   it('should impute median', function(done) {
-    parseSpec(spec({method: 'median'}),
-      function(model) {
+    parseSpec(spec({method: 'median'}), modelFactory,
+      function(error, model) {
         var ds = model.data('table'),
             data = ds.values().filter(imputed);
 
@@ -74,13 +72,12 @@ describe('Impute', function() {
         expect(data[0]).to.have.property('c', 3);
         expect(data[1]).to.have.property('c', 5);
         done();
-      },
-      modelFactory);
+      });
   });
 
   it('should impute min', function(done) {
-    parseSpec(spec({method: 'min'}),
-      function(model) {
+    parseSpec(spec({method: 'min'}), modelFactory,
+      function(error, model) {
         var ds = model.data('table'),
             data = ds.values().filter(imputed);
 
@@ -88,13 +85,12 @@ describe('Impute', function() {
         expect(data[0]).to.have.property('c', 1);
         expect(data[1]).to.have.property('c', 2);
         done();
-      },
-      modelFactory);
+      });
   });
 
   it('should impute max', function(done) {
-    parseSpec(spec({method: 'max'}),
-      function(model) {
+    parseSpec(spec({method: 'max'}), modelFactory,
+      function(error, model) {
         var ds = model.data('table'),
             data = ds.values().filter(imputed);
 
@@ -102,8 +98,7 @@ describe('Impute', function() {
         expect(data[0]).to.have.property('c', 5);
         expect(data[1]).to.have.property('c', 11);
         done();
-      },
-      modelFactory);
+      });
   });
 
   it('should validate against the schema', function() {
@@ -119,9 +114,9 @@ describe('Impute', function() {
     expect(validate({ "type": "impute", "groupby": ["a"], "orderby": ["b"], "field": "c", "method": "value", "value": 5 })).to.be.true;
     expect(validate({ "type": "impute", "groupby": ["a"], "orderby": ["b"], "field": "c", "method": "value", "value": "na" })).to.be.true;
     expect(validate({ "type": "impute", "groupby": ["a"], "orderby": ["b"], "field": "c", "method": "value", "value": false })).to.be.true;
-    
+
     expect(validate({ "type": "foo" })).to.be.false;
-    expect(validate({ "type": "impute" })).to.be.false;    
+    expect(validate({ "type": "impute" })).to.be.false;
     expect(validate({ "type": "impute", "groupby": ["a"] })).to.be.false;
     expect(validate({ "type": "impute", "groupby": ["a"], "orderby": "b" })).to.be.false;
     expect(validate({ "type": "impute", "groupby": ["a"], "orderby": ["b"] })).to.be.false;

--- a/test/transforms/lookup.test.js
+++ b/test/transforms/lookup.test.js
@@ -10,22 +10,22 @@ describe('Lookup', function() {
     ];
 
     var spec = {
-      "data": [{ 
-        "name": "stats", 
+      "data": [{
+        "name": "stats",
         "values": statsVals
       }, {
         "name": "medals",
         "values": medalsVals,
         "transform": [
           {
-            "type": "lookup", 
-            "on": "stats", 
-            "onKey": "country", 
-            "keys": ["country"], 
+            "type": "lookup",
+            "on": "stats",
+            "onKey": "country",
+            "keys": ["country"],
             "as": ["country_stats"]
           }
         ]
-      }] 
+      }]
     };
 
     function expectUSA(medals) {
@@ -41,28 +41,28 @@ describe('Lookup', function() {
     }
 
     it('should handle initial datasources', function(done) {
-      parseSpec(spec, function(model) {
+      parseSpec(spec, modelFactory, function(error, model) {
         var medalsDS = model.data('medals'),
             statsDS  = model.data('stats'),
-            medals = medalsDS.values(), 
-            stats  = statsDS.values(), 
+            medals = medalsDS.values(),
+            stats  = statsDS.values(),
             i, len, d;
 
         expect(stats).to.have.length(2);
         expect(medals).to.have.length(2);
         expectUSA(medals);
-        expectCanada(medals);      
+        expectCanada(medals);
 
         done();
-      }, modelFactory);
+      });
     });
 
     it('should handle streaming adds w/o default', function(done) {
-      parseSpec(spec, function(model) {
+      parseSpec(spec, modelFactory, function(error, model) {
         var medalsDS = model.data('medals'),
             statsDS  = model.data('stats'),
-            medals = medalsDS.values(), 
-            stats  = statsDS.values(), 
+            medals = medalsDS.values(),
+            stats  = statsDS.values(),
             i, len, d;
 
         expect(stats).to.have.length(2);
@@ -86,7 +86,7 @@ describe('Lookup', function() {
         expect(stats).to.have.length(3);
         expect(medals).to.have.length(3);
         expectUSA(medals);
-        expectCanada(medals);  
+        expectCanada(medals);
 
         expect(medals[2].country_stats).to.not.be.undefined;
         expect(medals).to.have.deep.property('[2].country_stats.gdp', 1177);
@@ -94,18 +94,18 @@ describe('Lookup', function() {
         expect(medals).to.have.deep.property('[2].country_stats.athletes', 78);
 
         done();
-      }, modelFactory);
+      });
     });
 
     it('should handle streaming adds w/default', function(done) {
       var s = dl.duplicate(spec);
       s.data[1].transform[0].default = {"foo": "bar"};
 
-      parseSpec(s, function(model) {
+      parseSpec(s, modelFactory, function(error, model) {
         var medalsDS = model.data('medals'),
             statsDS  = model.data('stats'),
-            medals = medalsDS.values(), 
-            stats  = statsDS.values(), 
+            medals = medalsDS.values(),
+            stats  = statsDS.values(),
             i, len, d;
 
         expect(stats).to.have.length(2);
@@ -130,7 +130,7 @@ describe('Lookup', function() {
         expect(stats).to.have.length(3);
         expect(medals).to.have.length(3);
         expectUSA(medals);
-        expectCanada(medals);  
+        expectCanada(medals);
 
         expect(medals[2].country_stats).to.not.be.undefined;
         expect(medals).to.have.deep.property('[2].country_stats.gdp', 1177);
@@ -138,15 +138,15 @@ describe('Lookup', function() {
         expect(medals).to.have.deep.property('[2].country_stats.athletes', 78);
 
         done();
-      }, modelFactory);
+      });
     });
 
     it('should handle streaming rems w/o default', function(done) {
-      parseSpec(spec, function(model) {
+      parseSpec(spec, modelFactory, function(error, model) {
         var medalsDS = model.data('medals'),
             statsDS  = model.data('stats'),
-            medals = medalsDS.values(), 
-            stats  = statsDS.values(), 
+            medals = medalsDS.values(),
+            stats  = statsDS.values(),
             i, len, d;
 
         expect(stats).to.have.length(2);
@@ -155,7 +155,7 @@ describe('Lookup', function() {
         expectCanada(medals);
 
         statsDS.remove(function(x) { return x.country == "Canada" }).fire();
-        stats  = statsDS.values(); 
+        stats  = statsDS.values();
         medals = medalsDS.values();
         expect(stats).to.have.length(1);
         expect(medals).to.have.length(2);
@@ -164,18 +164,18 @@ describe('Lookup', function() {
         expect(medals[1].country_stats).to.be.undefined;
 
         done();
-      }, modelFactory);
+      });
     });
 
     it('should handle streaming rems w/default', function(done) {
       var s = dl.duplicate(spec);
       s.data[1].transform[0].default = {"foo": "bar"};
 
-      parseSpec(s, function(model) {
+      parseSpec(s, modelFactory, function(error, model) {
         var medalsDS = model.data('medals'),
             statsDS  = model.data('stats'),
-            medals = medalsDS.values(), 
-            stats  = statsDS.values(), 
+            medals = medalsDS.values(),
+            stats  = statsDS.values(),
             i, len, d;
 
         expect(stats).to.have.length(2);
@@ -184,7 +184,7 @@ describe('Lookup', function() {
         expectCanada(medals);
 
         statsDS.remove(function(x) { return x.country == "Canada" }).fire();
-        stats  = statsDS.values(); 
+        stats  = statsDS.values();
         medals = medalsDS.values();
         expect(stats).to.have.length(1);
         expect(medals).to.have.length(2);
@@ -194,15 +194,15 @@ describe('Lookup', function() {
         expect(medals).to.have.deep.property('[1].country_stats.foo', 'bar');
 
         done();
-      }, modelFactory);
+      });
     });
 
     it('should propagate streaming mods', function(done) {
-      parseSpec(spec, function(model) {
+      parseSpec(spec, modelFactory, function(error, model) {
         var medalsDS = model.data('medals'),
             statsDS  = model.data('stats'),
-            medals = medalsDS.values(), 
-            stats  = statsDS.values(), 
+            medals = medalsDS.values(),
+            stats  = statsDS.values(),
             i, len, d;
 
         expect(stats).to.have.length(2);
@@ -213,7 +213,7 @@ describe('Lookup', function() {
         // Inner mod
         statsDS.update(function(x) { return x.country == "Canada" },
           'athletes', function(x) { return 100; }).fire();
-        stats  = statsDS.values(); 
+        stats  = statsDS.values();
         medals = medalsDS.values();
         expect(stats).to.have.length(2);
         expect(medals).to.have.length(2);
@@ -226,7 +226,7 @@ describe('Lookup', function() {
         // Key mod on joined datasource
         statsDS.update(function(x) { return x.country == "Canada" },
           'country', function(x) { return 'Mexico'; }).fire();
-        stats  = statsDS.values(); 
+        stats  = statsDS.values();
         medals = medalsDS.values();
         expect(stats).to.have.length(2);
         expect(medals).to.have.length(2);
@@ -236,7 +236,7 @@ describe('Lookup', function() {
         // Key mod on primary datasource
         medalsDS.update(function(x) { return x.country == "Canada" },
           'country', function(x) { return 'Mexico'; }).fire();
-        stats  = statsDS.values(); 
+        stats  = statsDS.values();
         medals = medalsDS.values();
         expect(stats).to.have.length(2);
         expect(medals).to.have.length(2);
@@ -244,7 +244,7 @@ describe('Lookup', function() {
         expect(medals[1].country_stats).to.not.be.undefined;
 
         done();
-      }, modelFactory);
+      });
     });
 
   });
@@ -256,33 +256,33 @@ describe('Lookup', function() {
     ], zipVals = [{"zip2": "A"}, {"zip2": "B"}, {"zip2": "C"}];
 
     var spec = {
-      "data": [{ 
-        "name": "zip", 
+      "data": [{
+        "name": "zip",
         "values": zipVals
       }, {
         "name": "medals",
         "values": medalsVals,
         "transform": [
           {
-            "type": "lookup", 
+            "type": "lookup",
             "on": "zip",
             "keys": ["index"],
             "as": ["zip"]
           }
         ]
-      }] 
+      }]
     };
 
     it('should handle initial datasources', function(done) {
-      parseSpec(spec, function(model) {
+      parseSpec(spec, modelFactory, function(error, model) {
         var medalsDS = model.data('medals'),
             zipDS  = model.data('zip'),
             medals = medalsDS.values(),
-            zip = zipDS.values(), 
+            zip = zipDS.values(),
             i, len, d;
 
         model.fire();
-        zip  = zipDS.values(); 
+        zip  = zipDS.values();
         medals = medalsDS.values();
         expect(zip).to.have.length(3);
         expect(medals).to.have.length(2);
@@ -290,15 +290,15 @@ describe('Lookup', function() {
         expect(medals).to.have.deep.property('[1].zip.zip2', 'B');
 
         done();
-      }, modelFactory);
+      });
     });
 
     it('should handle streaming adds', function(done) {
-      parseSpec(spec, function(model) {
+      parseSpec(spec, modelFactory, function(error, model) {
         var medalsDS = model.data('medals'),
             zipDS  = model.data('zip'),
             medals = medalsDS.values(),
-            zip = zipDS.values(), 
+            zip = zipDS.values(),
             i, len, d;
 
         expect(zip).to.have.length(3);
@@ -325,15 +325,15 @@ describe('Lookup', function() {
         expect(medals).to.have.deep.property('[2].zip.zip2', 'C');
 
         done();
-      }, modelFactory);
+      });
     });
 
     it('should handle streaming rems', function(done) {
-      parseSpec(spec, function(model) {
+      parseSpec(spec, modelFactory, function(error, model) {
         var medalsDS = model.data('medals'),
             zipDS  = model.data('zip'),
             medals = medalsDS.values(),
-            zip = zipDS.values(), 
+            zip = zipDS.values(),
             i, len, d;
 
         expect(zip).to.have.length(3);
@@ -342,7 +342,7 @@ describe('Lookup', function() {
         expect(medals).to.have.deep.property('[1].zip.zip2', 'B');
 
         zipDS.remove(function(x) { return x.zip2 == "B" }).fire();
-        zip  = zipDS.values(); 
+        zip  = zipDS.values();
         medals = medalsDS.values();
         expect(zip).to.have.length(2);
         expect(medals).to.have.length(2);
@@ -350,15 +350,15 @@ describe('Lookup', function() {
         expect(medals).to.have.deep.property('[1].zip.zip2', 'C');
 
         done();
-      }, modelFactory);
+      });
     });
 
     it('should propagate streaming mods', function(done) {
-      parseSpec(spec, function(model) {
+      parseSpec(spec, modelFactory, function(error, model) {
         var medalsDS = model.data('medals'),
             zipDS  = model.data('zip'),
             medals = medalsDS.values(),
-            zip = zipDS.values(), 
+            zip = zipDS.values(),
             i, len, d;
 
         expect(zip).to.have.length(3);
@@ -368,7 +368,7 @@ describe('Lookup', function() {
 
         zipDS.update(function(x) { return x.zip2 == "B" },
           'zip2', function(x) { return "F"; }).fire();
-        zip  = zipDS.values(); 
+        zip  = zipDS.values();
         medals = medalsDS.values();
         expect(zip).to.have.length(3);
         expect(medals).to.have.length(2);
@@ -376,7 +376,7 @@ describe('Lookup', function() {
         expect(medals).to.have.deep.property('[1].zip.zip2', 'F');
 
         done();
-      }, modelFactory);
+      });
     });
 
   });
@@ -391,7 +391,7 @@ describe('Lookup', function() {
         "as": ["t"], "keys": ["k"] })).to.be.true;
     expect(validate({ "type": "lookup", "on": "table", "onKey": "k",
         "as": ["t"], "keys": ["k"], "default": 1 })).to.be.true;
-    
+
     expect(validate({ "type": "foo" })).to.be.false;
     expect(validate({ "type": "lookup" })).to.be.false;
     expect(validate({ "type": "lookup", "on": "table" })).to.be.false;

--- a/test/transforms/sort.test.js
+++ b/test/transforms/sort.test.js
@@ -26,9 +26,9 @@ describe('Sort', function() {
   }
 
   it('should sort asc w/a single static fieldName', function(done) {
-    parseSpec(spec, function(model) {
+    parseSpec(spec, modelFactory, function(error, model) {
       var ds = model.data('table'),
-          data = ds.values(), 
+          data = ds.values(),
           i, len, d;
 
       expect(data).to.have.length(20);
@@ -37,16 +37,16 @@ describe('Sort', function() {
       }
 
       done();
-    }, modelFactory);
+    });
   });
 
   it('should sort desc w/a single static fieldName', function(done) {
     var s = dl.duplicate(spec);
     s.data[0].transform[0].by.field = "-y";
 
-    parseSpec(s, function(model) {
+    parseSpec(s, modelFactory, function(error, model) {
       var ds = model.data('table'),
-          data = ds.values(), 
+          data = ds.values(),
           i, len, d;
 
       expect(data).to.have.length(20);
@@ -55,16 +55,16 @@ describe('Sort', function() {
       }
 
       done();
-    }, modelFactory);
+    });
   });
 
   it('should sort w/a single signal', function(done) {
     var s = dl.duplicate(spec);
     s.data[0].transform[0].by = {"signal": "sortBy1"};
 
-    parseSpec(s, function(model) {
+    parseSpec(s, modelFactory, function(error, model) {
       var ds = model.data('table'),
-          data = ds.values(), 
+          data = ds.values(),
           i, len, d;
 
       expect(data).to.have.length(20);
@@ -80,16 +80,16 @@ describe('Sort', function() {
       }
 
       done();
-    }, modelFactory);
-  }); 
+    });
+  });
 
   it('should sort w/multiple static fieldNames', function(done) {
     var s = dl.duplicate(spec);
     s.data[0].transform[0].by = [{"field": "-x"}, {"field": "y"}];
 
-    parseSpec(s, function(model) {
+    parseSpec(s, modelFactory, function(error, model) {
       var ds = model.data('table'),
-          data = ds.values(), 
+          data = ds.values(),
           i, len, d;
 
       expect(data).to.have.length(20);
@@ -101,16 +101,16 @@ describe('Sort', function() {
       }
 
       done();
-    }, modelFactory);
-  }); 
+    });
+  });
 
   it('should sort w/multiple signals', function(done) {
     var s = dl.duplicate(spec);
     s.data[0].transform[0].by = [{"signal": "sortBy0"}, {"signal": "sortBy1"}];
 
-    parseSpec(s, function(model) {
+    parseSpec(s, modelFactory, function(error, model) {
       var ds = model.data('table'),
-          data = ds.values(), 
+          data = ds.values(),
           i, len, d;
 
       expect(data).to.have.length(20);
@@ -142,16 +142,16 @@ describe('Sort', function() {
       }
 
       done();
-    }, modelFactory);
-  });   
+    });
+  });
 
   it('should sort w/mixed fieldNames+signals', function(done) {
     var s = dl.duplicate(spec);
     s.data[0].transform[0].by = [{"field": "-x"}, {"signal": "sortBy1"}];
 
-    parseSpec(s, function(model) {
+    parseSpec(s, modelFactory, function(error, model) {
       var ds = model.data('table'),
-          data = ds.values(), 
+          data = ds.values(),
           i, len, d;
 
       expect(data).to.have.length(20);
@@ -173,8 +173,8 @@ describe('Sort', function() {
       }
 
       done();
-    }, modelFactory);
-  }); 
+    });
+  });
 
   it('should validate against the schema', function() {
     var schema = schemaPath(transforms.sort.schema),
@@ -183,10 +183,10 @@ describe('Sort', function() {
     expect(validate({ "type": "sort", "by": "price" })).to.be.true;
     expect(validate({ "type": "sort", "by": "-price" })).to.be.true;
     expect(validate({ "type": "sort", "by": ["price", "gdp"] })).to.be.true;
-    
+
     expect(validate({ "type": "foo" })).to.be.false;
     expect(validate({ "type": "sort" })).to.be.false;
     expect(validate({ "type": "sort", "by": true })).to.be.false;
-  });  
+  });
 
 });

--- a/test/transforms/stack.test.js
+++ b/test/transforms/stack.test.js
@@ -14,7 +14,7 @@ describe('Stack', function() {
     {a: 3, b: 9, c: 'c'},
     {a: 3, b: 2, c: 'a'}
   ];
-  
+
   function spec(opt) {
     var stack = {
       type: "stack",
@@ -24,7 +24,7 @@ describe('Stack', function() {
       offset: opt.offset,
       output: {start: "y2", end: "y", mid: "cy"}
     };
-    
+
     return {
       data: [{
         name: "table",
@@ -36,7 +36,8 @@ describe('Stack', function() {
 
   it('should perform flat stack', function(done) {
     parseSpec(spec({groupby:null, sortby:null, field:"b", offset:"zero"}),
-      function(model) {
+      modelFactory,
+      function(error, model) {
         var ds = model.data('table'),
             data = ds.values(),
             y = [0,1,3,6,10,15,21,28,36,45,47];
@@ -47,13 +48,13 @@ describe('Stack', function() {
           expect(data[i]).to.have.property('cy', 0.5 * (y[i] + y[i+1]));
         }
         done();
-      },
-      modelFactory);
+      });
   });
 
   it('should perform grouped stack', function(done) {
     parseSpec(spec({groupby:["a"], sortby:null, field:"b", offset:"zero"}),
-      function(model) {
+      modelFactory,
+      function(error, model) {
         var ds = model.data('table'),
             data = ds.values(),
             y0 = [0,1,3,  0,4, 9,  0, 7,15,24],
@@ -65,13 +66,13 @@ describe('Stack', function() {
           expect(data[i]).to.have.property('cy', 0.5 * (y0[i] + y1[i]));
         }
         done();
-      },
-      modelFactory);
+      });
   });
-  
+
   it('should perform grouped stack with offset center', function(done) {
     parseSpec(spec({groupby:["a"], sortby:null, field:"b", offset:"center"}),
-      function(model) {
+      modelFactory,
+      function(error, model) {
         var ds = model.data('table'),
             data = ds.values(),
             y0 = [10,11,13,  5.5, 9.5,14.5,  0, 7,15,24],
@@ -83,13 +84,13 @@ describe('Stack', function() {
           expect(data[i]).to.have.property('cy', 0.5 * (y0[i] + y1[i]));
         }
         done();
-      },
-      modelFactory);
+      });
   });
 
   it('should perform grouped stack with offset normalize', function(done) {
     parseSpec(spec({groupby:["a"], sortby:null, field:"b", offset:"normalize"}),
-      function(model) {
+      modelFactory,
+      function(error, model) {
         var ds = model.data('table'),
             data = ds.values(),
             y0 = [0/6,1/6,3/6,  0/15,4/15, 9/15,  0/26, 7/26,15/26,24/26],
@@ -101,13 +102,13 @@ describe('Stack', function() {
           expect(data[i]).to.have.property('cy').closeTo(0.5 * (y0[i] + y1[i]), EPSILON);
         }
         done();
-      },
-      modelFactory);
+      });
   });
-  
+
   it('should perform grouped sorted stack', function(done) {
     parseSpec(spec({groupby:["a"], sortby:"c", field:"b", offset:"zero"}),
-      function(model) {
+      modelFactory,
+      function(error, model) {
         var ds = model.data('table'),
             data = ds.values(),
             y0 = [0,1,3,  0,4, 9,  0, 9,17,7],
@@ -119,8 +120,7 @@ describe('Stack', function() {
           expect(data[i]).to.have.property('cy', 0.5 * (y0[i] + y1[i]));
         }
         done();
-      },
-      modelFactory);
+      });
   });
 
   it('should validate against the schema', function() {
@@ -128,35 +128,35 @@ describe('Stack', function() {
         validate = validator(schema);
 
     expect(validate({ "type": "stack", "groupby": ["country"], "field": "medals" })).to.be.true;
-    expect(validate({ "type": "stack", "groupby": ["country"], 
+    expect(validate({ "type": "stack", "groupby": ["country"],
       "field": "medals", "sortby": ["gdp"] })).to.be.true;
-    expect(validate({ "type": "stack", "groupby": ["country"], 
+    expect(validate({ "type": "stack", "groupby": ["country"],
       "field": "medals", "offset": "zero" })).to.be.true;
-    expect(validate({ "type": "stack", "groupby": ["country"], 
+    expect(validate({ "type": "stack", "groupby": ["country"],
       "field": "medals", "offset": "center" })).to.be.true;
-    expect(validate({ "type": "stack", "groupby": ["country"], 
+    expect(validate({ "type": "stack", "groupby": ["country"],
       "field": "medals", "offset": "normalize" })).to.be.true;
-    expect(validate({ "type": "stack", "groupby": ["country"], 
+    expect(validate({ "type": "stack", "groupby": ["country"],
       "field": "medals", "output": {"start": "start", "mid": "mid", "end": "end"} })).to.be.true;
-    
+
     expect(validate({ "type": "foo" })).to.be.false;
     expect(validate({ "type": "stack" })).to.be.false;
     expect(validate({ "type": "stack", "groupby": ["country"] })).to.be.false;
     expect(validate({ "type": "stack", "groupby": "country", "field": "medals" })).to.be.false;
     expect(validate({ "type": "stack", "groupby": ["country"], "field": ["medals"] })).to.be.false;
-    expect(validate({ "type": "stack", "groupby": ["country"], 
+    expect(validate({ "type": "stack", "groupby": ["country"],
       "field": "medals", "sortby": "gdp" })).to.be.false;
-    expect(validate({ "type": "stack", "groupby": ["country"], 
+    expect(validate({ "type": "stack", "groupby": ["country"],
       "field": "medals", "offset": "foo" })).to.be.false;
-    expect(validate({ "type": "stack", "groupby": ["country"], 
+    expect(validate({ "type": "stack", "groupby": ["country"],
       "field": "medals", "output": {"foo": "bar"} })).to.be.false;
-    expect(validate({ "type": "stack", "groupby": ["country"], 
+    expect(validate({ "type": "stack", "groupby": ["country"],
       "field": "medals", "bar": "foo" })).to.be.false;
-    expect(validate({ "type": "stack", "groupby": ["country"], 
+    expect(validate({ "type": "stack", "groupby": ["country"],
       "field": "medals", "offset": "silhouette" })).to.be.false;
-    expect(validate({ "type": "stack", "groupby": ["country"], 
+    expect(validate({ "type": "stack", "groupby": ["country"],
       "field": "medals", "offset": "wiggle" })).to.be.false;
-    expect(validate({ "type": "stack", "groupby": ["country"], 
+    expect(validate({ "type": "stack", "groupby": ["country"],
       "field": "medals", "offset": "expand" })).to.be.false;
   });
 });

--- a/test/transforms/treeify.test.js
+++ b/test/transforms/treeify.test.js
@@ -18,8 +18,8 @@ describe('Treeify', function() {
   }
 
   it('should treeify a table', function(done) {
-    parseSpec(spec(),
-      function(model) {
+    parseSpec(spec(), modelFactory,
+      function(error, model) {
         var ds = model.data('table'),
             data = ds.values(),
             root = data.filter(function(d) { return d.parent==null; });
@@ -31,8 +31,7 @@ describe('Treeify', function() {
         expect(root[0].children[1].children).to.have.length(2);
 
         done();
-      },
-      modelFactory);
+      });
   });
 
   it('should validate against the schema', function() {

--- a/test/transforms/voronoi.test.js
+++ b/test/transforms/voronoi.test.js
@@ -22,14 +22,14 @@ describe('Voronoi', function() {
   };
 
   it('should compute voronoi diagram', function(done) {
-    parseSpec(spec, function(model) {
+    parseSpec(spec, modelFactory, function(error, model) {
       var data = model.data('table').values().sort(dl.comparator('p'));
       expect(data[0].p).to.equal('M-100000,0L0,0L0,-100000L-100000,-100000Z');
       expect(data[1].p).to.equal('M0,-100000L0,0L100000,0L100000,-100000Z');
       expect(data[2].p).to.equal('M0,0L0,100000L100000,100000L100000,0Z');
       expect(data[3].p).to.equal('M0,100000L0,0L-100000,0L-100000,100000Z');
       done();
-    }, modelFactory);
+    });
   });
 
   it('should validate against the schema', function() {

--- a/test/transforms/wordcloud.test.js
+++ b/test/transforms/wordcloud.test.js
@@ -23,7 +23,7 @@ describe('Wordcloud', function() {
     var s = dl.duplicate(spec);
     s.data[0].transform[0].fontScale = null;
 
-    parseSpec(s, function(model) {
+    parseSpec(s, modelFactory, function(error, model) {
       var data = model.data('table').values();
       expect(data.length).to.equal(3);
       expect(data[0].w).to.equal('a');
@@ -43,13 +43,13 @@ describe('Wordcloud', function() {
       expect(data[2].layout_y).to.be.defined;
 
       done();
-    }, modelFactory);
+    });
   });
 
   it('should layout scaled wordcloud', function(done) {
     var s = dl.duplicate(spec);
     s.data[0].transform[0].rotate = 'r';
-    parseSpec(s, function(model) {
+    parseSpec(s, modelFactory, function(error, model) {
       var data = model.data('table').values();
       expect(data.length).to.equal(3);
       expect(data[0].w).to.equal('a');
@@ -69,7 +69,7 @@ describe('Wordcloud', function() {
       expect(data[2].layout_y).to.be.defined;
 
       done();
-    }, modelFactory);
+    });
   });
 
   it('should validate against the schema', function() {
@@ -110,7 +110,7 @@ describe('Wordcloud', function() {
     expect(validate({ "type": "wordcloud", "output": {"rotate": "rotate"} })).to.be.true;
 
     expect(validate({ "type": "foo" })).to.be.false;
-    expect(validate({ "type": "wordcloud", "size": 1 })).to.be.false;    
+    expect(validate({ "type": "wordcloud", "size": 1 })).to.be.false;
     expect(validate({ "type": "wordcloud", "font": 2 })).to.be.false;
     expect(validate({ "type": "wordcloud", "fontStyle": 2 })).to.be.false;
     expect(validate({ "type": "wordcloud", "fontWeight": 3 })).to.be.false;


### PR DESCRIPTION
This is an extended version of pull request #431.

- Standardize spec parse signature. Callback is now always the last argument.
- Support `cb(error, result)` callback signature. For backwards compatibility, invoke callback as `cb(result)` if `cb.length === 1`. 
- Update test cases and command line utils to use the updated signatures.
- Add node-canvas as an optional dependency. This proved necessary for test cases to run on a clean npm install, in part due to d3-cloud's setup.

__Going forward, parsing callbacks with the signature (error, result) are the preferred method. Documentation and dependent libs should be updated in response upon the next release.__