### PR TITLE
Add functionality to allow deprecation of predicates

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "d3-cloud": "^1.2.1",
     "datalib": "^1.5.7",
     "topojson": "^1.6.19",
-    "vega-dataflow": "^1.3.2",
-    "vega-expression": "^1.1.0",
+    "vega-dataflow": "^1.4.0",
+    "vega-expression": "^1.2.0",
     "vega-logging": "^1.0.1",
     "vega-scenegraph": "^1.0.16",
     "yargs": "^3.30.0"

--- a/src/core/Model.js
+++ b/src/core/Model.js
@@ -19,6 +19,7 @@ function Model(cfg) {
   this._builder = null; // Top-level scenegraph builder.
 
   this._reset = {axes: false, legends: false};
+  this._requestedIndexes = [];
 
   this.config(cfg);
   this.expr = compiler(this);
@@ -96,6 +97,10 @@ prototype.predicate = function(name, predicate) {
 };
 
 prototype.predicates = function() { return this._predicates; };
+
+prototype.requestIndex = function(data, field) {
+  this._requestedIndexes.push({data: data, field: field});
+};
 
 prototype.scene = function(renderer) {
   if (!arguments.length) return this._scene;

--- a/src/core/Model.js
+++ b/src/core/Model.js
@@ -99,7 +99,19 @@ prototype.predicate = function(name, predicate) {
 prototype.predicates = function() { return this._predicates; };
 
 prototype.requestIndex = function(data, field) {
+  if (!this._requestedIndexes) throw Error("Cannot request indexes after parse time.");
   this._requestedIndexes.push({data: data, field: field});
+};
+
+prototype.buildIndexes = function() {
+  this._requestedIndexes = false;
+  // Make indexes
+  for (i=0; i<this._requestedIndexes.length; ++i) {
+    request = this._requestedIndexes[i];
+    data = this.data(request.data);
+    if (!data) throw Error("Data source '" + request.data + "' does not exist");
+    data.getIndex(request.field);
+  }
 };
 
 prototype.scene = function(renderer) {

--- a/src/core/Model.js
+++ b/src/core/Model.js
@@ -19,7 +19,6 @@ function Model(cfg) {
   this._builder = null; // Top-level scenegraph builder.
 
   this._reset = {axes: false, legends: false};
-  this._requestedIndexes = [];
 
   this.config(cfg);
   this.expr = compiler(this);
@@ -97,22 +96,6 @@ prototype.predicate = function(name, predicate) {
 };
 
 prototype.predicates = function() { return this._predicates; };
-
-prototype.requestIndex = function(data, field) {
-  if (!this._requestedIndexes) throw Error("Cannot request indexes after parse time.");
-  this._requestedIndexes.push({data: data, field: field});
-};
-
-prototype.buildIndexes = function() {
-  this._requestedIndexes = false;
-  // Make indexes
-  for (i=0; i<this._requestedIndexes.length; ++i) {
-    request = this._requestedIndexes[i];
-    data = this.data(request.data);
-    if (!data) throw Error("Data source '" + request.data + "' does not exist");
-    data.getIndex(request.field);
-  }
-};
 
 prototype.scene = function(renderer) {
   if (!arguments.length) return this._scene;

--- a/src/parse/expr.js
+++ b/src/parse/expr.js
@@ -79,15 +79,12 @@ function indataGen(codegen) {
       throw Error("Data source name must be a literal for indata.");
     }
 
-    data = indataGen.model.data(args[0].value);
-    console.log(indataGen.model);
-    if (!data) {
-      throw Error("Data source '" + args[0].value + "' does not exist.");
+    data = args[0].value;
+    if (args[2].type === 'Literal') {
+      indataGen.model.requestIndex(data, args[2].value);
     }
     // mark the dataSource as a dependency
-    dataSources[args[0].value] = 1;
-    if (args[2].type === 'Literal')
-      data.getIndex(args[2].value);
+    dataSources[data] = 1;
 
     args = args.map(codegen);
     return 'this.defs.indata(this.model,' + args[0] + ',' + args[1] + ',' + args[2] + ')'

--- a/src/parse/expr.js
+++ b/src/parse/expr.js
@@ -71,23 +71,24 @@ function inrange(val, a, b, exclusive) {
 
 function indataGen(codegen) {
   return function(args, globals, fields, dataSources) {
-    var n = args.length,
-        field, data;
-    if (n < 2 || n > 3) {
-      throw Error("indata takes exactly 2 or 3 arguments.");
+    var data;
+    if (args.length !== 3) {
+      throw Error("indata takes 3 arguments.");
     }
     if (args[0].type !== 'Literal') {
       throw Error("Data source name must be a literal for indata.");
     }
 
-    field = args[2] ? args[2].value : null;
     data = indataGen.model.data(args[0].value);
+    if (!data) {
+      throw Error("Data source '" + args[0].value + "' does not exist.");
+    }
     // mark the dataSource as a dependency
     dataSources[args[0].value] = 1;
-    if (data) data.getIndex(field);
+    data.getIndex(field);
 
     args = args.map(codegen);
-    return 'this.defs.indata(this.model,' + args[0] + ',' + args[1] + (n > 2 ? ',' + args[2] : '') + ')'
+    return 'this.defs.indata(this.model,' + args[0] + ',' + args[1] + ',' + args[2] + ')'
   }
 }
 

--- a/src/parse/expr.js
+++ b/src/parse/expr.js
@@ -80,12 +80,14 @@ function indataGen(codegen) {
     }
 
     data = indataGen.model.data(args[0].value);
+    console.log(indataGen.model);
     if (!data) {
       throw Error("Data source '" + args[0].value + "' does not exist.");
     }
     // mark the dataSource as a dependency
     dataSources[args[0].value] = 1;
-    data.getIndex(field);
+    if (args[2].type === 'Literal')
+      data.getIndex(args[2].value);
 
     args = args.map(codegen);
     return 'this.defs.indata(this.model,' + args[0] + ',' + args[1] + ',' + args[2] + ')'

--- a/src/parse/expr.js
+++ b/src/parse/expr.js
@@ -90,7 +90,7 @@ function indataGen(codegen) {
 
 function indata(model, dataname, val, field) {
   var data = model.data(dataname);
-  return data ? data.hasElement(val, field) : false;
+  return data && data.hasElement(val, field);
 }
 
 function numberFormat(specifier, v) {

--- a/src/parse/modify.js
+++ b/src/parse/modify.js
@@ -95,6 +95,7 @@ function parseModify(model, def, ds) {
 
   if (exprTrigger) {
     node.dependency(Deps.SIGNALS, exprTrigger.globals);
+    node.dependency(Deps.DATA,    exprTrigger.dataSources);
   }
 
   return node;

--- a/src/parse/properties.js
+++ b/src/parse/properties.js
@@ -450,19 +450,22 @@ function valueSchema(type) {
       "type": "array",
       "items": {
         "allOf": [{
-          "type": "object",
-          "properties": {
-            "predicate": {
-              "oneOf": [
-                {"type": "string"},
-                {
-                  "type": "object",
-                  "properties": {"name": { "type": "string" }},
-                  "required": ["name"]
-                }
-              ]
+          "oneOf": [{
+            "type": "object",
+            "properties": {
+              "predicate": {
+                "oneOf": [
+                  {"type": "string"},
+                  {
+                    "type": "object",
+                    "properties": {"name": { "type": "string" }},
+                    "required": ["name"]
+                  }
+                ]
+              }
             }
-          }
+          },
+          {"type": "object", "properties": {"test": {"type": "string"}}}]
         },
         valRef]
       }

--- a/src/parse/properties.js
+++ b/src/parse/properties.js
@@ -21,7 +21,7 @@ function properties(model, mark, spec) {
         reflow:  false
       };
 
-  code += "var o = trans ? {} : item, d=0, set=this.tpl.set, tmpl=signals||{}, t;\n" +
+  code += "var o = trans ? {} : item, d=0, exprs=this.exprs, set=this.tpl.set, tmpl=signals||{}, t;\n" +
           // Stash for dl.template
           "tmpl.datum  = item.datum;\n" +
           "tmpl.group  = group;\n" +
@@ -124,13 +124,11 @@ function properties(model, mark, spec) {
 
   try {
     /* jshint evil:true */
-    var innerEncoder = Function('exprs', 'item', 'group', 'trans', 'db',
+    var encoder = Function('item', 'group', 'trans', 'db',
       'signals', 'predicates', code);
 
-    var encoder = function(item, group, trans, db, signals, predicates) {
-      return innerEncoder.call(this, exprs, item, group, trans, db, signals, predicates);
-    }
     encoder.tpl  = Tuple;
+    encoder.exprs = exprs;
     encoder.util = dl;
     encoder.d3   = d3; // For color spaces
     dl.extend(encoder, dl.template.context);

--- a/src/parse/properties.js
+++ b/src/parse/properties.js
@@ -185,6 +185,7 @@ function rule(model, name, rules, exprs) {
       // rule uses an expression instead of a predicate.
       var exprFn = model.expr(r.test);
       deps.signals.push.apply(deps.signals, exprFn.globals);
+      deps.data.push.apply(deps.data, exprFn.dataSources);
       ref = valueRef(config, name, r);
       dependencies(deps, ref);
 

--- a/src/parse/spec.js
+++ b/src/parse/spec.js
@@ -73,13 +73,7 @@ var dl = require('datalib'),
         data:       parsers.data(model, spec.data, onCreate)
       });
 
-      // Make indexes
-      for (i=0; i<model._requestedIndexes.length; ++i) {
-        request = model._requestedIndexes[i];
-        data = model.data(request.data);
-        if (!data) throw Error("Data source '" + request.data + "' does not exist");
-        data.getIndex(request.field);
-      }
+      model.buildIndexes();
     } catch (err) { onError(err); }
   }
 

--- a/src/parse/spec.js
+++ b/src/parse/spec.js
@@ -68,8 +68,8 @@ var dl = require('datalib'),
         background: parsers.background(spec.background),
         signals:    parsers.signals(model, spec.signals),
         predicates: parsers.predicates(model, spec.predicates),
-        marks:      parsers.marks(model, spec, width, height),
-        data:       parsers.data(model, spec.data, onCreate)
+        data:       parsers.data(model, spec.data, onCreate),
+        marks:      parsers.marks(model, spec, width, height)
       });
     } catch (err) { onError(err); }
   }

--- a/src/parse/spec.js
+++ b/src/parse/spec.js
@@ -45,6 +45,7 @@ var dl = require('datalib'),
   }
 
   function parse(spec) {
+    var i, request, data;
     try {
       // protect against subsequent spec modification
       spec = dl.duplicate(spec);
@@ -68,9 +69,17 @@ var dl = require('datalib'),
         background: parsers.background(spec.background),
         signals:    parsers.signals(model, spec.signals),
         predicates: parsers.predicates(model, spec.predicates),
-        data:       parsers.data(model, spec.data, onCreate),
-        marks:      parsers.marks(model, spec, width, height)
+        marks:      parsers.marks(model, spec, width, height),
+        data:       parsers.data(model, spec.data, onCreate)
       });
+
+      // Make indexes
+      for (i=0; i<model._requestedIndexes.length; ++i) {
+        request = model._requestedIndexes[i];
+        data = model.data(request.data);
+        if (!data) throw Error("Data source '" + request.data + "' does not exist");
+        data.getIndex(request.field);
+      }
     } catch (err) { onError(err); }
   }
 

--- a/src/transforms/Parameter.js
+++ b/src/transforms/Parameter.js
@@ -83,6 +83,7 @@ prototype.set = function(value) {
         e = graph.expr(v);
         p._transform.dependency(Deps.FIELDS,  e.fields);
         p._transform.dependency(Deps.SIGNALS, e.globals);
+        p._transform.dependency(Deps.DATA,    e.dataSources);
         return e.fn;
       } else if (isField) {  // Backwards compatibility
         p._accessors[i] = dl.accessor(v);

--- a/test/parse/expr.test.js
+++ b/test/parse/expr.test.js
@@ -50,4 +50,24 @@ describe('Expression Parser', function() {
     expect(run('utcFormat("%b %Y %H:%M", utc(2009,9,1,10))')).to.equal('Oct 2009 10:00');
   });
 
+  it('should evaluate indata function', function(done) {
+    var spec = {
+      signals: [{name:'sig', streams:[]}],
+      data: [{name: 'source', values: [{x: 1, y:2}, {x: 1, y: 5}]}]
+    };
+    parseSpec(spec, viewFactory, function(error, model) {
+      var expr = require('../../src/parse/expr')(model);
+      function run(code, datum, evt) {
+        return expr(code).fn(datum, evt);
+      }
+      expect(run('indata("source", 1, "x")')).to.equal(true);
+      expect(run('indata("source", 2, "x")')).to.equal(false);
+      expect(run('indata("source", 5, "y")')).to.equal(true);
+
+      // data source must be a consant expression
+      expect(run.bind('indata(sig, 1, "x")')).to.throw(Error);
+      done();
+    });
+  });
+
 });

--- a/test/parse/properties.test.js
+++ b/test/parse/properties.test.js
@@ -1,0 +1,76 @@
+var dl = require('datalib');
+
+describe('Properties Parser', function() {
+  it('should evaluate expression rules', function(done) {
+    var spec = {
+      data: [],
+      signals: [{name: 'signal1', init: true}],
+      marks: [
+        {
+          name: 'mark1',
+          type: 'rect',
+          properties: {
+            update: {
+              x: 0,
+              y: 0,
+              width: 100,
+              height: 100,
+              fill: [
+                {test:'false', value: 'red'},
+                {test:'signal1', value: 'blue'},
+                {value: 'green'}
+              ]
+            }
+          }
+        }
+      ]
+    };
+    parseSpec(spec, function(error, viewFactory) {
+      var view = viewFactory().update();
+      // get the rect item, which is in group -> mark1 -> item
+      var mark = view.model().scene().items[0].items[0].items[0];
+      expect(mark.fill).to.equal('blue');
+      view.model().signal('signal1', false);
+      view.update();
+      expect(mark.fill).to.equal('green');
+      done();
+    });
+  });
+
+  it('should evaluate predicate rules', function(done) {
+    var spec = {
+      data: [],
+      signals: [{name: 'signal1', init: true}],
+      predicates: [{name:'predicate1', type:'==', operands: [{signal:'signal1'}, {value: true}]}],
+      marks: [
+        {
+          name: 'mark1',
+          type: 'rect',
+          properties: {
+            update: {
+              x: 0,
+              y: 0,
+              width: 100,
+              height: 100,
+              fill: [
+                {predicate:'predicate1', value: 'blue'},
+                {value: 'green'}
+              ]
+            }
+          }
+        }
+      ]
+    };
+    parseSpec(spec, function(error, viewFactory) {
+      var view = viewFactory().update();
+      // get the rect item, which is in group -> mark1 -> item
+      var mark = view.model().scene().items[0].items[0].items[0];
+      expect(mark.fill).to.equal('blue');
+      view.model().signal('signal1', false);
+      view.update();
+      expect(mark.fill).to.equal('green');
+      done();
+    });
+  });
+
+});

--- a/test/parse/properties.test.js
+++ b/test/parse/properties.test.js
@@ -37,6 +37,42 @@ describe('Properties Parser', function() {
     });
   });
 
+  it("should register indata's data source dependencies", function(done) {
+    var spec = {
+      data: [{name: 'data1'}],
+      marks: [
+        {
+          name: 'mark1',
+          type: 'rect',
+          properties: {
+            update: {
+              x: 0,
+              y: 0,
+              width: 100,
+              height: 100,
+              fill: [
+                {test:'!indata("data1", 1, "a")', value: 'blue'},
+                {value: 'green'}
+              ]
+            }
+          }
+        }
+      ]
+    };
+    parseSpec(spec, function(error, viewFactory) {
+      var view = viewFactory().update();
+      // get the rect item, which is in group -> mark1 -> item
+      var mark = view.model().scene().items[0].items[0].items[0];
+      expect(mark.fill).to.equal('blue');
+      // the predicate should re-evaluate the expression when the
+      // data source updates
+      view.data('data1').insert([{a: 1}]);
+      view.update();
+      expect(mark.fill).to.equal('green');
+      done();
+    });
+  });
+
   it('should evaluate predicate rules', function(done) {
     var spec = {
       data: [],


### PR DESCRIPTION
I've been working on implementing the changes necessary to have all the functionality of predicates using expressions (Issue #372 )

This adds an indata function, which takes indata(dataname, value, [field]). It returns true if a point in the data source has the given value under the given field. If field is not provided, it uses the entire data point.

I also added the property `test` which is an expression for a data source clear modification. This clears the data source when the expression becomes true.

For production rules, instead of a predicate property, you can provide a `test` property. This expression is evaluated for each datum instead of a predicate.

I still need to finish implementing the getIndex and hasElement functions in vega-dataflow. getIndex([field]) will create a map of all the values of the given field to the number of times they appear. hasElement returns true if the count is greater than 0. If the field is not provided, then the entire data point is used.

I still need to add the functionality of inrange for ordinal scales, and then I believe all the functionality of predicates will be implemented.