### PR TITLE
Add parent in expressions context

### DIFF
--- a/src/parse/expr.js
+++ b/src/parse/expr.js
@@ -1,7 +1,7 @@
 var dl = require('datalib'),
     template = dl.template,
     expr = require('vega-expression'),
-    args = ['datum', 'event', 'signals'];
+    args = ['datum', 'parent', 'event', 'signals'];
 
 var compile = expr.compiler(args, {
   idWhiteList: args,

--- a/src/parse/properties.js
+++ b/src/parse/properties.js
@@ -186,7 +186,7 @@ function rule(model, name, rules, exprs) {
       deps.signals.push.apply(deps.signals, exprFn.globals);
       deps.data.push.apply(deps.data, exprFn.dataSources);
 
-      code += "if (exprs[" + exprs.length + "](item.datum, null)) {" +
+      code += "if (exprs[" + exprs.length + "](item.datum, item.mark.group.datum, null)) {" +
           "\n    d += set(o, "+dl.str(name)+", " +ref.val+");";
       code += rules[i+1] ? "\n  } else " : "  }";
 

--- a/src/parse/streams.js
+++ b/src/parse/streams.js
@@ -57,7 +57,7 @@ function parseStreams(view) {
     view.on(type, function(evt, item) {
       evt.preventDefault(); // stop text selection
       extendEvent(evt, item);
-      fire(internal, type, (item && item.datum) || {}, evt);
+      fire(internal, type, (item && item.datum) || {}, (item && item.mark && item.mark.group && item.mark.group.datum) || {}, evt);
     });
   });
 
@@ -72,7 +72,7 @@ function parseStreams(view) {
 
     function handler(evt) {
       extendEvent(evt);
-      fire(external, type, d3.select(this).datum(), evt);
+      fire(external, type, d3.select(this).datum(), this.parentNode && d3.select(this.parentNode).datum(), evt);
     }
 
     for (var i=0; i<elt.length; ++i) {
@@ -125,7 +125,7 @@ function parseStreams(view) {
     evt.vg.y = mouse[1] - pad.top;
   }
 
-  function fire(registry, type, datum, evt) {
+  function fire(registry, type, datum, parent, evt) {
     var handlers = registry.handlers[type],
         node = registry.nodes[type],
         cs = df.ChangeSet.create(null, true),
@@ -133,7 +133,7 @@ function parseStreams(view) {
         val, i, n, h;
 
     function invoke(f) {
-      return !f.fn(datum, evt);
+      return !f.fn(datum, parent, evt);
     }
 
     for (i=0, n=handlers.length; i<n; ++i) {
@@ -141,7 +141,7 @@ function parseStreams(view) {
       filtered = h.filters.some(invoke);
       if (filtered) continue;
 
-      val = h.exp.fn(datum, evt);
+      val = h.exp.fn(datum, parent, evt);
       if (h.spec.scale) {
         val = parseSignals.scale(model, h.spec, val, datum, evt);
       }

--- a/test/parse/expr.test.js
+++ b/test/parse/expr.test.js
@@ -10,10 +10,10 @@ describe('Expression Parser', function() {
     getY:     function() { return 'yy'; }
   }};
 
-  function run(code, model, datum) {
+  function run(code, model, datum, parent) {
     var e = expr(code);
     e.model = model;
-    return e.fn(datum, evt);
+    return e.fn(datum, parent, evt);
   }
 
   it('should evaluate event functions', function() {
@@ -57,8 +57,8 @@ describe('Expression Parser', function() {
     };
     parseSpec(spec, viewFactory, function(error, model) {
       var expr = require('../../src/parse/expr')(model);
-      function run(code, datum, evt) {
-        return expr(code).fn(datum, evt);
+      function run(code, datum, parent, evt) {
+        return expr(code).fn(datum, parent, evt);
       }
       expect(run('indata("source", 1, "x")')).to.equal(true);
       expect(run('indata("source", 2, "x")')).to.equal(false);


### PR DESCRIPTION
From an expression, it can be useful to access the current datum’s parent. This commit allows to use parent the same way as datum within any expression.

This pull request can be an example if you want to implement it differently, but I haven’t found any work around.

Fixes https://github.com/vega/vega/issues/560