### PR TITLE
Update PORTING_GUIDE.md about domain/range_min/max

### DIFF
--- a/PORTING_GUIDE.md
+++ b/PORTING_GUIDE.md
@@ -137,6 +137,8 @@ This document describes the various changes needed to port Vega 2.x visualizatio
 
 - Scale domains involving multiple data fields from the same table must now be listed under the `"fields"` property, not `"field"`. For example, `"domain": {"data": "table", "fields": ["fieldA", "fieldB"]}`.
 
+- `domainMin`, `domainMax`, `rangeMin`, `rangeMax` are no longer supported.  Please simply use `domain` and `range`.
+
 ## Data Transforms
 
 - Vega 3 also introduces a number of new transforms, and modifications to previous transforms (including a dramatically improved `"force"` transform and improved hierarchical layout support). Web-based documentation is still forthcoming. However, most of these transforms are demonstrated in the example specifications included in this repo. In addition, the parameters accepted by each transform are documented via JSDoc comments in the source code. Please consult the appropriate Vega module repositories for further information.


### PR DESCRIPTION
I got an error that `range_min` and `range_max` is not supported.

I guess the same would be applied for `domain_*` but not sure where to check / if this is intended. 

Please merge if this is the case / feel free to reject this PR if you plan to add these properties back.   