### PR TITLE
Update county-unemployment.vg.json

### DIFF
--- a/docs/examples/county-unemployment.vg.json
+++ b/docs/examples/county-unemployment.vg.json
@@ -32,8 +32,7 @@
     {
       "name": "color",
       "type": "quantize",
-      "domain": {"data":"counties", "field": "rate"},
-      "domainMax": 0.22,
+      "domain": [0, 0.15],
       "range": {"scheme": "blues-9"}
     }
   ],

--- a/docs/examples/county-unemployment.vg.json
+++ b/docs/examples/county-unemployment.vg.json
@@ -15,8 +15,8 @@
       "url": "data/us-10m.json",
       "format": {"type": "topojson", "feature": "counties"},
       "transform": [
-        { "type": "lookup", "from": "unemp", "key": "id", "fields": ["id"], "as": ["unemp"] },
-        { "type": "filter", "expr": "datum.unemp != null" }
+        { "type": "lookup", "from": "unemp", "key": "id", "fields": ["id"], "values": ["rate"] },
+        { "type": "filter", "expr": "datum.rate != null" }
       ]
     }
   ],
@@ -32,7 +32,8 @@
     {
       "name": "color",
       "type": "quantize",
-      "domain": [0, 0.15],
+      "domain": {"data":"counties", "field": "rate"},
+      "domainMax": 0.22,
       "range": {"scheme": "blues-9"}
     }
   ],
@@ -60,8 +61,8 @@
       "type": "shape",
       "from": {"data": "counties"},
       "encode": {
-        "enter": { "tooltip": {"signal": "format(datum.unemp.rate, '0.1%')"}},
-        "update": { "fill": {"scale": "color", "field": "unemp.rate"} },
+        "enter": { "tooltip": {"signal": "format(datum.rate, '0.1%')"}},
+        "update": { "fill": {"scale": "color", "field": "rate"} },
         "hover": { "fill": {"value": "red"} }
       },
       "transform": [


### PR DESCRIPTION
use specific value lookup - makes tooltip more useful, and allows for scale to use the value directly