### PR TITLE
Fix titleOffset property

### DIFF
--- a/src/scene/axis.js
+++ b/src/scene/axis.js
@@ -501,11 +501,11 @@ function axisTitleExtend(orient, title, range, offset) {
   if (orient === 'bottom' || orient === 'top') {
     update.x = {value: mid};
     update.angle = {value: 0};
-    if (offset >= 0) update.y = sign * offset;
+    if (offset >= 0) update.y = {value: sign * offset};
   } else {
     update.y = {value: mid};
     update.angle = {value: orient === 'left' ? -90 : 90};
-    if (offset >= 0) update.x = sign * offset;
+    if (offset >= 0) update.x = {value: sign * offset};
   }
 }
 


### PR DESCRIPTION
The extra `y` and `x` properties should be within a `{value: n}` object
rather than plain integer in order to work.

-----

To reproduce use the `bar` example of vega editor and add a `titleOffset: 50` to one of the axes. The parameter is not taken into account and the title has an offset forced to 0.