### PR TITLE
Center images instead of left aligning (better for large screens)

### DIFF
--- a/docs/assets/main.css
+++ b/docs/assets/main.css
@@ -415,8 +415,7 @@ ul.column-set, .column-set ul {
   box-shadow: 0px 8px 16px rgba(0,0,0,0.3);
 }
 #showcase .examples {
-  position: absolute;
-  left: -30px;
+  margin: 0 auto;
   height: 300px;
   width: 1440px;
   line-height: 0;


### PR DESCRIPTION
<img width="789" alt="screen shot 2017-04-14 at 12 38 12" src="https://cloud.githubusercontent.com/assets/589034/25053999/9d2e4a4e-210f-11e7-956e-5f18b0418ef5.png">
<img width="1672" alt="screen shot 2017-04-14 at 12 38 02" src="https://cloud.githubusercontent.com/assets/589034/25054004/9ffbcd8c-210f-11e7-86ea-fcbd41c9a6d2.png">
