### PR TITLE
Implemented scale function in expression language.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,10 @@
     {
       "name": "Jeffrey Heer",
       "url": "http://idl.cs.washington.edu"
+    },
+    {
+      "name": "Ryan Russell",
+      "url": "https://github.com/RussellSprouts"
     }
   ],
   "license": "BSD-3-Clause",
@@ -35,10 +39,10 @@
     "d3": "^3.5.9",
     "d3-geo-projection": "^0.2.15",
     "d3-cloud": "^1.2.1",
-    "datalib": "^1.5.0",
+    "datalib": "^1.5.4",
     "topojson": "^1.6.19",
     "vega-dataflow": "^1.3.2",
-    "vega-expression": "^1.0.3",
+    "vega-expression": "^1.0.4",
     "vega-logging": "^1.0.1",
     "vega-scenegraph": "^1.0.16",
     "yargs": "^3.30.0"

--- a/package.json
+++ b/package.json
@@ -39,10 +39,10 @@
     "d3": "^3.5.9",
     "d3-geo-projection": "^0.2.15",
     "d3-cloud": "^1.2.1",
-    "datalib": "^1.5.4",
+    "datalib": "^1.5.6",
     "topojson": "^1.6.19",
     "vega-dataflow": "^1.3.2",
-    "vega-expression": "^1.0.4",
+    "vega-expression": "^1.0.5",
     "vega-logging": "^1.0.1",
     "vega-scenegraph": "^1.0.16",
     "yargs": "^3.30.0"

