### PR TITLE
More granular bounds recalculation.

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "vega-dataflow": "^1.3.2",
     "vega-expression": "^1.0.3",
     "vega-logging": "^1.0.1",
-    "vega-scenegraph": "^1.0.15",
+    "vega-scenegraph": "^1.0.16",
     "yargs": "^3.30.0"
   },
   "optionalDependencies": {


### PR DESCRIPTION
In lieu of #454. This does a full recalculation of mark bounds for line and area marks. For others, it runs itemBounds for `input.add` and `input.mod`. Mark bounds are recalculated by union-ing only if an added item falls outside previously calculated mark bounds, or if a modified item aligns with them. 