### PR TITLE
Make canvas a peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ folder. The last command launches a local webserver. Now, you can open
 [`http://127.0.0.1:4000/vega/`](http://127.0.0.1:4000/vega/) to see the
 website.
 
+### Peer Dependencies and Optional Dependencies
+
+If you require HTML5 Canvas support and are targetting an environment which does not natively support HTML5 Canvas (eg: [Node.js](https://nodejs.org/en/)), Vega provides support for this feature via a third-party node dependency called [`canvas`](https://www.npmjs.com/package/canvas).
+
+A prebuilt version of canvas (called [`canvas-prebuilt`](https://www.npmjs.com/package/canvas-prebuilt)) is installed as an [optional dependency](https://docs.npmjs.com/files/package.json#optionaldependencies). This dependency can be omitted during installation if it is not required by using `npm install --no-optional` or `yarn install --ignore-optional`.
+
+If you need to build canvas from source for your target environment then you will need to opt-in explicitly by installing the [peer dependency](https://docs.npmjs.com/files/package.json#peerdependencies) [`canvas`](https://www.npmjs.com/package/canvas).
+
 ## Development Setup
 
 For a more advanced development setup in which you will be working on multiple

--- a/package.json
+++ b/package.json
@@ -86,8 +86,10 @@
     "vega-wordcloud": "^2.1",
     "yargs": "4"
   },
+  "peerDependencies": {
+    "canvas": "^1.6"
+  },
   "optionalDependencies": {
-    "canvas": "^1.6",
     "canvas-prebuilt": "^1.6"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -204,12 +204,6 @@ canvas-prebuilt@^1.6:
   dependencies:
     node-pre-gyp "^0.6.29"
 
-canvas@^1.6:
-  version "1.6.9"
-  resolved "https://registry.yarnpkg.com/canvas/-/canvas-1.6.9.tgz#e3f95cec7b16bf2d6f3fc725c02d940d3258f69b"
-  dependencies:
-    nan "^2.4.0"
-
 caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
@@ -1265,7 +1259,7 @@ mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
-nan@^2.0.5, nan@^2.4.0:
+nan@^2.0.5:
   version "2.9.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.9.2.tgz#f564d75f5f8f36a6d9456cca7a6c4fe488ab7866"
 


### PR DESCRIPTION
__Description:__

This PR changes the npm dependency of `canvas` from an optional dependency to a peer dependency.

The motivation behind this change is to mitigate installations from failing (particularly in build environments / CI environments) when the underlying dependencies that `canvas` post-install script requires to compile are not available.

While optional dependencies are not supposed to fail the installation, we have seen several instances within our own builds, as well as these [other](https://github.com/npm/npm/issues/14185#issuecomment-264879789) documented cases, where this is not the case for this particular dependency.

__What's Changed?__

- Updated `package.json` to include `canvas` as an **opt-in** peer-dependency
- Updated the `README.md` with a section on Peer Dependencies and Optional Dependencies in order to communicate the change and what uses need to do if they wish to not use `canvas-prebuilt`.