### PR TITLE
Split Data type into separate dataset definitions in vega-typings

### DIFF
--- a/packages/vega-typings/types/spec/data.d.ts
+++ b/packages/vega-typings/types/spec/data.d.ts
@@ -30,20 +30,25 @@ export type FormatTopoJSON = {
       mesh?: 'string';
     });
 export type Format = FormatJSON | FormatSV | FormatDSV | FormatTopoJSON | { parse: Parse };
-export type Data = (
-  | {
-      source: string;
-    }
-  | {
-      values: Datum[];
-    }
-  | {
-      url: string | SignalRef;
-    }
-  | {}) & {
+
+export interface BaseData {
   name: string;
   on?: OnTrigger[];
   format?: Format | SignalRef;
   transform?: Transform[];
-};
+}
+
+export type SourceData = {
+  source: string;
+} & BaseData;
+
+export type ValuesData = {
+  values: Datum[];
+} & BaseData;
+
+export type UrlData = {
+  url: string | SignalRef;
+} & BaseData;
+
+export type Data = SourceData | ValuesData | UrlData | BaseData;
 export type Datum = any;


### PR DESCRIPTION
Hello! In https://github.com/vega/lyra/pull/416#issuecomment-443005618 we found that when we use the `Data` type definition, Typescript complains when we reference properties specific to a subtype, like `source` or `values` or `url`. This change splits `Data` into a union of separate type definitions so that we can use type guards to narrow the type later on.

cc @arvind 