### PR TITLE
Implement documentation version tagging

### DIFF
--- a/docs/_includes/tag
+++ b/docs/_includes/tag
@@ -1,0 +1,1 @@
+<span class="tag version" title="Requires version {{ include.ver }} or later">≥&nbsp;{{ include.ver }}</span>

--- a/docs/assets/main.css
+++ b/docs/assets/main.css
@@ -555,6 +555,20 @@ nav > .dropdown:hover a:hover {
   color: #000;
 }
 
+.tag {
+  border-radius: 2px;
+  box-sizing: border-box;
+  display: inline-block;
+  font-weight: 600;
+  line-height: 15px;
+  padding: 0.15em 0.3em;
+}
+
+.tag.version {
+  background-color: #0078a0;
+  color: #ffffff;
+}
+
 /* Media queries */
 @media (max-width:768px) {
   body {

--- a/docs/docs/event-streams.md
+++ b/docs/docs/event-streams.md
@@ -53,7 +53,7 @@ The supported DOM event types for mark items are:
 
 Other event types supported by the browser (e.g., [`resize`](https://developer.mozilla.org/en-US/docs/Web/Events/resize) events on the window object) may be captured from DOM elements on the same web page as the Vega visualization. The list above applies _only_ to mark items contained within the Vega view's scenegraph.
 
-In addition, Vega supports a `timer` event, which fires a new event at a specified time interval (in milliseconds) determined by the event stream _throttle_ property.
+In addition, Vega supports a `timer` event, which fires a new event at a specified time interval (in milliseconds) determined by the event stream _throttle_ property. {% include tag ver="4.0" %}
 
 
 ## <a name="object"></a>Event Stream Objects


### PR DESCRIPTION
This allows all new features in documentation
to be tagged with the minimum required version.

Includes one example usage for the event timer.
![image](https://user-images.githubusercontent.com/1641515/42473523-dfc94598-8392-11e8-93ee-9cebda649558.png)

To use:   `{% include tag ver="4.0" %}`

Eventually the template should be expanded to support
deprecations, and possibly other warnings.