### PR TITLE
Fix error in panzoom example

### DIFF
--- a/test/spec/panzoom_points.json
+++ b/test/spec/panzoom_points.json
@@ -49,7 +49,7 @@
       "name": "zoom",
       "init": 1.0,
       "streams": [
-        {"type": "wheel", "expr": "pow(1.001, event.deltaY)"}
+        {"type": "wheel", "expr": "pow(1.001, event.deltaY) + random()/100"}
       ]
     },
     {


### PR DESCRIPTION
Example won't work well with mice wheel that return a constant event.deltaY. In these cases, only the first time you roll the wheel in a direction is captured by the signal. This is easily fixed by adding a random number to the signal.