### PR TITLE
Adding rank transform.

### DIFF
--- a/src/transforms/Rank.js
+++ b/src/transforms/Rank.js
@@ -6,8 +6,8 @@ var Tuple = require('vega-dataflow').Tuple,
 function Rank(graph) {
   BatchTransform.prototype.init.call(this, graph);
   Transform.addParameters(this, {
-    min:  {type: 'value', default: 1},
-    step: {type: 'value', default: 1},
+    start: {type: 'value', default: 1},
+    step:  {type: 'value', default: 1},
     normalize: {type: 'value', default: false}
   });
 
@@ -28,7 +28,7 @@ prototype.batchTransform = function(input, data) {
       len   = data.length,
       norm  = this.param('normalize'),
       step  = norm ? 1/len : this.param('step'),
-      value = (norm ? 0 : this.param('min')) - step;
+      value = (norm ? 0 : this.param('start')) - step;
 
   for (var i = 0; i<len; ++i) {
     Tuple.set(data[i], rank, value+=step);
@@ -47,7 +47,7 @@ Rank.schema = {
   "type": "object",
   "properties": {
     "type": {"enum": ["rank"]},
-    "min": {
+    "start": {
       "oneOf": [{"type": "number"}, {"$ref": "#/refs/signal"}],
       "default": 1
     },

--- a/src/transforms/Rank.js
+++ b/src/transforms/Rank.js
@@ -1,0 +1,76 @@
+var Tuple = require('vega-dataflow').Tuple,
+    log = require('vega-logging'),
+    Transform = require('./Transform'),
+    BatchTransform = require('./BatchTransform');
+
+function Rank(graph) {
+  BatchTransform.prototype.init.call(this, graph);
+  Transform.addParameters(this, {
+    min:  {type: 'value', default: 1},
+    step: {type: 'value', default: 1},
+    normalize: {type: 'value', default: false}
+  });
+
+  this._output = {
+    'rank': 'rank'
+  };
+
+  return this.mutates(true);
+}
+
+var prototype = (Rank.prototype = Object.create(BatchTransform.prototype));
+prototype.constructor = Rank;
+
+prototype.batchTransform = function(input, data) {
+  log.debug(input, ['rank']);
+
+  var rank = this._output.rank,
+      len   = data.length,
+      norm  = this.param('normalize'),
+      step  = norm ? 1/len : this.param('step'),
+      value = (norm ? 0 : this.param('min')) - step;
+
+  for (var i = 0; i<len; ++i) {
+    Tuple.set(data[i], rank, value+=step);
+  }
+
+  input.fields[rank] = 1;
+  return input;
+};
+
+module.exports = Rank;
+
+Rank.schema = {
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Rank transform",
+  "description": "Computes ascending rank scores for data tuples.",
+  "type": "object",
+  "properties": {
+    "type": {"enum": ["rank"]},
+    "min": {
+      "oneOf": [{"type": "number"}, {"$ref": "#/refs/signal"}],
+      "default": 1
+    },
+    "step": {
+      "oneOf": [{
+        "type": "number", "minimum": 0, "exclusiveMinimum": true,
+      }, {"$ref": "#/refs/signal"}],
+      "default": 1
+    },
+    "normalize": {
+      "description": "If true, values of the output field will lie in the range [0, 1].",
+      "oneOf": [{"type": "boolean"}, {"$ref": "#/refs/signal"}],
+      "default": false
+    },
+    "output": {
+      "type": "object",
+      "description": "Rename the output data fields",
+      "properties": {
+        "rank": {"type": "string", "default": "rank"}
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false,
+  "required": ["type"]
+};

--- a/src/transforms/index.js
+++ b/src/transforms/index.js
@@ -15,6 +15,7 @@ module.exports = {
   impute:       require('./Impute'),
   lookup:       require('./Lookup'),
   pie:          require('./Pie'),
+  rank:         require('./Rank'),
   sort:         require('./Sort'),
   stack:        require('./Stack'),
   treeify:      require('./Treeify'),

--- a/test/transforms/rank.test.js
+++ b/test/transforms/rank.test.js
@@ -45,60 +45,6 @@ describe('Rank', function() {
     });
   });
 
-  it('should support custom start', function(done) {
-    parseSpec(spec({start: 3}), modelFactory, function(error, model) {
-      if (error) return done(error);
-
-      var ds = model.data('table'),
-          data = ds.values(),
-          i, len;
-
-      expect(data).to.have.length(20);
-      for(i=1, len=data.length; i<len; ++i) {
-        expect(data[i].y).to.be.at.least(data[i-1].y);
-        expect(data[i].rank).to.equal(i+3);
-      }
-
-      done();
-    });
-  });
-
-  it('should support custom step', function(done) {
-    parseSpec(spec({step: 2}), modelFactory, function(error, model) {
-      if (error) return done(error);
-
-      var ds = model.data('table'),
-          data = ds.values(),
-          i, len;
-
-      expect(data).to.have.length(20);
-      for(i=1, len=data.length; i<len; ++i) {
-        expect(data[i].y).to.be.at.least(data[i-1].y);
-        expect(data[i].rank).to.equal(1+2*i);
-      }
-
-      done();
-    });
-  });
-
-  it('should support custom start+step', function(done) {
-    parseSpec(spec({start: 3, step: 2}), modelFactory, function(error, model) {
-      if (error) return done(error);
-
-      var ds = model.data('table'),
-          data = ds.values(),
-          i, len;
-
-      expect(data).to.have.length(20);
-      for(i=1, len=data.length; i<len; ++i) {
-        expect(data[i].y).to.be.at.least(data[i-1].y);
-        expect(data[i].rank).to.equal(3+2*i);
-      }
-
-      done();
-    });
-  });
-
   it('should rank by key field', function(done) {
     var spec = {
       data: [{
@@ -145,13 +91,12 @@ describe('Rank', function() {
       var ds = model.data('table'),
           data = ds.values(),
           len  = data.length,
-          step = 1/len,
           i = 1;
 
       expect(data).to.have.length(20);
       for(; i<len; ++i) {
         expect(data[i].y).to.be.at.least(data[i-1].y);
-        expect(data[i].rank).to.be.closeTo(i*step, EPSILON);
+        expect(data[i].rank).to.equal((i+1)/len);
       }
 
       done();
@@ -163,11 +108,6 @@ describe('Rank', function() {
         validate = validator(schema);
 
     expect(validate({ 'type': 'rank' })).to.be.true;
-    expect(validate({ 'type': 'rank', 'start': 0 })).to.be.true;
-    expect(validate({ 'type': 'rank', 'start': 2 })).to.be.true;
-    expect(validate({ 'type': 'rank', 'start': {'signal': 'start_sig'} })).to.be.true;
-    expect(validate({ 'type': 'rank', 'step': 2 })).to.be.true;
-    expect(validate({ 'type': 'rank', 'step': {'signal': 'step_sig'} })).to.be.true;
     expect(validate({ 'type': 'rank', 'normalize': true })).to.be.true;
     expect(validate({ 'type': 'rank', 'normalize': false })).to.be.true;
     expect(validate({ 'type': 'rank', 'normalize': {'signal': 'norm_sig'} })).to.be.true;
@@ -176,9 +116,6 @@ describe('Rank', function() {
     expect(validate({ 'type': 'rank', 'output': {'rank': 'idx'} })).to.be.true;
 
     expect(validate({ 'type': 'foo' })).to.be.false;
-    expect(validate({ 'type': 'rank', 'start': 'min_sig' })).to.be.false;
-    expect(validate({ 'type': 'rank', 'step': 0 })).to.be.false;
-    expect(validate({ 'type': 'rank', 'step': 'step_sg' })).to.be.false;
     expect(validate({ 'type': 'rank', 'normalize': 'hello' })).to.be.false;
     expect(validate({ 'type': 'rank', 'output': {'foo': 'bar'} })).to.be.false;
     expect(validate({ 'type': 'rank', 'foo': 'bar' })).to.be.false;

--- a/test/transforms/rank.test.js
+++ b/test/transforms/rank.test.js
@@ -6,18 +6,18 @@ describe('Rank', function() {
   var spec = function(rank) {
     return {
       data: [{
-        name: "table",
+        name: 'table',
         values: [
-          {"x": 1,  "y": 28}, {"x": 2,  "y": 55},
-          {"x": 3,  "y": 43}, {"x": 4,  "y": 91},
-          {"x": 5,  "y": 81}, {"x": 6,  "y": 53},
-          {"x": 7,  "y": 19}, {"x": 8,  "y": 87},
-          {"x": 9,  "y": 52}, {"x": 10, "y": 48},
-          {"x": 11, "y": 24}, {"x": 12, "y": 49},
-          {"x": 13, "y": 87}, {"x": 14, "y": 66},
-          {"x": 15, "y": 17}, {"x": 16, "y": 27},
-          {"x": 17, "y": 68}, {"x": 18, "y": 16},
-          {"x": 19, "y": 49}, {"x": 20, "y": 15}
+          {'x': 1,  'y': 28}, {'x': 2,  'y': 55},
+          {'x': 3,  'y': 43}, {'x': 4,  'y': 91},
+          {'x': 5,  'y': 81}, {'x': 6,  'y': 53},
+          {'x': 7,  'y': 19}, {'x': 8,  'y': 87},
+          {'x': 9,  'y': 52}, {'x': 10, 'y': 48},
+          {'x': 11, 'y': 24}, {'x': 12, 'y': 49},
+          {'x': 13, 'y': 87}, {'x': 14, 'y': 66},
+          {'x': 15, 'y': 17}, {'x': 16, 'y': 27},
+          {'x': 17, 'y': 68}, {'x': 18, 'y': 16},
+          {'x': 19, 'y': 49}, {'x': 20, 'y': 15}
         ],
         transform: [
           {type: 'sort', by: 'y'},
@@ -99,6 +99,45 @@ describe('Rank', function() {
     });
   });
 
+  it('should rank by key field', function(done) {
+    var spec = {
+      data: [{
+        name: 'table',
+        values: [
+          {x: 'A', y: 12}, {x: 'B', y: 32}, {x: 'C', y: 6},
+          {x: 'A', y: 35}, {x: 'B', y: 19}, {x: 'C', y: 66}
+        ],
+        transform: [
+          {type: 'sort', by: ['y']},
+          {type: 'rank', field: 'x'}
+        ]
+      }]
+    };
+
+    parseSpec(spec, modelFactory, function(error, model) {
+      if (error) return done(error);
+
+      var ds = model.data('table'),
+          data = ds.values(),
+          i, len, d, r;
+
+      expect(data).to.have.length(6);
+      for(i=1, len=data.length; i<len; ++i) {
+        d = data[i];
+        r = d.rank;
+
+        expect(d.y).to.be.at.least(data[i-1].y);
+        switch (d.x) {
+          case 'C': expect(r).to.equal(1); break;
+          case 'A': expect(r).to.equal(2); break;
+          case 'B': expect(r).to.equal(3); break;
+        }
+      }
+
+      done();
+    });
+  });
+
   it('should normalize', function(done) {
     parseSpec(spec({normalize: true}), modelFactory, function(error, model) {
       if (error) return done(error);
@@ -123,24 +162,26 @@ describe('Rank', function() {
     var schema = schemaPath(transforms.rank.schema),
         validate = validator(schema);
 
-    expect(validate({ "type": "rank" })).to.be.true;
-    expect(validate({ "type": "rank", "start": 0 })).to.be.true;
-    expect(validate({ "type": "rank", "start": 2 })).to.be.true;
-    expect(validate({ "type": "rank", "start": {"signal": "start_sig"} })).to.be.true;
-    expect(validate({ "type": "rank", "step": 2 })).to.be.true;
-    expect(validate({ "type": "rank", "step": {"signal": "step_sig"} })).to.be.true;
-    expect(validate({ "type": "rank", "normalize": true })).to.be.true;
-    expect(validate({ "type": "rank", "normalize": false })).to.be.true;
-    expect(validate({ "type": "rank", "normalize": {"signal": "norm_sig"} })).to.be.true;
-    expect(validate({ "type": "rank", "output": {"rank": "idx"} })).to.be.true;
+    expect(validate({ 'type': 'rank' })).to.be.true;
+    expect(validate({ 'type': 'rank', 'start': 0 })).to.be.true;
+    expect(validate({ 'type': 'rank', 'start': 2 })).to.be.true;
+    expect(validate({ 'type': 'rank', 'start': {'signal': 'start_sig'} })).to.be.true;
+    expect(validate({ 'type': 'rank', 'step': 2 })).to.be.true;
+    expect(validate({ 'type': 'rank', 'step': {'signal': 'step_sig'} })).to.be.true;
+    expect(validate({ 'type': 'rank', 'normalize': true })).to.be.true;
+    expect(validate({ 'type': 'rank', 'normalize': false })).to.be.true;
+    expect(validate({ 'type': 'rank', 'normalize': {'signal': 'norm_sig'} })).to.be.true;
+    expect(validate({ 'type': 'rank', 'field': "hello" })).to.be.true;
+    expect(validate({ 'type': 'rank', 'field': {'signal': 'field_sig'} })).to.be.true;
+    expect(validate({ 'type': 'rank', 'output': {'rank': 'idx'} })).to.be.true;
 
-    expect(validate({ "type": "foo" })).to.be.false;
-    expect(validate({ "type": "rank", "start": "min_sig" })).to.be.false;
-    expect(validate({ "type": "rank", "step": 0 })).to.be.false;
-    expect(validate({ "type": "rank", "step": "step_sg" })).to.be.false;
-    expect(validate({ "type": "rank", "normalize": "hello" })).to.be.false;
-    expect(validate({ "type": "rank", "output": {"foo": "bar"} })).to.be.false;
-    expect(validate({ "type": "rank", "foo": "bar" })).to.be.false;
+    expect(validate({ 'type': 'foo' })).to.be.false;
+    expect(validate({ 'type': 'rank', 'start': 'min_sig' })).to.be.false;
+    expect(validate({ 'type': 'rank', 'step': 0 })).to.be.false;
+    expect(validate({ 'type': 'rank', 'step': 'step_sg' })).to.be.false;
+    expect(validate({ 'type': 'rank', 'normalize': 'hello' })).to.be.false;
+    expect(validate({ 'type': 'rank', 'output': {'foo': 'bar'} })).to.be.false;
+    expect(validate({ 'type': 'rank', 'foo': 'bar' })).to.be.false;
   });
 
 

--- a/test/transforms/rank.test.js
+++ b/test/transforms/rank.test.js
@@ -45,8 +45,8 @@ describe('Rank', function() {
     });
   });
 
-  it('should support custom min', function(done) {
-    parseSpec(spec({min: 3}), modelFactory, function(error, model) {
+  it('should support custom start', function(done) {
+    parseSpec(spec({start: 3}), modelFactory, function(error, model) {
       if (error) return done(error);
 
       var ds = model.data('table'),
@@ -81,8 +81,8 @@ describe('Rank', function() {
     });
   });
 
-  it('should support custom min+step', function(done) {
-    parseSpec(spec({min: 3, step: 2}), modelFactory, function(error, model) {
+  it('should support custom start+step', function(done) {
+    parseSpec(spec({start: 3, step: 2}), modelFactory, function(error, model) {
       if (error) return done(error);
 
       var ds = model.data('table'),
@@ -124,9 +124,9 @@ describe('Rank', function() {
         validate = validator(schema);
 
     expect(validate({ "type": "rank" })).to.be.true;
-    expect(validate({ "type": "rank", "min": 0 })).to.be.true;
-    expect(validate({ "type": "rank", "min": 2 })).to.be.true;
-    expect(validate({ "type": "rank", "min": {"signal": "min_sig"} })).to.be.true;
+    expect(validate({ "type": "rank", "start": 0 })).to.be.true;
+    expect(validate({ "type": "rank", "start": 2 })).to.be.true;
+    expect(validate({ "type": "rank", "start": {"signal": "start_sig"} })).to.be.true;
     expect(validate({ "type": "rank", "step": 2 })).to.be.true;
     expect(validate({ "type": "rank", "step": {"signal": "step_sig"} })).to.be.true;
     expect(validate({ "type": "rank", "normalize": true })).to.be.true;
@@ -135,7 +135,7 @@ describe('Rank', function() {
     expect(validate({ "type": "rank", "output": {"rank": "idx"} })).to.be.true;
 
     expect(validate({ "type": "foo" })).to.be.false;
-    expect(validate({ "type": "rank", "min": "min_sig" })).to.be.false;
+    expect(validate({ "type": "rank", "start": "min_sig" })).to.be.false;
     expect(validate({ "type": "rank", "step": 0 })).to.be.false;
     expect(validate({ "type": "rank", "step": "step_sg" })).to.be.false;
     expect(validate({ "type": "rank", "normalize": "hello" })).to.be.false;

--- a/test/transforms/rank.test.js
+++ b/test/transforms/rank.test.js
@@ -1,0 +1,147 @@
+var dl = require('datalib'),
+    EPSILON = 1e-15;
+
+describe('Rank', function() {
+
+  var spec = function(rank) {
+    return {
+      data: [{
+        name: "table",
+        values: [
+          {"x": 1,  "y": 28}, {"x": 2,  "y": 55},
+          {"x": 3,  "y": 43}, {"x": 4,  "y": 91},
+          {"x": 5,  "y": 81}, {"x": 6,  "y": 53},
+          {"x": 7,  "y": 19}, {"x": 8,  "y": 87},
+          {"x": 9,  "y": 52}, {"x": 10, "y": 48},
+          {"x": 11, "y": 24}, {"x": 12, "y": 49},
+          {"x": 13, "y": 87}, {"x": 14, "y": 66},
+          {"x": 15, "y": 17}, {"x": 16, "y": 27},
+          {"x": 17, "y": 68}, {"x": 18, "y": 16},
+          {"x": 19, "y": 49}, {"x": 20, "y": 15}
+        ],
+        transform: [
+          {type: 'sort', by: 'y'},
+          dl.extend({type: 'rank'}, rank)
+        ]
+      }]
+    };
+  }
+
+  it('should compute sorted rank', function(done) {
+    parseSpec(spec(), modelFactory, function(error, model) {
+      if (error) return done(error);
+
+      var ds = model.data('table'),
+          data = ds.values(),
+          i, len;
+
+      expect(data).to.have.length(20);
+      for(i=1, len=data.length; i<len; ++i) {
+        expect(data[i].y).to.be.at.least(data[i-1].y);
+        expect(data[i].rank).to.equal(i+1);
+      }
+
+      done();
+    });
+  });
+
+  it('should support custom min', function(done) {
+    parseSpec(spec({min: 3}), modelFactory, function(error, model) {
+      if (error) return done(error);
+
+      var ds = model.data('table'),
+          data = ds.values(),
+          i, len;
+
+      expect(data).to.have.length(20);
+      for(i=1, len=data.length; i<len; ++i) {
+        expect(data[i].y).to.be.at.least(data[i-1].y);
+        expect(data[i].rank).to.equal(i+3);
+      }
+
+      done();
+    });
+  });
+
+  it('should support custom step', function(done) {
+    parseSpec(spec({step: 2}), modelFactory, function(error, model) {
+      if (error) return done(error);
+
+      var ds = model.data('table'),
+          data = ds.values(),
+          i, len;
+
+      expect(data).to.have.length(20);
+      for(i=1, len=data.length; i<len; ++i) {
+        expect(data[i].y).to.be.at.least(data[i-1].y);
+        expect(data[i].rank).to.equal(1+2*i);
+      }
+
+      done();
+    });
+  });
+
+  it('should support custom min+step', function(done) {
+    parseSpec(spec({min: 3, step: 2}), modelFactory, function(error, model) {
+      if (error) return done(error);
+
+      var ds = model.data('table'),
+          data = ds.values(),
+          i, len;
+
+      expect(data).to.have.length(20);
+      for(i=1, len=data.length; i<len; ++i) {
+        expect(data[i].y).to.be.at.least(data[i-1].y);
+        expect(data[i].rank).to.equal(3+2*i);
+      }
+
+      done();
+    });
+  });
+
+  it('should normalize', function(done) {
+    parseSpec(spec({normalize: true}), modelFactory, function(error, model) {
+      if (error) return done(error);
+
+      var ds = model.data('table'),
+          data = ds.values(),
+          len  = data.length,
+          step = 1/len,
+          i = 1;
+
+      expect(data).to.have.length(20);
+      for(; i<len; ++i) {
+        expect(data[i].y).to.be.at.least(data[i-1].y);
+        expect(data[i].rank).to.be.closeTo(i*step, EPSILON);
+      }
+
+      done();
+    });
+  });
+
+  it('should validate against the schema', function() {
+    var schema = schemaPath(transforms.rank.schema),
+        validate = validator(schema);
+
+    expect(validate({ "type": "rank" })).to.be.true;
+    expect(validate({ "type": "rank", "min": 0 })).to.be.true;
+    expect(validate({ "type": "rank", "min": 2 })).to.be.true;
+    expect(validate({ "type": "rank", "min": {"signal": "min_sig"} })).to.be.true;
+    expect(validate({ "type": "rank", "step": 2 })).to.be.true;
+    expect(validate({ "type": "rank", "step": {"signal": "step_sig"} })).to.be.true;
+    expect(validate({ "type": "rank", "normalize": true })).to.be.true;
+    expect(validate({ "type": "rank", "normalize": false })).to.be.true;
+    expect(validate({ "type": "rank", "normalize": {"signal": "norm_sig"} })).to.be.true;
+    expect(validate({ "type": "rank", "output": {"rank": "idx"} })).to.be.true;
+
+    expect(validate({ "type": "foo" })).to.be.false;
+    expect(validate({ "type": "rank", "min": "min_sig" })).to.be.false;
+    expect(validate({ "type": "rank", "step": 0 })).to.be.false;
+    expect(validate({ "type": "rank", "step": "step_sg" })).to.be.false;
+    expect(validate({ "type": "rank", "normalize": "hello" })).to.be.false;
+    expect(validate({ "type": "rank", "output": {"foo": "bar"} })).to.be.false;
+    expect(validate({ "type": "rank", "foo": "bar" })).to.be.false;
+  });
+
+
+});


### PR DESCRIPTION
Implementing a simple `rank` transform to facilitate #477. Supported parameters include `start`, `step`, and `normalize`. The first two default to `1`. If the latter is true, the output `rank` field falls between [0, 1] (i.e., start = 0, step = 1/data.length). 