### PR TITLE
Fixed sandbox issue

### DIFF
--- a/src/parse/signals.js
+++ b/src/parse/signals.js
@@ -67,7 +67,7 @@ parseSignals.scale = function scale(model, spec, value, datum, evt) {
   }
 
   // Verify scope is valid
-  if (!model.group(scope._id)) {
+  if (model.group(scope._id) !== scope) {
     throw new Error('Scope for scale "'+name+'" is not a valid group item.');
   }
 


### PR DESCRIPTION
Arvind's fix has almost everything we need to fix #444, but I think we need to check that the object is exactly the group, otherwise this exploit works:

```json
{
  "signals": [
    {
      "name": "signal1",
      "streams": [
        {
          "type":"@rectangle:mousemove",
          "expr": "{__proto__:eventGroup(), scale: ('').constructor.constructor}",
          "scale": {"name": "alert('xss')", "scope": {"signal": "signal1"}}
        }
      ]
    }
  ],
  "marks": [
    {
      "type": "group",
      "marks": [{
        "name": "rectangle",
        "type": "rect",
        "properties": {
          "enter": {
            "fill": {"value": "red"},
            "width": {"value": 100},
            "height": {"value": 100}
          }
        }
      }]
    }  
  ]
}
```