### PR TITLE
Fix schema deployment script

### DIFF
--- a/bin/deploy-schema.sh
+++ b/bin/deploy-schema.sh
@@ -9,7 +9,9 @@ pushd ../schema/vega/
 git checkout master
 git pull
 
+rm -f v$version.json
 cp ../../vega/build/vega-schema.json v$version.json
+echo "Copied schema to v$version.json"
 
 prefix=$version
 while echo "$prefix" | grep -q '\.'; do


### PR DESCRIPTION
cp does not overwrite symlinks. When we had alpha, beta, or rc versions, we created a symlink for `v3.0.0.json` and so we ended up without a schema file for version 3.0.0. I will fix that one schema manually.