### PR TITLE
Use Vega datasets from npm so it can be cached.

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "vega-crossfilter": "2",
     "vega-dataflow": "3",
-    "vega-datasets": "vega/vega-datasets#gh-pages",
+    "vega-datasets": "1",
     "vega-encode": "2",
     "vega-expression": "2",
     "vega-force": "2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2233,9 +2233,9 @@ vega-dataflow@3:
     vega-loader "2"
     vega-util "1"
 
-vega-datasets@vega/vega-datasets#gh-pages:
+vega-datasets@1:
   version "1.10.0"
-  resolved "https://codeload.github.com/vega/vega-datasets/tar.gz/7080ba8297825d27495bdfb8386d10cff83cbacf"
+  resolved "https://registry.yarnpkg.com/vega-datasets/-/vega-datasets-1.10.0.tgz#fe923df5aa3828eeb350b5e710a79936a25f29f0"
 
 vega-encode@2:
   version "2.0.5"


### PR DESCRIPTION
See https://github.com/jupyterlab/jupyter-renderers/pull/15#issuecomment-340522499