### PR TITLE
Add labelSeparation property for axes and legends.

### DIFF
--- a/packages/vega-parser/src/parsers/guides/axis-labels.js
+++ b/packages/vega-parser/src/parsers/guides/axis-labels.js
@@ -25,7 +25,8 @@ export default function(spec, config, userEncode, dataRef, size) {
       labelAlign = lookup('labelAlign', spec, config),
       labelBaseline = lookup('labelBaseline', spec, config),
       zero = {value: 0},
-      encode, enter, tickSize, tickPos, align, baseline, offset, bound, overlap;
+      encode, enter, tickSize, tickPos, align, baseline, offset,
+      bound, overlap, separation;
 
   tickSize = encoder(size);
   tickSize.mult = sign;
@@ -89,15 +90,17 @@ export default function(spec, config, userEncode, dataRef, size) {
   addEncode(encode, 'fillOpacity', lookup('labelOpacity', spec, config));
   bound   = lookup('labelBound', spec, config);
   overlap = lookup('labelOverlap', spec, config);
+  separation = lookup('labelSeparation', spec, config);
 
   spec = guideMark(TextMark, AxisLabelRole, GuideLabelStyle, Value, dataRef, encode, userEncode);
 
   // if overlap method or bound defined, request label overlap removal
   if (overlap || bound) {
     spec.overlap = {
+      separation: separation,
       method: overlap,
-      order:  'datum.index',
-      bound:  bound ? {scale: scale, orient: orient, tolerance: bound} : null
+      order: 'datum.index',
+      bound: bound ? {scale: scale, orient: orient, tolerance: bound} : null
     };
   }
 

--- a/packages/vega-parser/src/parsers/guides/legend-gradient-labels.js
+++ b/packages/vega-parser/src/parsers/guides/legend-gradient-labels.js
@@ -18,6 +18,7 @@ export default function(spec, config, userEncode, dataRef) {
       thickness = encoder(gradientThickness(spec, config)),
       length = gradientLength(spec, config),
       overlap = lookup('labelOverlap', spec, config),
+      separation = lookup('labelSeparation', spec, config),
       encode, enter, update, u, v, adjust = '';
 
   encode = {
@@ -55,6 +56,12 @@ export default function(spec, config, userEncode, dataRef) {
   thickness.offset = value(spec.labelOffset, config.gradientLabelOffset) || 0;
 
   spec = guideMark(TextMark, LegendLabelRole, GuideLabelStyle, Value, dataRef, encode, userEncode);
-  if (overlap) spec.overlap = {method: overlap, order:  'datum.' + Index};
+  if (overlap) {
+    spec.overlap = {
+      separation: separation,
+      method: overlap,
+      order: 'datum.' + Index
+    };
+  }
   return spec;
 }

--- a/packages/vega-parser/src/parsers/mark.js
+++ b/packages/vega-parser/src/parsers/mark.js
@@ -137,9 +137,11 @@ export default function(spec, scope) {
 
 function parseOverlap(overlap, source, scope) {
   var method = overlap.method,
-      bound = overlap.bound, tol;
+      bound = overlap.bound,
+      sep = overlap.separation, tol;
 
   var params = {
+    separation: isSignal(sep) ? scope.signalRef(sep.signal) : sep,
     method: isSignal(method) ? scope.signalRef(method.signal) : method,
     pulse:  source
   };

--- a/packages/vega-schema/src/axis.js
+++ b/packages/vega-schema/src/axis.js
@@ -105,6 +105,7 @@ const axis = object({
   labelLimit: numberValue,
   labelOpacity: numberValue,
   labelPadding: numberValue,
+  labelSeparation: numberOrSignal,
 
   // CUSTOMIZED ENCODERS
   encode: object({

--- a/packages/vega-schema/src/legend.js
+++ b/packages/vega-schema/src/legend.js
@@ -111,6 +111,7 @@ const legendProps = object({
   labelOffset: numberValue,
   labelOpacity: numberValue,
   labelOverlap: labelOverlapRef,
+  labelSeparation: numberOrSignal,
 
   // CUSTOMIZED ENCODERS
   encode: object({

--- a/packages/vega/test/specs-valid/contour-map.vg.json
+++ b/packages/vega/test/specs-valid/contour-map.vg.json
@@ -109,7 +109,7 @@
       "scales": [
         {
           "name": "color",
-          "type": "sequential",
+          "type": "linear",
           "domain": {"data": "contours", "field": "value"},
           "range": {"scheme": "viridis"}
         }

--- a/packages/vega/test/specs-valid/contour-scatter.vg.json
+++ b/packages/vega/test/specs-valid/contour-scatter.vg.json
@@ -92,7 +92,7 @@
       "scales": [
         {
           "name": "color",
-          "type": "sequential",
+          "type": "linear",
           "domain": {"data": "contours", "field": "value"},
           "range": "ramp"
         }

--- a/packages/vega/test/specs-valid/contour-volcano.vg.json
+++ b/packages/vega/test/specs-valid/contour-volcano.vg.json
@@ -33,7 +33,7 @@
   "scales": [
     {
       "name": "color",
-      "type": "sequential",
+      "type": "linear",
       "domain": [90, 190],
       "range": "heatmap"
     }

--- a/packages/vega/test/specs-valid/flush-axis-labels.vg.json
+++ b/packages/vega/test/specs-valid/flush-axis-labels.vg.json
@@ -14,6 +14,10 @@
       "bind": {"input": "select", "options": [true, false, "parity", "greedy"]}
     },
     {
+      "name": "labelSeparation", "value": 0,
+      "bind": {"input": "range", "min": -10, "max": 30, "step": 1}
+    },
+    {
       "name": "labelBound", "value": -1,
       "bind": {"input": "range", "min": -1, "max": 30, "step": 1}
     },
@@ -63,6 +67,7 @@
       "format": "s",
       "labelFlush": {"signal": "labelFlush"},
       "labelFlushOffset": {"signal": "labelFlushOffset"},
+      "labelSeparation": {"signal": "labelSeparation"},
       "labelOverlap": {"signal": "labelOverlap"},
       "labelBound": {"signal": "labelBound"}
     },
@@ -71,6 +76,7 @@
       "scale": "backwardx",
       "labelFlush": {"signal": "labelFlush"},
       "labelFlushOffset": {"signal": "labelFlushOffset"},
+      "labelSeparation": {"signal": "labelSeparation"},
       "labelOverlap": {"signal": "labelOverlap"},
       "labelBound": {"signal": "labelBound"}
     },
@@ -80,6 +86,7 @@
       "format": "s",
       "labelFlush": {"signal": "labelFlush"},
       "labelFlushOffset": {"signal": "labelFlushOffset"},
+      "labelSeparation": {"signal": "labelSeparation"},
       "labelOverlap": {"signal": "labelOverlap"},
       "labelBound": {"signal": "labelBound"}
     },
@@ -88,6 +95,7 @@
       "scale": "backwardy",
       "labelFlush": {"signal": "labelFlush"},
       "labelFlushOffset": {"signal": "labelFlushOffset"},
+      "labelSeparation": {"signal": "labelSeparation"},
       "labelOverlap": {"signal": "labelOverlap"},
       "labelBound": {"signal": "labelBound"}
     }

--- a/packages/vega/test/specs-valid/gradient.vg.json
+++ b/packages/vega/test/specs-valid/gradient.vg.json
@@ -7,7 +7,7 @@
   "scales": [
     {
       "name": "color",
-      "type": "sequential",
+      "type": "linear",
       "range": {"scheme": "viridis"},
       "domain": [0, 100]
     }

--- a/packages/vega/test/specs-valid/heatmap.vg.json
+++ b/packages/vega/test/specs-valid/heatmap.vg.json
@@ -89,7 +89,7 @@
     },
     {
       "name": "color",
-      "type": "sequential",
+      "type": "linear",
       "range": {"scheme": {"signal": "palette"}},
       "domain": {"data": "temperature", "field": "temp"},
       "reverse": {"signal": "reverse"},

--- a/packages/vega/test/specs-valid/legends-continuous.vg.json
+++ b/packages/vega/test/specs-valid/legends-continuous.vg.json
@@ -7,14 +7,18 @@
       "offset": 5,
       "gradientDirection": "horizontal",
       "gradientLength": 300,
-      "labelOverlap": {"signal": "labelOverlap"}
+      "labelOverlap": {"signal": "labelOverlap"},
+      "labelSeparation": {"signal": "labelSeparation"}
     }
   },
 
   "signals": [
-    {"name": "labelOverlap", "value": true, "bind": {"input": "checkbox"}},
-    {"name": "seqScheme", "value": "purples"},
-    {"name": "linearRange", "value": ["purple", "orange"]}
+    { "name": "labelOverlap", "value": true,
+      "bind": {"input": "checkbox"} },
+    { "name": "labelSeparation", "value": 0,
+      "bind": {"input": "range", "min": -10, "max": 20, "step": 1} },
+    { "name": "seqScheme", "value": "purples" },
+    { "name": "linearRange", "value": ["purple", "orange"] }
   ],
 
   "data": [

--- a/packages/vega/test/specs-valid/legends.vg.json
+++ b/packages/vega/test/specs-valid/legends.vg.json
@@ -14,7 +14,7 @@
   "scales": [
     {
       "name": "sequence",
-      "type": "sequential",
+      "type": "linear",
       "range": {"scheme": "viridis"},
       "domain": [0, 100]
     },

--- a/packages/vega/test/specs-valid/tree-cluster.vg.json
+++ b/packages/vega/test/specs-valid/tree-cluster.vg.json
@@ -62,7 +62,7 @@
   "scales": [
     {
       "name": "color",
-      "type": "sequential",
+      "type": "linear",
       "range": {"scheme": "magma"},
       "domain": {"data": "tree", "field": "depth"},
       "zero": true

--- a/packages/vega/test/specs-valid/tree-radial.vg.json
+++ b/packages/vega/test/specs-valid/tree-radial.vg.json
@@ -97,7 +97,7 @@
   "scales": [
     {
       "name": "color",
-      "type": "sequential",
+      "type": "linear",
       "range": {"scheme": "magma"},
       "domain": {"data": "tree", "field": "depth"},
       "zero": true


### PR DESCRIPTION
Changes:

**vega**
- Update `flush-axis-labels` and `legend-continuous` test specs to use `labelSeparation`.
- Update test specs to use `linear` rather than `sequential` scale type.

**vega-parser**
- Add `labelSeparation` property for axes and legends. (#1507)

**vega-schema**
- Add axis/legend `labelSeparation` property to schema. (#1507)

**vega-view-transforms**
- Update `Overlap` transform to support separation parameter. (#1507)