--- a/src/parse/expr.js
+++ b/src/parse/expr.js
@@ -1,4 +1,5 @@
-var expr = require('vega-expression'),
+var template = require('datalib').template,
+    expr = require('vega-expression'),
     args = ['model', 'datum', 'event', 'signals'];
 
 module.exports = expr.compiler(args, {
@@ -7,20 +8,26 @@ module.exports = expr.compiler(args, {
   globalVar:   args[3],
   functions:   function(codegen) {
     var fn = expr.functions(codegen);
-    fn.eventItem = 'event.vg.item';
+    fn.eventItem  = 'event.vg.item';
     fn.eventGroup = 'event.vg.getGroup';
-    fn.eventX = 'event.vg.getX';
-    fn.eventY = 'event.vg.getY';
-    fn.open = 'window.open';
-    fn.inrange = 'this.defs.inrange';
-    fn.scale  = scaleGen(codegen, false);
-    fn.iscale = scaleGen(codegen, true);
+    fn.eventX     = 'event.vg.getX';
+    fn.eventY     = 'event.vg.getY';
+    fn.open       = 'window.open';
+    fn.scale      = scaleGen(codegen, false);
+    fn.iscale     = scaleGen(codegen, true);
+    fn.inrange    = 'this.defs.inrange';
+    fn.format     = 'this.defs.number';
+    fn.timeFormat = 'this.defs.time';
+    fn.utcFormat  = 'this.defs.utc';
     return fn;
   },
   functionDefs: function(/*codegen*/) {
     return {
       'scale':   scale,
-      'inrange': inrange
+      'inrange': inrange,
+      'number':  numberFormat,
+      'time':    timeFormat,
+      'utc':     utcFormat
     };
   }
 });
@@ -55,4 +62,18 @@ function inrange(val, a, b, exclusive) {
   return exclusive ?
     (min < val && max > val) :
     (min <= val && max >= val);
+}
+
+function numberFormat(specifier, v) {
+  return template.format(specifier, 'number')(v);
+}
+
+function timeFormat(specifier, d) {
+  return template.format(specifier, 'time')
+    (typeof d==='number' ? new Date(d) : d);
+}
+
+function utcFormat(specifier, d) {
+  return template.format(specifier, 'utc')
+    (typeof d==='number' ? new Date(d) : d);
 }

--- a/src/parse/expr.js
+++ b/src/parse/expr.js
@@ -2,7 +2,7 @@ var expr = require('vega-expression'),
     args = ['model', 'datum', 'event', 'signals'];
 
 module.exports = expr.compiler(args, {
-  idWhiteList: args,
+  idWhiteList: ['datum', 'event', 'signals'],
   fieldVar:    args[1],
   globalVar:   args[3],
   functions:   function(codegen) {

--- a/src/parse/expr.js
+++ b/src/parse/expr.js
@@ -42,7 +42,7 @@ module.exports = expr.compiler(args, {
   },
   functionDefs: function(codegen) {
     return {
-      'scale': scale
+      'scale': scale,
       'inrange': inrange
     };
   }

--- a/src/parse/expr.js
+++ b/src/parse/expr.js
@@ -7,14 +7,18 @@ module.exports = expr.compiler(args, {
   globalVar:   args[3],
   functions:   function(codegen) {
     var fn = expr.functions(codegen);
-    fn.eventItem = function() { return 'event.vg.item'; };
+    fn.eventItem = 'event.vg.item';
     fn.eventGroup = 'event.vg.getGroup';
     fn.eventX = 'event.vg.getX';
     fn.eventY = 'event.vg.getY';
     fn.open = 'window.open';
     fn.inrange = 'this.defs.inrange';
+    fn.scale = scaleCodegen;
+    fn.iscale = iscaleCodegen;
 
-    fn.scale = function(args) {
+    return fn;
+
+    function scaleCodegen(args) {
       args = args.map(codegen);
       if (args.length == 2) {
         return 'this.defs.scale(model, false, ' + args[0] + ',' + args[1] + ')';
@@ -23,9 +27,9 @@ module.exports = expr.compiler(args, {
       } else {
         throw new Error("scale takes exactly 2 or 3 arguments.");
       }
-    };
+    }
 
-    fn.iscale = function(args) {
+    function iscaleCodegen(args) {
       args = args.map(codegen);
       if (args.length == 2) {
         return 'this.defs.scale(model, true, ' + args[0] + ',' + args[1] + ')';
@@ -34,8 +38,7 @@ module.exports = expr.compiler(args, {
       } else {
         throw new Error("iscale takes exactly 2 or 3 arguments.");
       }
-    };
-    return fn;
+    }
   },
   functionDefs: function(codegen) {
     return {

--- a/src/parse/expr.js
+++ b/src/parse/expr.js
@@ -16,9 +16,9 @@ module.exports = expr.compiler(args, {
     fn.scale = function(args) {
       args = args.map(codegen);
       if (args.length == 2) {
-        return 'fn.scale(model, false, ' + args[0] + ',' + args[1] + ')';
+        return 'this.defs.scale(model, false, ' + args[0] + ',' + args[1] + ')';
       } else if (args.length == 3) {
-        return 'fn.scale(model, false, ' + args[0] + ',' + args[1] + ',' + args[2] + ')';
+        return 'this.defs.scale(model, false, ' + args[0] + ',' + args[1] + ',' + args[2] + ')';
       } else {
         throw new Error("scale takes exactly 2 or 3 arguments.");
       }
@@ -27,30 +27,30 @@ module.exports = expr.compiler(args, {
     fn.iscale = function(args) {
       args = args.map(codegen);
       if (args.length == 2) {
-        return 'fn.scale(model, true, ' + args[0] + ',' + args[1] + ')';
+        return 'this.defs.scale(model, true, ' + args[0] + ',' + args[1] + ')';
       } else if (args.length == 3) {
-        return 'fn.scale(model, true, ' + args[0] + ',' + args[1] + ',' + args[2] + ')';
+        return 'this.defs.scale(model, true, ' + args[0] + ',' + args[1] + ',' + args[2] + ')';
       } else {
         throw new Error("iscale takes exactly 2 or 3 arguments.");
       }
     };
     return fn;
   },
-  functionDefinitions: function(codegen) {
-    var fns = expr.functionDefinitions(codegen);
-    fns.scale = function(model, invert, name, value, scope) {
-      if (!scope || !scope.scale) {
-        scope = (scope && scope.mark) ? scope.mark.group : model.scene().items[0];
-      }
+  functionDefs: function(codegen) {
+    return {
+     scale: function(model, invert, name, value, scope) {
+        if (!scope || !scope.scale) {
+          scope = (scope && scope.mark) ? scope.mark.group : model.scene().items[0];
+        }
 
-      // Verify scope is valid
-      if (model.group(scope._id) !== scope) {
-        throw new Error('Scope for scale "'+name+'" is not a valid group item.');
-      }
+        // Verify scope is valid
+        if (model.group(scope._id) !== scope) {
+          throw new Error('Scope for scale "'+name+'" is not a valid group item.');
+        }
 
-      var s = scope.scale(name);
-      return !s ? value : (invert ? s.invert(value) : s(value));
+        var s = scope.scale(name);
+        return !s ? value : (invert ? s.invert(value) : s(value));
+      }
     };
-    return fns;
   }
 });

--- a/src/parse/expr.js
+++ b/src/parse/expr.js
@@ -16,18 +16,18 @@ module.exports = expr.compiler(args, {
     fn.scale      = scaleGen(codegen, false);
     fn.iscale     = scaleGen(codegen, true);
     fn.inrange    = 'this.defs.inrange';
-    fn.format     = 'this.defs.number';
-    fn.timeFormat = 'this.defs.time';
-    fn.utcFormat  = 'this.defs.utc';
+    fn.format     = 'this.defs.format';
+    fn.timeFormat = 'this.defs.timeFormat';
+    fn.utcFormat  = 'this.defs.utcFormat';
     return fn;
   },
   functionDefs: function(/*codegen*/) {
     return {
-      'scale':   scale,
-      'inrange': inrange,
-      'number':  numberFormat,
-      'time':    timeFormat,
-      'utc':     utcFormat
+      'scale':      scale,
+      'inrange':    inrange,
+      'format':     numberFormat,
+      'timeFormat': timeFormat,
+      'utcFormat':  utcFormat
     };
   }
 });
@@ -69,11 +69,9 @@ function numberFormat(specifier, v) {
 }
 
 function timeFormat(specifier, d) {
-  return template.format(specifier, 'time')
-    (typeof d==='number' ? new Date(d) : d);
+  return template.format(specifier, 'time')(typeof d==='number' ? new Date(d) : d);
 }
 
 function utcFormat(specifier, d) {
-  return template.format(specifier, 'utc')
-    (typeof d==='number' ? new Date(d) : d);
+  return template.format(specifier, 'utc')(typeof d==='number' ? new Date(d) : d);
 }

--- a/src/parse/signals.js
+++ b/src/parse/signals.js
@@ -44,7 +44,7 @@ function parseSignals(model, spec) {
 
 function exprVal(model, spec) {
   var e = spec.expr,
-      val = e.fn(null, null, model.values(SIGNALS, e.globals));
+      val = e.fn(model, null, null, model.values(SIGNALS, e.globals));
   return spec.scale ? parseSignals.scale(model, spec, val) : val;
 }
 
@@ -58,7 +58,7 @@ parseSignals.scale = function scale(model, spec, value, datum, evt) {
       scope = model.signalRef(scope.signal);
     } else if (dl.isString(scope)) { // Scope is an expression
       e = def._expr = (def._expr || expr(scope));
-      scope = e.fn(datum, evt, model.values(SIGNALS, e.globals));
+      scope = e.fn(model, datum, evt, model.values(SIGNALS, e.globals));
     }
   }
 

--- a/src/parse/streams.js
+++ b/src/parse/streams.js
@@ -126,7 +126,7 @@ function parseStreams(view) {
         val, i, n, h;
 
     function invoke(f) {
-      return !f.fn(datum, evt, model.values(SIGNALS, f.globals));
+      return !f.fn(model, datum, evt, model.values(SIGNALS, f.globals));
     }
 
     for (i=0, n=handlers.length; i<n; ++i) {
@@ -134,7 +134,7 @@ function parseStreams(view) {
       filtered = h.filters.some(invoke);
       if (filtered) continue;
 
-      val = h.exp.fn(datum, evt, model.values(SIGNALS, h.exp.globals));
+      val = h.exp.fn(model, datum, evt, model.values(SIGNALS, h.exp.globals));
       if (h.spec.scale) {
         val = parseSignals.scale(model, h.spec, val, datum, evt);
       }
@@ -188,7 +188,7 @@ function parseStreams(view) {
     var n = new df.Node(model);
     n.evaluate = function(input) {
       if (!input.signals[selector.signal]) return model.doNotPropagate;
-      var val = exp.fn(null, null, model.values(SIGNALS, exp.globals));
+      var val = exp.fn(model, null, null, model.values(SIGNALS, exp.globals));
       if (spec.scale) {
         val = parseSignals.scale(model, spec, val);
       }

--- a/src/transforms/Cross.js
+++ b/src/transforms/Cross.js
@@ -18,7 +18,7 @@ function Cross(graph) {
   this._output = {'left': 'a', 'right': 'b'};
   this._lastWith = null; // Last time we crossed w/with-ds.
   this._cids  = {};
-  this._cache = {}; 
+  this._cache = {};
 
   return this.router(true).produces(true);
 }
@@ -26,7 +26,7 @@ function Cross(graph) {
 var prototype = (Cross.prototype = Object.create(BatchTransform.prototype));
 prototype.constructor = Cross;
 
-// Each cached incoming tuple also has a flag to determine whether 
+// Each cached incoming tuple also has a flag to determine whether
 // any tuples were filtered.
 function _cache(x, t) {
   var c = this._cache,
@@ -42,7 +42,7 @@ function add(output, left, data, diag, test, mids, x) {
   var as = this._output,
       cache = this._cache,
       cids  = this._cids,
-      oadd  = output.add, 
+      oadd  = output.add,
       fltrd = false,
       i = 0, len = data.length,
       t = {}, y, cid;
@@ -57,7 +57,7 @@ function add(output, left, data, diag, test, mids, x) {
     Tuple.set(t, as.right, left ? y : x);
 
     // Only ingest a tuple if we keep it around. Otherwise, flag the
-    // caches as filtered. 
+    // caches as filtered.
     if (!test || test(t)) {
       oadd.push(t=Tuple.ingest(t));
       _cache.call(this, x, t);
@@ -86,7 +86,7 @@ function mod(output, left, data, diag, test, mids, rids, x) {
       i, t, y, l, cid;
 
   // If we have cached values, iterate through them for lazy
-  // removal, and to re-run the filter. 
+  // removal, and to re-run the filter.
   if (tpls) {
     for (i=tpls.length-1; i>=0; --i) {
       t = tpls[i];
@@ -116,14 +116,14 @@ function mod(output, left, data, diag, test, mids, rids, x) {
 
   // If we have a filter param, call add to catch any tuples that may
   // have previously been filtered.
-  if (test && fltrd) add.call(this, output, left, data, diag, test, mids, x); 
+  if (test && fltrd) add.call(this, output, left, data, diag, test, mids, x);
 }
 
 function rem(output, left, rids, x) {
   var as = this._output,
       cross = this._cache[x._id],
       cids  = this._cids,
-      orem  = output.rem, 
+      orem  = output.rem,
       i, len, t, y, l;
   if (!cross) return;
 
@@ -171,7 +171,7 @@ prototype.batchTransform = function(input, data, reset) {
       diag = this.param('diagonal'),
       as = this._output,
       sg = g.values(SIGNALS, this.dependency(SIGNALS)),
-      test = f ? function(x) {return f(x, null, sg); } : null,
+      test = f ? function(x) {return f(g, x, null, sg); } : null,
       selfCross = (!w.name),
       woutput = selfCross ? input : w.source.last(),
       wdata   = selfCross ? data : w.source.values(),

--- a/src/transforms/Filter.js
+++ b/src/transforms/Filter.js
@@ -29,12 +29,12 @@ prototype.transform = function(input) {
   });
 
   input.add.forEach(function(x) {
-    if (test(x, null, signals)) output.add.push(x);
+    if (test(graph, x, null, signals)) output.add.push(x);
     else skip[x._id] = 1;
   });
 
   input.mod.forEach(function(x) {
-    var b = test(x, null, signals),
+    var b = test(graph, x, null, signals),
         s = (skip[x._id] === 1);
     if (b && s) {
       skip[x._id] = 0;

--- a/src/transforms/Formula.js
+++ b/src/transforms/Formula.js
@@ -26,7 +26,7 @@ prototype.transform = function(input) {
       signals = g.values(SIGNALS, this.dependency(SIGNALS));
 
   function set(x) {
-    Tuple.set(x, field, expr(x, null, signals));
+    Tuple.set(x, field, expr(g, x, null, signals));
   }
 
   input.add.forEach(set);

--- a/src/transforms/Parameter.js
+++ b/src/transforms/Parameter.js
@@ -113,7 +113,7 @@ prototype.set = function(value) {
       p._signals.push({
         index: i,
         value: function(graph) {
-          return e.fn(null, null, graph.values(Deps.SIGNALS, e.globals));
+          return e.fn(graph, null, null, graph.values(Deps.SIGNALS, e.globals));
         }
       });
       return v.expr;

--- a/test/parse/expr.test.js
+++ b/test/parse/expr.test.js
@@ -1,0 +1,51 @@
+var dl = require('datalib'),
+    expr = require('../../src/parse/expr');
+
+describe('Expression Parser', function() {
+
+  var evt = {vg: {
+    item:     function() { return 'foo'; },
+    getGroup: function() { return 'bar'; },
+    getX:     function() { return 'xx'; },
+    getY:     function() { return 'yy'; }
+  }};
+
+  function run(code, model, datum, signals) {
+    return expr(code).fn(model, datum, evt, signals);
+  }
+
+  it('should evaluate event functions', function() {
+    expect(run('eventItem()')).to.equal('foo');
+    expect(run('eventGroup()')).to.equal('bar');
+    expect(run('eventX()')).to.equal('xx');
+    expect(run('eventY()')).to.equal('yy');
+  });
+
+  it('should evaluate scale functions', function(done) {
+    var spec = {"data": [], "scales": [
+      {name:"y", type:"linear", domain:[1,5], range:[0,1], zero:false}
+    ]};
+    parseSpec(spec, viewFactory, function(error, model) {
+      var group = model.scene().items[0],
+          y = group.scale('y');
+      expect(run('scale("y", 1)', model)).to.equal(y(1));
+      expect(run('scale("y", 5)', model)).to.equal(y(5));
+      expect(run('iscale("y", 0)', model)).to.equal(y.invert(0));
+      expect(run('iscale("y", 1)', model)).to.equal(y.invert(1));
+      done();
+    });
+  });
+
+  it('should evaluate inrange function', function() {
+    expect(run('inrange(2, 1, 3)')).to.equal(true);
+    expect(run('inrange(3, 1, 3)')).to.equal(true);
+    expect(run('inrange(3, 1, 3, true)')).to.equal(false);
+  });
+
+  it('should evaluate format functions', function() {
+    expect(run('format(",.2f", 1200.342)')).to.equal('1,200.34');
+    expect(run('timeFormat("%b %Y", datetime(2000,9))')).to.equal('Oct 2000');
+    expect(run('utcFormat("%b %Y %H:%M", utc(2009,9,1,10))')).to.equal('Oct 2009 10:00');
+  });
+
+});


### PR DESCRIPTION
This adds the functions scale and iscale to the expression language. (i)scale takes 2 or 3 parameters. The first is a scale name, the second it the value to pass to the scale, and the third (optional) is a group object to perform the lookup on.

Previously, the expressions had no direct access to the model, so I had to add model as a parameter when you call an expression. I believe that I updated everywhere we call an expression.

This requires https://github.com/vega/vega-expression/pull/3 to be merged first, so we should bump the dependency on vega-expression to whatever the new value is before merging this.