### PR TITLE
v3.0.0-beta.16

### DIFF
--- a/spec/bar-rangestep.vg.json
+++ b/spec/bar-rangestep.vg.json
@@ -55,7 +55,7 @@
     {
       "name": "xscale",
       "type": "band",
-      "rangeStep": {"signal": "step"},
+      "range": {"step": {"signal": "step"}},
       "paddingInner": {"signal": "inner"},
       "paddingOuter": {"signal": "outer"},
       "round": {"signal": "round"},

--- a/spec/chart-rangestep.vg.json
+++ b/spec/chart-rangestep.vg.json
@@ -48,7 +48,7 @@
     {
       "name": "xscale",
       "type": "band",
-      "rangeStep": 40,
+      "range": {"step": 40},
       "domain": {"data": "values", "field": "x"}
     },
     {

--- a/spec/heatmap-lines.vg.json
+++ b/spec/heatmap-lines.vg.json
@@ -29,7 +29,7 @@
         6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
         0, 1, 2, 3, 4, 5
       ],
-      "rangeStep": {"signal": "rangeStep"}
+      "range": {"step": {"signal": "rangeStep"}}
     },
     {
       "name": "x",

--- a/spec/matrix-reorder.vg.json
+++ b/spec/matrix-reorder.vg.json
@@ -77,7 +77,7 @@
       "name": "position",
       "type": "band",
       "domain": {"data": "nodes", "field": "order", "sort": true},
-      "rangeStep": {"signal": "cellSize"}
+      "range": {"step": {"signal": "cellSize"}}
     },
     {
       "name": "color",

--- a/spec/movies-sort.vg.json
+++ b/spec/movies-sort.vg.json
@@ -95,7 +95,7 @@
           "order": {"signal": "sortorder"}
         }
       },
-      "rangeStep": {"signal": "cellSize"},
+      "range": {"step": {"signal": "cellSize"}},
       "padding": 0.5
     }
   ],

--- a/spec/nested-plot.vg.json
+++ b/spec/nested-plot.vg.json
@@ -137,7 +137,7 @@
           "paddingOuter": {"signal": "outerPadding"},
           "round": true,
           "domain": {"data": "faceted_tuples", "field": "b"},
-          "rangeStep": {"signal": "rangeStep"}
+          "range": {"step": {"signal": "rangeStep"}}
         }
       ],
 


### PR DESCRIPTION
Beta release of v3.0.0-beta.16

**Breaking changes**
- Move scale `rangeStep` property to a nested range.step property (`"range": {"step": 20}`).

Other changes:
- Add range scheme `count` to discretize color schemes for quantile and quantize scales (`"range":{"scheme": "plasma", "count": 7}`).
- Add support to include raw domain value arrays (or array-valued signals) in multi-domain scale definitions (For example: `"domain": {"fields": [{"data": "table", "field": "foo"}, ["a", "b", "c"], {"signal": "values"}]}`)
- Update legend label formatting to show value ranges for quantile, quantize and threshold scales.
- Update example specs to track changes.