### PR TITLE
Rename joy plot to ridgeline plot

### DIFF
--- a/docs/examples/u-district-cuisine.md
+++ b/docs/examples/u-district-cuisine.md
@@ -5,6 +5,6 @@ permalink: /examples/u-district-cuisine/index.html
 spec: u-district-cuisine
 ---
 
-A [joy plot](http://blog.revolutionanalytics.com/2017/07/joyplots.html) showing the prevalence of various food and beverage categories in Seattle's University District. One never has to go far for coffee! Similar to a [violin plot](../violin-plot), this plot uses a continuous approximation of discrete data computed using [kernel density estimation (KDE)](https://en.wikipedia.org/wiki/Kernel_density_estimation). This graphic originally appeared in [Alaska Airlines Beyond Magazine (Sep 2017, p. 120)](http://www.paradigmcg.com/digitaleditions/abm-0917/html5/).
+A [ridgeline plot](http://blog.revolutionanalytics.com/2017/07/joyplots.html) showing the prevalence of various food and beverage categories in Seattle's University District. One never has to go far for coffee! Similar to a [violin plot](../violin-plot), this plot uses a continuous approximation of discrete data computed using [kernel density estimation (KDE)](https://en.wikipedia.org/wiki/Kernel_density_estimation). This graphic originally appeared in [Alaska Airlines Beyond Magazine (Sep 2017, p. 120)](http://www.paradigmcg.com/digitaleditions/abm-0917/html5/).
 
 {% include example spec=page.spec %}


### PR DESCRIPTION
As per http://serialmentor.com/blog/2017/9/15/goodbye-joyplots:

> Unfortunately, when the name “joyplot” took off, nobody in the datascience community was aware of the origin of the name “Joy Division”. As described in the book House of Dolls, joy divisions were groups of Jewish women in Nazi concentration camps kept for the sexual pleasure of soldiers. The band Joy Division took their name directly from this book and even quoted from the book in one of their early songs.
>
> Thus, as joyful as the name “joyplot” sounds to the uninformed, its history is rather dark, and we would do better using a different name. For this reason, I have decided to now call these plots “ridgeline plots”. Indeed, from day one, the ggjoy package contained a geom_ridgeline(), so I’m just keeping in this tradition.