### PR TITLE
Remove pegjs from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "jshint": "^2.8.0",
     "jstransform": "^11.0.2",
     "mocha": "^2.2.5",
-    "pegjs": "~0.8.0",
     "through": "^2.3.8",
     "tv4": "^1.1.12",
     "uglify-js": "^2.4.24",
@@ -77,8 +76,7 @@
     "lint": "jshint src/",
     "test": "mocha --timeout 30000 --recursive test/",
     "cover": "istanbul cover _mocha -- --timeout 30000 --recursive test/",
-    "pegjs": "pegjs src/parse/events.pegjs",
-    "build": "npm run pegjs && browserify index.js -d -s vg | exorcist vega.js.map > vega.js",
+    "build": "browserify index.js -d -s vg | exorcist vega.js.map > vega.js",
     "postbuild": "uglifyjs vega.js -cm > vega.min.js",
     "schema": "node scripts/schema.js > vega-schema.json",
     "watch": "watchify index.js -v -d -s vg -o 'exorcist vega.js.map > vega.js'"


### PR DESCRIPTION
It looks like the event parser generator was moved into separate dependency in https://github.com/vega/vega/commit/9792c3d947c41c4434c68c4daf57ef5719f7db2b , but the pegjs build process is still part of the build process, which results in a build error:

```
16:24 vega$ npm run build

> vega@2.4.2 build /opt/src/vega/vega
> npm run pegjs && browserify index.js -d -s vg | exorcist vega.js.map > vega.js


> vega@2.4.2 pegjs /opt/src/vega/vega
> pegjs src/parse/events.pegjs

(node) util.error is deprecated. Use console.error instead.
Can't read from file "src/parse/events.pegjs".

```

Perhaps Travis should be configured to try to run the full build to catch this sort of problem in the future?