### PR TITLE
Remove half a pixel offset from axes

### DIFF
--- a/src/scene/axis.js
+++ b/src/scene/axis.js
@@ -112,11 +112,11 @@ function axs(model) {
     // setup scale mapping
     var newScale, oldScale, range;
     if (scale.type === ORDINAL) {
-      newScale = {scale: scale.scaleName, offset: 0.5 + scale.rangeBand()/2};
+      newScale = {scale: scale.scaleName, offset: scale.rangeBand()/2};
       oldScale = newScale;
     } else {
-      newScale = {scale: scale.scaleName, offset: 0.5};
-      oldScale = {scale: scale.scaleName+':prev', offset: 0.5};
+      newScale = {scale: scale.scaleName};
+      oldScale = {scale: scale.scaleName+':prev'};
     }
     range = axisScaleRange(scale);
 
@@ -564,8 +564,8 @@ function axisDomain(config) {
     interactive: false,
     properties: {
       enter: {
-        x: {value: 0.5},
-        y: {value: 0.5},
+        x: {value: 0},
+        y: {value: 0},
         stroke: {value: config.axisColor},
         strokeWidth: {value: config.axisWidth}
       },


### PR DESCRIPTION
Fixes vega/vega-scenegraph#22

before
<img width="712" alt="screen shot 2016-02-11 at 21 49 43" src="https://cloud.githubusercontent.com/assets/589034/12999927/66e9e738-d109-11e5-86f6-be308cd496aa.png">

after
<img width="682" alt="screen shot 2016-02-11 at 21 49 23" src="https://cloud.githubusercontent.com/assets/589034/12999929/6c6879cc-d109-11e5-8f4e-d6cac0b933e9.png">

I also looked through the vega examples and the axis positioning looks generally better. 