### PR TITLE
Add support for rel attribute in href links.

### DIFF
--- a/packages/vega-loader/src/loader.js
+++ b/packages/vega-loader/src/loader.js
@@ -116,6 +116,11 @@ function sanitize(uri, options) {
       result.target = options.target + '';
     }
 
+    // set default result rel, if specified (#1542)
+    if (options.rel) {
+      result.rel = options.rel + '';
+    }
+
     // return
     accept(result);
   });


### PR DESCRIPTION
Changes:

**vega-loader**
- Copy `rel` loader option to the `sanitize` result. The scenegraph handler will copy this over as an HTML `rel` attribute of a generated `a` element. (Fix #1542)