### PR TITLE
Add mouseup signal to brush_end in overview+detail

### DIFF
--- a/examples/overview+detail.json
+++ b/examples/overview+detail.json
@@ -15,7 +15,7 @@
       "name": "brush_end",
       "init": {"expr": "datetime('Jan 1 2000')"},
       "streams": [{
-        "type": "@overview:mousedown, [@overview:mousedown, window:mouseup] > window:mousemove",
+        "type": "@overview:mousedown, [@overview:mousedown, window:mouseup] > window:mousemove, @overview:mouseup",
         "expr": "clamp(eventX(), 0, 720)",
         "scale": {"name": "xOverview", "invert": true}
       }]


### PR DESCRIPTION
With larger datasets, things get sluggish (as expected).  With this slow-down, a quick mousedown, mousemove, and mouseup by the user produces a much smaller brush region than desired, missing the true brush_end.  If you include mouseup as a signal in brush_end, it corrects this.