### PR TITLE
Support setting custom cursors

### DIFF
--- a/src/parse/spec.js
+++ b/src/parse/spec.js
@@ -54,10 +54,11 @@ var dl = require('datalib'),
           height  = spec.height || 500,
           padding = parsers.padding(spec.padding);
 
-      // create signals for width, height and padding
+      // create signals for width, height, padding, and cursor
       model.signal('width', width);
       model.signal('height', height);
       model.signal('padding', padding);
+      cursor(spec);
 
       // initialize model
       model.defs({
@@ -84,6 +85,20 @@ var dl = require('datalib'),
     });
   } else {
     onError('INVALID SPECIFICATION: Must be a valid JSON object or URL.');
+  }
+
+  function cursor(spec) {
+    var signals = spec.signals || (spec.signals=[]),  def;
+    signals.some(function(sg) {
+      return (sg.name === 'cursor') ? (def=sg, true) : false;
+    });
+
+    if (!def) signals.push(def={name: 'cursor', streams: []});
+
+    // Add a stream def at the head, so that custom defs can override it.
+    def.streams.unshift({
+      type: 'mousemove', expr: '{default: eventItem().cursor}'
+    });
   }
 }
 

--- a/src/parse/spec.js
+++ b/src/parse/spec.js
@@ -1,7 +1,7 @@
-var dl = require('datalib'),
+var dl  = require('datalib'),
     log = require('vega-logging'),
     Model = require('../core/Model'),
-    View = require('../core/View');
+    View  = require('../core/View');
 
 /**
  * Parse graph specification
@@ -26,22 +26,16 @@ var dl = require('datalib'),
     model.config(arguments[arglen - argidx]);
   }
 
-  function onDone(err, value) {
-    if (cb) {
-      if (cb.length > 1) cb(err, value);
-      else if (!err) cb(value);
-      cb = null;
-    }
-  }
-
-  function onError(err) {
-    log.error(err);
-    onDone(err);
-  }
-
-  function onCreate(err) {
-    if (err) onError(err);
-    else onDone(null, viewFactory(model.buildIndexes()));
+  if (dl.isObject(spec)) {
+    parse(spec);
+  } else if (dl.isString(spec)) {
+    var opts = dl.extend({url: spec}, model.config().load);
+    dl.json(opts, function(err, spec) {
+      if (err) done('SPECIFICATION LOAD FAILED: ' + err);
+      else parse(spec);
+    });
+  } else {
+    done('INVALID SPECIFICATION: Must be a valid JSON object or URL.');
   }
 
   function parse(spec) {
@@ -70,21 +64,9 @@ var dl = require('datalib'),
         signals:    parsers.signals(model, spec.signals),
         predicates: parsers.predicates(model, spec.predicates),
         marks:      parsers.marks(model, spec, width, height),
-        data:       parsers.data(model, spec.data, onCreate)
+        data:       parsers.data(model, spec.data, done)
       });
-    } catch (err) { onError(err); }
-  }
-
-  if (dl.isObject(spec)) {
-    parse(spec);
-  } else if (dl.isString(spec)) {
-    var opts = dl.extend({url: spec}, model.config().load);
-    dl.json(opts, function(err, spec) {
-      if (err) onError('SPECIFICATION LOAD FAILED: ' + err);
-      else parse(spec);
-    });
-  } else {
-    onError('INVALID SPECIFICATION: Must be a valid JSON object or URL.');
+    } catch (err) { done(err); }
   }
 
   function cursor(spec) {
@@ -99,6 +81,21 @@ var dl = require('datalib'),
     def.streams.unshift({
       type: 'mousemove', expr: '{default: eventItem().cursor}'
     });
+  }
+
+  function done(err) {
+    var view;
+    if (err) {
+      log.error(err);
+    } else {
+      view = viewFactory(model.buildIndexes());
+    }
+
+    if (cb) {
+      if (cb.length > 1) cb(err, view);
+      else if (!err) cb(view);
+      cb = null;
+    }
   }
 }
 


### PR DESCRIPTION
Resolves #314 with a new named signal `cursor`. By default, if no `cursor` signal is explicitly specified in the specification, the cursor signal is set to the `cursor` property of a the scenegraph item underneath the cursor. A signal handler then takes this value and sets the `cursor` style of the `body`.

If the user specifies a `cursor` signal in their specification, they can interactively specify the cursor style. They are then entirely responsible for managing this signal and the default behaviour described above is ignored. To revert back to the default behaviour, users must set the `cursor` signal to `default`. 

See this spec for an example. Hovering over the rects should switch the cursor to `pointer`. If you `mousedown`, the cursor switches to `ne-resize` and stays this way until you `mouseup`.

```json
{
  "width": 400,
  "height": 200,
  "padding": {"top": 10, "left": 30, "bottom": 30, "right": 10},
  "signals": [{
    "name": "cursor",
    "streams": [
      {"type": "mousedown", "expr": "'ne-resize'"},
      {"type": "mouseup", "expr": "'default'"}
    ]
  }],
  "data": [
    {
      "name": "table",
      "values": [
        {"x": 1,  "y": 28}, {"x": 2,  "y": 55},
        {"x": 3,  "y": 43}, {"x": 4,  "y": 91},
        {"x": 5,  "y": 81}, {"x": 6,  "y": 53},
        {"x": 7,  "y": 19}, {"x": 8,  "y": 87},
        {"x": 9,  "y": 52}, {"x": 10, "y": 48},
        {"x": 11, "y": 24}, {"x": 12, "y": 49},
        {"x": 13, "y": 87}, {"x": 14, "y": 66},
        {"x": 15, "y": 17}, {"x": 16, "y": 27},
        {"x": 17, "y": 68}, {"x": 18, "y": 16},
        {"x": 19, "y": 49}, {"x": 20, "y": 15}
      ]
    }
  ],
  "scales": [
    {
      "name": "x",
      "type": "ordinal",
      "range": "width",
      "domain": {"data": "table", "field": "x"}
    },
    {
      "name": "y",
      "type": "linear",
      "range": "height",
      "domain": {"data": "table", "field": "y"},
      "nice": true
    }
  ],
  "axes": [
    {"type": "x", "scale": "x"},
    {"type": "y", "scale": "y"}
  ],
  "marks": [
    {
      "type": "rect",
      "from": {"data": "table"},
      "properties": {
        "enter": {
          "x": {"scale": "x", "field": "x"},
          "width": {"scale": "x", "band": true, "offset": -1},
          "y": {"scale": "y", "field": "y"},
          "y2": {"scale": "y", "value": 0}
        },
        "update": {
          "fill": {"value": "steelblue"}
        },
        "hover": {
          "fill": {"value": "red"},
          "cursor": {"value": "pointer"}
        }
      }
    }
  ]
}
```