### PR TITLE
Added missing 'property' parameter for topojson

### DIFF
--- a/docs/docs/data.md
+++ b/docs/docs/data.md
@@ -81,6 +81,7 @@ Load a JavaScript Object Notation (JSON) file using the [TopoJSON](https://githu
 | :------------ | :---------------------------: | :------------- |
 | feature       | {% include type t="String" %} | The name of the TopoJSON object set to convert to a GeoJSON feature collection. For example, in a map of the world, there may be an object set named `"countries"`. Using the feature property, we can extract this set and generate a GeoJSON feature object for each country.|
 | mesh          | {% include type t="String" %} | The name of the TopoJSON object set to convert to a mesh. Similar to the _feature_ option, _mesh_ extracts a named TopoJSON object set. Unlike the _feature_ option, the corresponding geo data is returned as a single, unified mesh instance, not as individual GeoJSON features. Extracting a mesh is useful for more efficiently drawing borders or other geographic elements that you do not need to associate with specific regions such as individual countries, states or counties.|
+| property      | {% include type t="String" %} | The JSON property containing the desired data. Similar to [type=json](#json), this optional parameter can be used when the loaded TopoJSON data has surrounding structure or meta-data. |
 
 
 ## <a name="examples"></a>Examples


### PR DESCRIPTION
Seems like type=topojson supports the `property` parameter, but doesn't document it.