### PR TITLE
v3.0.0-beta.36

### DIFF
--- a/docs/docs/axes.md
+++ b/docs/docs/axes.md
@@ -19,13 +19,11 @@ Properties for specifying a coordinate axis.
 | format        | {% include type t="String" %}  | The format specifier pattern for axis labels. For numerical values, must be a legal [d3-format](https://github.com/d3/d3-format#locale_format) specifier. For date-time values, must be a legal [d3-time-format](https://github.com/d3/d3-time-format#locale_format) specifier.|
 | grid          | {% include type t="Boolean" %} | A boolean flag indicating if grid lines should be included as part of the axis (default `false`).|
 | gridScale     | {% include type t="String" %}  | The name of the scale to use for including grid lines. By default grid lines are driven by the same scale as the ticks and labels.|
-| interactive   | {% include type t="Boolean" %} | A boolean flag indicating if axis elements should respond to input events such as mouse hover.|
 | labels        | {% include type t="Boolean" %} | A boolean flag indicating if labels should be included as part of the axis (default `true`).|
 | labelPadding  | {% include type t="Number" %}  | The padding in pixels between labels and ticks.|
 | labelOverlap  | {% include type t="Boolean|String" %}  | The strategy to use for resolving overlap of axis labels. If `false` (the default), no overlap reduction is attempted. If set to `true` or `"parity"`, a strategy of removing every other label is used (this works well for standard linear axes). If set to `"greedy"`, a linear scan of the labels is performed, removing any labels that overlaps with the last visible label (this often works better for log-scaled axes).|
 | minExtent     | {% include type t="Number|Value" %} | The minimum extent in pixels that axis ticks and labels should use. This determines a minimum offset value for axis titles.|
 | maxExtent     | {% include type t="Number|Value" %} | The maximum extent in pixels that axis ticks and labels should use. This determines a maximum offset value for axis titles.|
-| name          | {% include type t="String" %}  | A [mark name](../marks) property to apply to the axis group.|
 | offset        | {% include type t="Number|Value" %} | The orthogonal offset in pixels by which to displace the axis from its position along the edge of the chart.|
 | position      | {% include type t="Number|Value" %} | The anchor position of the axis in pixels (default `0`). For x-axes with top or bottom orientation, this sets the axis group `x` coordinate. For y-axes with left or right orientation, this sets the axis group `y` coordinate.|
 | ticks         | {% include type t="Boolean" %} | A boolean flag indicating if ticks should be included as part of the axis (default `true`).|

--- a/docs/docs/legends.md
+++ b/docs/docs/legends.md
@@ -24,8 +24,6 @@ Properties for specifying a legend. Legends accept one or more [scales](../scale
 | encode        | {% include type t="Object" %}  | Optional mark encodings for custom legend styling. Supports encoding blocks for `legend`, `title`, `labels`, `symbols` and `gradient`. See [custom legend encodings](#custom). |
 | entryPadding  | {% include type t="Number|Value" %} | The padding between entries in a symbol legend.|
 | format        | {% include type t="String" %}  | The format specifier pattern for legend labels. For numerical values, must be a legal [d3-format](https://github.com/d3/d3-format#locale_format) specifier. For date-time values,  must be a legal [d3-time-format](https://github.com/d3/d3-time-format#locale_format) specifier.|
-| interactive   | {% include type t="Boolean" %} | A boolean flag indicating if axis elements should respond to input events such as mouse hover.|
-| name          | {% include type t="String" %}  | A [mark name](../marks) property to apply to the legend group.|
 | offset        | {% include type t="Number|Value" %} | The offset in pixels by which to displace the legend from the data rectangle and axes.|
 | padding       | {% include type t="Number|Value" %} | The padding between the border and content of the legend group.|
 | tickCount     | {% include type t="Number" %}  | The desired number of tick values for quantitative legends.|

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vega",
-  "version": "3.0.0-beta.35",
+  "version": "3.0.0-beta.36",
   "description": "The Vega visualization grammar.",
   "keywords": [
     "vega",

--- a/test/specs-valid/chart-rangestep.vg.json
+++ b/test/specs-valid/chart-rangestep.vg.json
@@ -174,11 +174,11 @@
     {
       "shape": "innerScale",
       "orient": "bottom-right",
-      "interactive": true,
       "offset": 6,
       "padding": 4,
       "encode": {
         "legend": {
+          "interactive": true,
           "enter": {
             "cursor": {"value": "crosshair"},
             "fill": {"value": "#fff"},

--- a/test/specs-valid/chart.vg.json
+++ b/test/specs-valid/chart.vg.json
@@ -194,11 +194,11 @@
     {
       "shape": "innerScale",
       "orient": "bottom-right",
-      "interactive": true,
       "offset": 6,
       "padding": 4,
       "encode": {
         "legend": {
+          "interactive": true,
           "enter": {
             "fill": {"value": "#fff"},
             "fillOpacity": {"value": 0.5},

--- a/test/specs-valid/scatter-plot-guides.vg.json
+++ b/test/specs-valid/scatter-plot-guides.vg.json
@@ -195,7 +195,8 @@
         "enter": {
           "x": {"value": 0},
           "height": {"value": 35},
-          "fill": {"value": "transparent"}
+          "fill": {"value": "transparent"},
+          "cursor": {"value": "ew-resize"}
         },
         "update": {
           "y": {"signal": "height"},

--- a/yarn.lock
+++ b/yarn.lock
@@ -1290,10 +1290,6 @@ path-is-inside@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
 
-path-parse@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
-
 path-type@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"
@@ -1449,15 +1445,9 @@ resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
 
-resolve@1.1.7, resolve@~1.1.7:
+resolve@1.1.7, resolve@^1.1.5, resolve@^1.1.6, resolve@~1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
-
-resolve@^1.1.5, resolve@^1.1.6:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.3.tgz#655907c3469a8680dc2de3a275a8fdd69691f0e5"
-  dependencies:
-    path-parse "^1.0.5"
 
 restore-cursor@^1.0.1:
   version "1.0.1"
@@ -1804,8 +1794,8 @@ vega-crossfilter@>=1.0.0-beta:
     vega-util "1"
 
 vega-dataflow@>=2.0.0-beta, vega-dataflow@>=2.0.0-beta.27, vega-dataflow@>=2.0.0-beta.4:
-  version "2.0.0-beta.29"
-  resolved "https://registry.yarnpkg.com/vega-dataflow/-/vega-dataflow-2.0.0-beta.29.tgz#b23a99538d67f8d402e972de78d0508a6165aae7"
+  version "2.0.0-beta.30"
+  resolved "https://registry.yarnpkg.com/vega-dataflow/-/vega-dataflow-2.0.0-beta.30.tgz#9422e883ce1d32826ef94f87dbed0d2698ff30c5"
   dependencies:
     d3-array "1"
     vega-loader ">=2.0.0-beta"
@@ -1874,8 +1864,8 @@ vega-loader@>=2.0.0-beta, vega-loader@>=2.0.0-beta.5:
     vega-util "1"
 
 vega-parser@>=1.0.0-beta:
-  version "1.0.0-beta.65"
-  resolved "https://registry.yarnpkg.com/vega-parser/-/vega-parser-1.0.0-beta.65.tgz#0d3bc3e9ba0c821265fd4f6e0e98aa9391acd07c"
+  version "1.0.0-beta.66"
+  resolved "https://registry.yarnpkg.com/vega-parser/-/vega-parser-1.0.0-beta.66.tgz#bceaa60ac53f1cc84fc6880f6fcfc3f6de0d7f1d"
   dependencies:
     d3-array "1"
     d3-color "1"


### PR DESCRIPTION
**Breaking changes**:
- Removed axis/legend `name` and `interactive` properties.

Changes:
- Added support for `name` and `interactive` properties to custom encoders for top-level axis and legend groups.
- Update schema, examples, and documentation.
- Fix `Formula` transform to not mark field as modified if `initonly` parameter is set.