### PR TITLE
Allow all valid D3 line interpolation options

### DIFF
--- a/src/parse/properties.js
+++ b/src/parse/properties.js
@@ -611,8 +611,11 @@ properties.schema = {
         "endAngle": {"$ref": "#/refs/numberValue"},
 
         // Area- and line-mark properties
-        "interpolate": valueSchema(["linear", "step-before", "step-after",
-          "basis", "basis-open", "cardinal", "cardinal-open", "monotone"]),
+        "interpolate": valueSchema(["linear", "linear-closed",
+          "step", "step-before", "step-after",
+          "basis", "basis-open", "basis-closed", 
+          "cardinal", "cardinal-open", "cardinal-closed",
+          "bundle", "monotone"]),
         "tension": {"$ref": "#/refs/numberValue"},
         "orient": valueSchema(["horizontal", "vertical"]),
 


### PR DESCRIPTION
As discussed at https://github.com/vega/vega-lite/pull/1205, interpolations like "bundle" and "cardinal-closed" are valid D3 interpolation options, and might conceivably be useful for visualizing something.