### PR TITLE
Enable resolution scale factor in vg2png

### DIFF
--- a/bin/vg2png
+++ b/bin/vg2png
@@ -19,8 +19,13 @@ var path = require('path'),
 var args = require('yargs')
   .usage(helpText)
   .demand(0)
-  .string('b').alias('b', 'base')
-  .describe('b', 'Base directory for data loading.')
+  .string('b')
+    .alias('b', 'base')
+    .describe('b', 'Base directory for data loading.')
+  .number('s')
+    .alias('s', 'scale')
+    .default('s', 1)
+    .describe('s', 'Output resolution scale factor.')
   .help()
   .version()
   .argv;
@@ -53,7 +58,7 @@ function render(spec) {
       renderer: 'none'
     })
     .initialize()
-    .toCanvas()
+    .toCanvas(args.s)
     .then(function(canvas) { writePNG(canvas, outputFile); })
     .catch(function(err) { console.error(err); });
 }

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -141,12 +141,13 @@ Note that a polyfill is necessary only for Internet Explorer support. Recent ver
 
 Vega includes two node.js-based command line utilities &ndash; `vg2png` and `vg2svg` &ndash; for rendering static visualization images. These commands render to PNG or SVG images, respectively.
 
-- **vg2png**: `vg2png [-b basedir] vega_json_file [output_png_file]`
+- **vg2png**: `vg2png [-b basedir] [-s scalefactor] vega_json_file [output_png_file]`
 - **vg2svg**: `vg2svg [-b basedir] [-h] vega_json_file [output_svg_file]`
 
 If no output file is given, the resulting PNG or SVG data will be written to standard output, and so can be piped into other applications. The programs also accept the following (optional) parameters:
 
 * __-b__, __--base__ - [String] A base directory to use for data and image loading. For web retrieval, use `-b http://host/data/`. For files, use `-b file:///dir/data/` (absolute path) or `-b data/` (relative path).
+* __-s__, __--scale__ - [Number] [Default:1] For png output, a resolution scale factor.  For example, `-s 2` results in a doubling of the output resolution.
 * __-h__, __--header__ - [Flag] Includes XML header and DOCTYPE in SVG output (vg2svg only).
 
 Within the Vega project directories, you can use `./bin/vg2png` or `./bin/vg2svg`. If you import Vega using npm, the commands are accessible either locally (`./node_modules/bin/vg2png`) or globally (`vg2png`) depending on how you install the Vega package. The `vg2png` utility requires that the optional [node-canvas](https://github.com/Automattic/node-canvas) dependency is installed. See below for more [information about Vega and node-canvas](#node-canvas).
@@ -177,6 +178,12 @@ Render the arc example to SVG and pipe through svg2pdf (requires [svg2pdf](http:
 
 ```
 bin/vg2svg spec/arc.vg.json | svg2pdf > arc.pdf
+```
+
+Render the bar chart example to a PNG file at double resolution:
+
+```
+bin/vg2png -s 2 spec/bar.vg.json bar.png
 ```
 
 [Back to reference](#reference)


### PR DESCRIPTION
This should fix #528.

I have tested on mac and using the following Docker image:

```
FROM node:latest

RUN npm config set unsafe-perm true

RUN npm install -g vega
RUN npm install -g vega-lite

COPY vg2png /tmp/
RUN cp /tmp/vg2png /usr/local/bin/vg2png && rm -f /tmp/vg2png

ENTRYPOINT ["vl2png"]
```

```
docker build . -t vg2_1
docker run --rm -v `pwd`:/tmp vg2_1 tmp/chart.json -s4 > chart.png
```

For future reference:  I had some issues with misalignment of the text in the output with the axes.  This was due to using `libpango1.0-dev` rather than `libpango1.0-0`.  

To use the changes made in this PR in `vl2png` you would use:

`vl2png chart.json -s 2 chart.png`

I considered updating vl2png so that it could be called like `vl2png -s2 chart.json chart.png` but I don't have much experience with bash, and parsing arguments seemed to [add a lot of complexity](https://stackoverflow.com/questions/192249/how-do-i-parse-command-line-arguments-in-bash).

If this solution makes sense, we could add a similar thing [here](https://github.com/altair-viz/altair/blob/92e9de8ddaae05a57137ba2491a45a110622eb01/altair/utils/headless.py#L73) in altair.

Do let me know if this PR is naive/way off base - it's my first contribution so entirely possible I've missed something obvious.