### PR TITLE
v3.0.0-beta.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "vega-force": ">=1.0.0-beta",
     "vega-geo": ">=1.0.0-beta",
     "vega-hierarchy": ">=1.0.0-beta",
-    "vega-loader": ">=2.0.0-beta.3",
+    "vega-loader": ">=2.0.0-beta.4",
     "vega-parser": ">=1.0.0-beta",
     "vega-runtime": ">=1.0.0-beta",
     "vega-scale": ">=2.0.0-beta",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vega",
-  "version": "3.0.0-beta.18",
+  "version": "3.0.0-beta.19",
   "description": "The Vega visualization grammar.",
   "keywords": [
     "vega",

--- a/spec/nested-plot.vg.json
+++ b/spec/nested-plot.vg.json
@@ -143,7 +143,7 @@
 
       "axes": [
         { "orient": "left", "scale": "yscale",
-          "tick": false, "domain": false, "labelPadding": 4 }
+          "ticks": false, "domain": false, "labelPadding": 4 }
       ],
 
       "marks": [


### PR DESCRIPTION
Beta release of v3.0.0-beta.19

**Breaking changes**:
- Standardize naming for Vega spec, config and encode properties for axis ticks and labels: inclusion flags and encode blocks now all use the plural forms `"ticks"` and `"labels"`. Note that `"grid"` and `"title"` properties remain singular and so are unchanged.

Other changes:
- Fix bounds calculation bugs.
- Fix vega-loader version in dependencies.