### PR TITLE
Update typing tests

### DIFF
--- a/packages/vega-typings/package.json
+++ b/packages/vega-typings/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "format": "prettier $([ \"$CI\" = true ] && echo --list-different || echo --write) './**/*.{ts,tsx,js,json,css}'",
     "build-tests": "./build-tests.sh",
+    "pretest": "npm run build-tests",
     "test": "dtslint ."
   },
   "dependencies": {

--- a/packages/vega-typings/tests/spec/valid/contour-map.ts
+++ b/packages/vega-typings/tests/spec/valid/contour-map.ts
@@ -112,7 +112,7 @@ export const spec: Spec = {
       "scales": [
         {
           "name": "color",
-          "type": "sequential",
+          "type": "linear",
           "domain": {"data": "contours", "field": "value"},
           "range": {"scheme": "viridis"}
         }

--- a/packages/vega-typings/tests/spec/valid/contour-scatter.ts
+++ b/packages/vega-typings/tests/spec/valid/contour-scatter.ts
@@ -95,7 +95,7 @@ export const spec: Spec = {
       "scales": [
         {
           "name": "color",
-          "type": "sequential",
+          "type": "linear",
           "domain": {"data": "contours", "field": "value"},
           "range": "ramp"
         }

--- a/packages/vega-typings/tests/spec/valid/contour-volcano.ts
+++ b/packages/vega-typings/tests/spec/valid/contour-volcano.ts
@@ -36,7 +36,7 @@ export const spec: Spec = {
   "scales": [
     {
       "name": "color",
-      "type": "sequential",
+      "type": "linear",
       "domain": [90, 190],
       "range": "heatmap"
     }

--- a/packages/vega-typings/tests/spec/valid/dynamic-format.ts
+++ b/packages/vega-typings/tests/spec/valid/dynamic-format.ts
@@ -1,0 +1,87 @@
+import { Spec } from 'vega';
+
+// https://vega.github.io/editor/#/examples/vega/bar-chart
+export const spec: Spec = {
+  "$schema": "https://vega.github.io/schema/vega/v4.json",
+  "width": 400,
+  "height": 200,
+  "padding": 5,
+
+  "signals": [
+    {
+      "name": "property", "value": "a",
+      "bind": {"input": "select", "options": ["a", "b"]}
+    }
+  ],
+
+  "data": [
+    {
+      "name": "table",
+      "format": {
+        "type": "json",
+        "property": {"signal": "property"}
+      },
+      "values": {
+        "a": [
+          {"u": 1, "v": 28}, {"u":  2, "v": 55},
+          {"u": 3, "v": 43}, {"u":  4, "v": 91},
+          {"u": 5, "v": 81}, {"u":  6, "v": 53},
+          {"u": 7, "v": 19}, {"u":  8, "v": 87},
+          {"u": 9, "v": 52}, {"u": 10, "v": 48}
+        ],
+        "b": [
+          {"u": 1, "v": 24}, {"u":  2, "v": 49},
+          {"u": 3, "v": 87}, {"u":  4, "v": 66},
+          {"u": 5, "v": 17}, {"u":  6, "v": 27},
+          {"u": 7, "v": 68}, {"u":  8, "v": 16},
+          {"u": 9, "v": 49}, {"u": 10, "v": 15}
+        ]
+      }
+    }
+  ],
+
+  "scales": [
+    {
+      "name": "xscale",
+      "type": "band",
+      "range": "width",
+      "padding": 0.05,
+      "round": true,
+      "domain": {"data": "table", "field": "u"}
+    },
+    {
+      "name": "yscale",
+      "type": "linear",
+      "range": "height",
+      "domain": {"data": "table", "field": "v"},
+      "zero": true,
+      "nice": true
+    }
+  ],
+
+  "axes": [
+    {"orient": "bottom", "scale": "xscale", "zindex": 1},
+    {"orient": "left", "scale": "yscale", "zindex": 1}
+  ],
+
+  "marks": [
+    {
+      "type": "rect",
+      "from": {"data": "table"},
+      "encode": {
+        "enter": {
+          "x": {"scale": "xscale", "field": "u"},
+          "width": {"scale": "xscale", "band": 1},
+          "y": {"scale": "yscale", "field": "v"},
+          "y2": {"scale": "yscale", "value": 0}
+        },
+        "update": {
+          "fill": {"value": "steelblue"}
+        },
+        "hover": {
+          "fill": {"value": "red"}
+        }
+      }
+    }
+  ]
+};

--- a/packages/vega-typings/tests/spec/valid/dynamic-url.ts
+++ b/packages/vega-typings/tests/spec/valid/dynamic-url.ts
@@ -1,0 +1,70 @@
+import { Spec } from 'vega';
+
+// https://vega.github.io/editor/#/examples/vega/bar-chart
+export const spec: Spec = {
+  "$schema": "https://vega.github.io/schema/vega/v4.json",
+  "width": 300,
+  "height": 300,
+  "padding": 5,
+
+  "signals": [
+    {
+      "name": "url",
+      "value": "data/normal-2d.json",
+      "bind": {
+        "input": "select",
+        "options": [
+          "data/normal-2d.json",
+          "data/uniform-2d.json"
+        ]
+      }
+    }
+  ],
+
+  "data": [
+    {
+      "name": "table",
+      "url": {"signal": "url"}
+    }
+  ],
+
+  "scales": [
+    {
+      "name": "xscale",
+      "type": "linear",
+      "range": "width",
+      "domain": [-0.7, 0.7]
+    },
+    {
+      "name": "yscale",
+      "type": "linear",
+      "range": "height",
+      "domain": [-0.7, 0.7]
+    }
+  ],
+
+  "axes": [
+    {"orient": "bottom", "scale": "xscale", "tickCount": 5, "zindex": 1},
+    {"orient": "left", "scale": "yscale", "tickCount": 5, "zindex": 1}
+  ],
+
+  "marks": [
+    {
+      "type": "symbol",
+      "from": {"data": "table"},
+      "encode": {
+        "enter": {
+          "x": {"scale": "xscale", "field": "u"},
+          "y": {"scale": "yscale", "field": "v"},
+          "fillOpacity": {"value": 0.8}
+        },
+        "update": {
+          "fill": {"value": "steelblue"}
+        },
+        "hover": {
+          "fill": {"value": "red"}
+        }
+      }
+    }
+  ]
+};

--- a/packages/vega-typings/tests/spec/valid/error.ts
+++ b/packages/vega-typings/tests/spec/valid/error.ts
@@ -25,8 +25,7 @@ export const spec: Spec = {
       "name": "y",
       "type": "band",
       "range": "height",
-      "domain": {"data": "aggregate", "field": "label"},
-      "zero": true
+      "domain": {"data": "aggregate", "field": "label"}
     },
     {
       "name": "x",

--- a/packages/vega-typings/tests/spec/valid/flush-axis-labels.ts
+++ b/packages/vega-typings/tests/spec/valid/flush-axis-labels.ts
@@ -2,7 +2,7 @@ import { Spec } from 'vega';
 
 // https://vega.github.io/editor/#/examples/vega/bar-chart
 export const spec: Spec = {
-  "$schema": "https://vega.github.io/schema/vega/v3.json",
+  "$schema": "https://vega.github.io/schema/vega/v4.json",
   "width": 300,
   "height": 200,
   "padding": 5,

--- a/packages/vega-typings/tests/spec/valid/flush-axis-labels.ts
+++ b/packages/vega-typings/tests/spec/valid/flush-axis-labels.ts
@@ -17,6 +17,10 @@ export const spec: Spec = {
       "bind": {"input": "select", "options": [true, false, "parity", "greedy"]}
     },
     {
+      "name": "labelSeparation", "value": 0,
+      "bind": {"input": "range", "min": -10, "max": 30, "step": 1}
+    },
+    {
       "name": "labelBound", "value": -1,
       "bind": {"input": "range", "min": -1, "max": 30, "step": 1}
     },
@@ -66,6 +70,7 @@ export const spec: Spec = {
       "format": "s",
       "labelFlush": {"signal": "labelFlush"},
       "labelFlushOffset": {"signal": "labelFlushOffset"},
+      "labelSeparation": {"signal": "labelSeparation"},
       "labelOverlap": {"signal": "labelOverlap"},
       "labelBound": {"signal": "labelBound"}
     },
@@ -74,6 +79,7 @@ export const spec: Spec = {
       "scale": "backwardx",
       "labelFlush": {"signal": "labelFlush"},
       "labelFlushOffset": {"signal": "labelFlushOffset"},
+      "labelSeparation": {"signal": "labelSeparation"},
       "labelOverlap": {"signal": "labelOverlap"},
       "labelBound": {"signal": "labelBound"}
     },
@@ -83,6 +89,7 @@ export const spec: Spec = {
       "format": "s",
       "labelFlush": {"signal": "labelFlush"},
       "labelFlushOffset": {"signal": "labelFlushOffset"},
+      "labelSeparation": {"signal": "labelSeparation"},
       "labelOverlap": {"signal": "labelOverlap"},
       "labelBound": {"signal": "labelBound"}
     },
@@ -91,6 +98,7 @@ export const spec: Spec = {
       "scale": "backwardy",
       "labelFlush": {"signal": "labelFlush"},
       "labelFlushOffset": {"signal": "labelFlushOffset"},
+      "labelSeparation": {"signal": "labelSeparation"},
       "labelOverlap": {"signal": "labelOverlap"},
       "labelBound": {"signal": "labelBound"}
     }

--- a/packages/vega-typings/tests/spec/valid/gradient.ts
+++ b/packages/vega-typings/tests/spec/valid/gradient.ts
@@ -10,7 +10,7 @@ export const spec: Spec = {
   "scales": [
     {
       "name": "color",
-      "type": "sequential",
+      "type": "linear",
       "range": {"scheme": "viridis"},
       "domain": [0, 100]
     }

--- a/packages/vega-typings/tests/spec/valid/heatmap.ts
+++ b/packages/vega-typings/tests/spec/valid/heatmap.ts
@@ -92,7 +92,7 @@ export const spec: Spec = {
     },
     {
       "name": "color",
-      "type": "sequential",
+      "type": "linear",
       "range": {"scheme": {"signal": "palette"}},
       "domain": {"data": "temperature", "field": "temp"},
       "reverse": {"signal": "reverse"},

--- a/packages/vega-typings/tests/spec/valid/legends-continuous.ts
+++ b/packages/vega-typings/tests/spec/valid/legends-continuous.ts
@@ -9,12 +9,14 @@ export const spec: Spec = {
     "legend": {
       "offset": 5,
       "gradientDirection": "horizontal",
-      "gradientLength": 300
+      "gradientLength": 300,
+      "labelOverlap": {"signal": "labelOverlap"}
     }
   },
 
   "signals": [
-    {"name": "seqScheme", "value": "blues"},
+    {"name": "labelOverlap", "value": true, "bind": {"input": "checkbox"}},
+    {"name": "seqScheme", "value": "purples"},
     {"name": "linearRange", "value": ["purple", "orange"]}
   ],
 
@@ -24,61 +26,91 @@ export const spec: Spec = {
       "values": [
         {"u": -10}, {"u": 10}
       ]
+    },
+    {
+      "name": "positive",
+      "values": [
+        {"u": 1}, {"u": 1000}
+      ]
     }
   ],
 
   "scales": [
     {
+      "name": "linear",
+      "type": "linear",
+      "range": "ramp",
+      "domain": {"data": "positive", "field": "u"},
+      "zero": false, "nice": true
+    },
+    {
+      "name": "pow",
+      "type": "pow",
+      "exponent": 1.5,
+      "range": "ramp",
+      "domain": {"data": "positive", "field": "u"},
+      "zero": false, "nice": true
+    },
+    {
+      "name": "sqrt",
+      "type": "sqrt",
+      "range": "ramp",
+      "domain": {"data": "positive", "field": "u"},
+      "zero": false, "nice": true
+    },
+    {
+      "name": "log10",
+      "type": "log",
+      "range": "ramp",
+      "domain": {"data": "positive", "field": "u"},
+      "zero": false, "nice": true
+    },
+    {
+      "name": "log2",
+      "type": "log",
+      "base": 2,
+      "range": "ramp",
+      "domain": {"data": "positive", "field": "u"},
+      "zero": false, "nice": true
+    },
+    {
+      "name": "symlog",
+      "type": "symlog",
+      "range": "ramp",
+      "domain": {"data": "positive", "field": "u"},
+      "zero": false, "nice": true
+    },
+
+    {
       "name": "seq0",
-      "type": "sequential",
+      "type": "linear",
       "range": {"scheme": {"signal": "seqScheme"}},
       "domain": {"data": "table", "field": "u"}
     },
     {
       "name": "seq1",
-      "type": "sequential",
+      "type": "linear",
       "range": {"scheme": {"signal": "seqScheme"}, "extent": [0, 1]},
       "domain": {"data": "table", "field": "u"}
     },
     {
       "name": "seq2",
-      "type": "sequential",
+      "type": "linear",
       "range": {"scheme": {"signal": "seqScheme"}, "extent": [0.2, 1]},
       "domain": {"data": "table", "field": "u"}
     },
     {
       "name": "seq3",
-      "type": "sequential",
+      "type": "linear",
       "range": {"scheme": {"signal": "seqScheme"}, "extent": [0.2, 1]},
       "reverse": true,
       "domain": {"data": "table", "field": "u"}
     },
     {
       "name": "seq4",
-      "type": "sequential",
+      "type": "linear",
       "range": {"scheme": {"signal": "seqScheme"}, "extent": [1, 0.2]},
       "domain": {"data": "table", "field": "u"}
-    },
-    {
-      "name": "seq5",
-      "type": "sequential",
-      "range": "diverging",
-      "domain": {"data": "table", "field": "u"},
-      "domainMid": 0
-    },
-    {
-      "name": "seq6",
-      "type": "sequential",
-      "range": ["purple", "orange", "gold"],
-      "domain": {"data": "table", "field": "u"},
-      "domainMid": 2
-    },
-    {
-      "name": "seq7",
-      "type": "linear",
-      "range": ["purple", "orange", "gold"],
-      "domain": {"data": "table", "field": "u"},
-      "domainMid": 2
     },
 
     {
@@ -126,34 +158,65 @@ export const spec: Spec = {
       "name": "lin6",
       "type": "linear",
       "range": {"signal": "linearRange"},
-      "interpolate": "hsl-long",
+      "interpolate": "hcl-long",
       "domain": {"data": "table", "field": "u"}
     },
     {
       "name": "lin7",
       "type": "linear",
       "range": {"signal": "linearRange"},
-      "interpolate": "hcl-long",
+      "interpolate": "hsl-long",
       "domain": {"data": "table", "field": "u"}
+    },
+
+    {
+      "name": "div0",
+      "type": "linear",
+      "range": "diverging",
+      "domain": {"data": "table", "field": "u"},
+      "domainMid": 0
+    },
+    {
+      "name": "div1",
+      "type": "linear",
+      "range": "diverging",
+      "domain": {"data": "table", "field": "u"},
+      "domainMid": -5
+    },
+    {
+      "name": "div2",
+      "type": "linear",
+      "range": "diverging",
+      "domain": {"data": "table", "field": "u"},
+      "domainMid": 5
     }
   ],
 
   "legends": [
-    {"orient": "left",  "type": "gradient", "fill": "seq0", "title": "Sequential"},
-    {"orient": "left",  "type": "gradient", "fill": "seq1", "title": "Sequential [0, 1]"},
-    {"orient": "left",  "type": "gradient", "fill": "seq2", "title": "Sequential [0.2, 1]"},
-    {"orient": "left",  "type": "gradient", "fill": "seq3", "title": "Sequential [0.2, 1] Reverse"},
-    {"orient": "left",  "type": "gradient", "fill": "seq4", "title": "Sequential [1, 0.2]"},
-    {"orient": "left",  "type": "gradient", "fill": "seq5", "title": "Sequential Diverging"},
-    {"orient": "left",  "type": "gradient", "fill": "seq6", "title": "Sequential Diverging Uneven"},
-    {"orient": "left",  "type": "gradient", "fill": "seq7", "title": "Linear Diverging Uneven"},
-    {"orient": "right", "type": "gradient", "fill": "lin0", "title": "Linear"},
-    {"orient": "right", "type": "gradient", "fill": "lin1", "title": "Linear RGB"},
-    {"orient": "right", "type": "gradient", "fill": "lin2", "title": "Linear RGB Gamma(2.2)"},
-    {"orient": "right", "type": "gradient", "fill": "lin3", "title": "Linear LAB"},
-    {"orient": "right", "type": "gradient", "fill": "lin4", "title": "Linear HCL"},
-    {"orient": "right", "type": "gradient", "fill": "lin5", "title": "Linear HSL"},
-    {"orient": "right", "type": "gradient", "fill": "lin6", "title": "Linear HSL-Long"},
-    {"orient": "right", "type": "gradient", "fill": "lin7", "title": "Linear HCL-Long"}
+    {"orient": "left",  "type": "gradient", "fill": "linear", "title": "Linear Ramp"},
+    {"orient": "left",  "type": "gradient", "fill": "pow",    "title": "Pow Ramp - Exponent 1.5"},
+    {"orient": "left",  "type": "gradient", "fill": "sqrt",   "title": "Pow Ramp - Exponent 0.5"},
+    {"orient": "left",  "type": "gradient", "fill": "log10",  "title": "Log Ramp - Base 10"},
+    {"orient": "left",  "type": "gradient", "fill": "log2",   "title": "Log Ramp - Base 2"},
+    {"orient": "left",  "type": "gradient", "fill": "symlog", "title": "Symlog Ramp"},
+
+    {"orient": "left",  "type": "gradient", "fill": "seq0", "title": "Scheme"},
+    {"orient": "left",  "type": "gradient", "fill": "seq1", "title": "Scheme Extent [0, 1]"},
+    {"orient": "left",  "type": "gradient", "fill": "seq2", "title": "Scheme Extent [0.2, 1]"},
+    {"orient": "left",  "type": "gradient", "fill": "seq3", "title": "Scheme Extent [0.2, 1] Reverse"},
+    {"orient": "left",  "type": "gradient", "fill": "seq4", "title": "Scheme Extent [1, 0.2]"},
+
+    {"orient": "right", "type": "gradient", "fill": "lin0", "title": "Interpolate Default"},
+    {"orient": "right", "type": "gradient", "fill": "lin1", "title": "Interpolate RGB"},
+    {"orient": "right", "type": "gradient", "fill": "lin2", "title": "Interpolate RGB Gamma 2.2"},
+    {"orient": "right", "type": "gradient", "fill": "lin3", "title": "Interpolate LAB"},
+    {"orient": "right", "type": "gradient", "fill": "lin4", "title": "Interpolate HCL"},
+    {"orient": "right", "type": "gradient", "fill": "lin5", "title": "Interpolate HSL"},
+    {"orient": "right", "type": "gradient", "fill": "lin6", "title": "Interpolate HCL-Long"},
+    {"orient": "right", "type": "gradient", "fill": "lin7", "title": "Interpolate HSL-Long"},
+
+    {"orient": "right", "type": "gradient", "fill": "div0", "title": "Diverging Mid 0"},
+    {"orient": "right", "type": "gradient", "fill": "div1", "title": "Diverging Range Mid -5"},
+    {"orient": "right", "type": "gradient", "fill": "div2", "title": "Diverging Range Mid 5"}
   ]
 };

--- a/packages/vega-typings/tests/spec/valid/legends-continuous.ts
+++ b/packages/vega-typings/tests/spec/valid/legends-continuous.ts
@@ -10,14 +10,18 @@ export const spec: Spec = {
       "offset": 5,
       "gradientDirection": "horizontal",
       "gradientLength": 300,
-      "labelOverlap": {"signal": "labelOverlap"}
+      "labelOverlap": {"signal": "labelOverlap"},
+      "labelSeparation": {"signal": "labelSeparation"}
     }
   },
 
   "signals": [
-    {"name": "labelOverlap", "value": true, "bind": {"input": "checkbox"}},
-    {"name": "seqScheme", "value": "purples"},
-    {"name": "linearRange", "value": ["purple", "orange"]}
+    { "name": "labelOverlap", "value": true,
+      "bind": {"input": "checkbox"} },
+    { "name": "labelSeparation", "value": 0,
+      "bind": {"input": "range", "min": -10, "max": 20, "step": 1} },
+    { "name": "seqScheme", "value": "purples" },
+    { "name": "linearRange", "value": ["purple", "orange"] }
   ],
 
   "data": [

--- a/packages/vega-typings/tests/spec/valid/legends-ordinal.ts
+++ b/packages/vega-typings/tests/spec/valid/legends-ordinal.ts
@@ -54,6 +54,12 @@ export const spec: Spec = {
       "type": "ordinal",
       "range": "heatmap",
       "domain": {"signal": "domain"}
+    },
+    {
+      "name": "custom",
+      "type": "ordinal",
+      "range": {"scheme": ["royalblue", "lightgray", "goldenrod"]},
+      "domain": {"signal": "domain"}
     }
   ],
 
@@ -62,6 +68,7 @@ export const spec: Spec = {
     {"orient": "none", "fill": "ordinal", "title": "Ordinal", "encode": {"legend": {"update": {"x": {"value":60}, "y": {"value": 0}}}}},
     {"orient": "none", "fill": "ramp", "title": "Ramp", "encode": {"legend": {"update": {"x": {"value":120}, "y": {"value": 0}}}}},
     {"orient": "none", "fill": "diverging", "title": "Diverging", "encode": {"legend": {"update": {"x": {"value":180}, "y": {"value": 0}}}}},
-    {"orient": "none", "fill": "heatmap", "title": "Heatmap", "encode": {"legend": {"update": {"x": {"value":240}, "y": {"value": 0}}}}}
+    {"orient": "none", "fill": "heatmap", "title": "Heatmap", "encode": {"legend": {"update": {"x": {"value":240}, "y": {"value": 0}}}}},
+    {"orient": "none", "fill": "custom", "title": "Custom", "encode": {"legend": {"update": {"x": {"value":300}, "y": {"value": 0}}}}}
   ]
 };

--- a/packages/vega-typings/tests/spec/valid/legends.ts
+++ b/packages/vega-typings/tests/spec/valid/legends.ts
@@ -17,7 +17,7 @@ export const spec: Spec = {
   "scales": [
     {
       "name": "sequence",
-      "type": "sequential",
+      "type": "linear",
       "range": {"scheme": "viridis"},
       "domain": [0, 100]
     },

--- a/packages/vega-typings/tests/spec/valid/nulls-histogram.ts
+++ b/packages/vega-typings/tests/spec/valid/nulls-histogram.ts
@@ -14,15 +14,19 @@ export const spec: Spec = {
       "bind": {"input": "select", "options": [5, 10, 20]}
     },
     {
-      "name": "binDomain",
+      "name": "binValues",
       "update": "sequence(bins.start, bins.stop + bins.step, bins.step)"
+    },
+    {
+      "name": "binDomain",
+      "update": "[bins.start, bins.stop]"
     },
     {
       "name": "nullGap", "value": 10
     },
     {
       "name": "barStep",
-      "update": "binDomain.length ? (width - nullGap) / binDomain.length : 0"
+      "update": "binValues.length ? (width - nullGap) / binValues.length : 0"
     }
   ],
 
@@ -86,10 +90,11 @@ export const spec: Spec = {
     },
     {
       "name": "xscale",
-      "type": "bin-linear",
+      "type": "linear",
       "range": [{"signal": "barStep + nullGap"}, {"signal": "width"}],
       "round": true,
-      "domain": {"signal": "binDomain"}
+      "domain": {"signal": "binDomain"},
+      "bins": {"signal": "binValues"}
     },
     {
       "name": "xscale-null",

--- a/packages/vega-typings/tests/spec/valid/scales-bin.ts
+++ b/packages/vega-typings/tests/spec/valid/scales-bin.ts
@@ -10,8 +10,12 @@ export const spec: Spec = {
 
   "signals": [
     {
-      "name": "binDomain",
+      "name": "binValues",
       "update": "sequence(bins.start, bins.stop + bins.step, bins.step)"
+    },
+    {
+      "name": "binDomain",
+      "update": "[bins.start, bins.stop]"
     },
     {
       "name": "maxbins", "value": 10,
@@ -62,23 +66,25 @@ export const spec: Spec = {
     },
     {
       "name": "xscale",
-      "type": "bin-linear",
+      "type": "linear",
       "range": "width",
       "round": true,
-      "domain": {"signal": "binDomain"}
+      "domain": {"signal": "binDomain"},
+      "bins": {"signal": "binValues"}
     },
     {
       "name": "size",
-      "type": "bin-linear",
+      "type": "linear",
       "range": [10, 100],
       "round": true,
-      "domain": {"signal": "binDomain"}
+      "domain": {"signal": "binDomain"},
+      "bins": {"signal": "binValues"}
     },
     {
       "name": "color",
       "type": "bin-ordinal",
       "range": {"scheme": "purpleorange"},
-      "domain": {"signal": "binDomain"}
+      "domain": {"signal": "binValues"}
     }
   ],
 

--- a/packages/vega-typings/tests/spec/valid/symbol-angle.ts
+++ b/packages/vega-typings/tests/spec/valid/symbol-angle.ts
@@ -1,0 +1,177 @@
+import { Spec } from 'vega';
+
+// https://vega.github.io/editor/#/examples/vega/bar-chart
+export const spec: Spec = {
+  "$schema": "https://vega.github.io/schema/vega/v4.json",
+  "padding": 5,
+
+  "signals": [
+    {
+      "name": "baseAngle", "value": 0,
+      "bind": {"input": "range", "min": -180, "max": 180, "step": 1}
+    }
+  ],
+
+  "data": [
+    {
+      "name": "table",
+      "values": [
+        {"u":  1, "v":  1, "a":    0, "s": "cross"},
+        {"u":  1, "v":  2, "a":   15, "s": "cross"},
+        {"u":  1, "v":  3, "a":   30, "s": "cross"},
+        {"u":  1, "v":  4, "a":   45, "s": "cross"},
+        {"u":  1, "v":  5, "a":   60, "s": "cross"},
+        {"u":  1, "v":  6, "a":   75, "s": "cross"},
+        {"u":  1, "v":  7, "a":   90, "s": "cross"},
+        {"u":  1, "v":  8, "a":  105, "s": "cross"},
+        {"u":  1, "v":  9, "a":  120, "s": "cross"},
+        {"u":  1, "v": 10, "a":  135, "s": "cross"},
+        {"u":  1, "v": 11, "a":  150, "s": "cross"},
+        {"u":  1, "v": 12, "a":  165, "s": "cross"},
+        {"u":  1, "v": 13, "a":  180, "s": "cross"},
+        {"u":  2, "v":  1, "a":    0, "s": "cross"},
+        {"u":  2, "v":  2, "a":  -15, "s": "cross"},
+        {"u":  2, "v":  3, "a":  -30, "s": "cross"},
+        {"u":  2, "v":  4, "a":  -45, "s": "cross"},
+        {"u":  2, "v":  5, "a":  -60, "s": "cross"},
+        {"u":  2, "v":  6, "a":  -75, "s": "cross"},
+        {"u":  2, "v":  7, "a":  -90, "s": "cross"},
+        {"u":  2, "v":  8, "a": -105, "s": "cross"},
+        {"u":  2, "v":  9, "a": -120, "s": "cross"},
+        {"u":  2, "v": 10, "a": -135, "s": "cross"},
+        {"u":  2, "v": 11, "a": -150, "s": "cross"},
+        {"u":  2, "v": 12, "a": -165, "s": "cross"},
+        {"u":  2, "v": 13, "a": -180, "s": "cross"},
+        {"u":  3, "v":  1, "a":    0, "s": "triangle"},
+        {"u":  3, "v":  2, "a":   15, "s": "triangle"},
+        {"u":  3, "v":  3, "a":   30, "s": "triangle"},
+        {"u":  3, "v":  4, "a":   45, "s": "triangle"},
+        {"u":  3, "v":  5, "a":   60, "s": "triangle"},
+        {"u":  3, "v":  6, "a":   75, "s": "triangle"},
+        {"u":  3, "v":  7, "a":   90, "s": "triangle"},
+        {"u":  3, "v":  8, "a":  105, "s": "triangle"},
+        {"u":  3, "v":  9, "a":  120, "s": "triangle"},
+        {"u":  3, "v": 10, "a":  135, "s": "triangle"},
+        {"u":  3, "v": 11, "a":  150, "s": "triangle"},
+        {"u":  3, "v": 12, "a":  165, "s": "triangle"},
+        {"u":  3, "v": 13, "a":  180, "s": "triangle"},
+        {"u":  4, "v":  1, "a":   0,  "s": "triangle"},
+        {"u":  4, "v":  2, "a":  -15, "s": "triangle"},
+        {"u":  4, "v":  3, "a":  -30, "s": "triangle"},
+        {"u":  4, "v":  4, "a":  -45, "s": "triangle"},
+        {"u":  4, "v":  5, "a":  -60, "s": "triangle"},
+        {"u":  4, "v":  6, "a":  -75, "s": "triangle"},
+        {"u":  4, "v":  7, "a":  -90, "s": "triangle"},
+        {"u":  4, "v":  8, "a": -105, "s": "triangle"},
+        {"u":  4, "v":  9, "a": -120, "s": "triangle"},
+        {"u":  4, "v": 10, "a": -135, "s": "triangle"},
+        {"u":  4, "v": 11, "a": -150, "s": "triangle"},
+        {"u":  4, "v": 12, "a": -165, "s": "triangle"},
+        {"u":  4, "v": 13, "a": -180, "s": "triangle"},
+        {"u":  5, "v":  1, "a":    0, "s": "wedge"},
+        {"u":  5, "v":  2, "a":   15, "s": "wedge"},
+        {"u":  5, "v":  3, "a":   30, "s": "wedge"},
+        {"u":  5, "v":  4, "a":   45, "s": "wedge"},
+        {"u":  5, "v":  5, "a":   60, "s": "wedge"},
+        {"u":  5, "v":  6, "a":   75, "s": "wedge"},
+        {"u":  5, "v":  7, "a":   90, "s": "wedge"},
+        {"u":  5, "v":  8, "a":  105, "s": "wedge"},
+        {"u":  5, "v":  9, "a":  120, "s": "wedge"},
+        {"u":  5, "v": 10, "a":  135, "s": "wedge"},
+        {"u":  5, "v": 11, "a":  150, "s": "wedge"},
+        {"u":  5, "v": 12, "a":  165, "s": "wedge"},
+        {"u":  5, "v": 13, "a":  180, "s": "wedge"},
+        {"u":  6, "v":  1, "a":   0,  "s": "wedge"},
+        {"u":  6, "v":  2, "a":  -15, "s": "wedge"},
+        {"u":  6, "v":  3, "a":  -30, "s": "wedge"},
+        {"u":  6, "v":  4, "a":  -45, "s": "wedge"},
+        {"u":  6, "v":  5, "a":  -60, "s": "wedge"},
+        {"u":  6, "v":  6, "a":  -75, "s": "wedge"},
+        {"u":  6, "v":  7, "a":  -90, "s": "wedge"},
+        {"u":  6, "v":  8, "a": -105, "s": "wedge"},
+        {"u":  6, "v":  9, "a": -120, "s": "wedge"},
+        {"u":  6, "v": 10, "a": -135, "s": "wedge"},
+        {"u":  6, "v": 11, "a": -150, "s": "wedge"},
+        {"u":  6, "v": 12, "a": -165, "s": "wedge"},
+        {"u":  6, "v": 13, "a": -180, "s": "wedge"},
+        {"u":  7, "v":  1, "a":    0, "s": "arrow"},
+        {"u":  7, "v":  2, "a":   15, "s": "arrow"},
+        {"u":  7, "v":  3, "a":   30, "s": "arrow"},
+        {"u":  7, "v":  4, "a":   45, "s": "arrow"},
+        {"u":  7, "v":  5, "a":   60, "s": "arrow"},
+        {"u":  7, "v":  6, "a":   75, "s": "arrow"},
+        {"u":  7, "v":  7, "a":   90, "s": "arrow"},
+        {"u":  7, "v":  8, "a":  105, "s": "arrow"},
+        {"u":  7, "v":  9, "a":  120, "s": "arrow"},
+        {"u":  7, "v": 10, "a":  135, "s": "arrow"},
+        {"u":  7, "v": 11, "a":  150, "s": "arrow"},
+        {"u":  7, "v": 12, "a":  165, "s": "arrow"},
+        {"u":  7, "v": 13, "a":  180, "s": "arrow"},
+        {"u":  8, "v":  1, "a":   0,  "s": "arrow"},
+        {"u":  8, "v":  2, "a":  -15, "s": "arrow"},
+        {"u":  8, "v":  3, "a":  -30, "s": "arrow"},
+        {"u":  8, "v":  4, "a":  -45, "s": "arrow"},
+        {"u":  8, "v":  5, "a":  -60, "s": "arrow"},
+        {"u":  8, "v":  6, "a":  -75, "s": "arrow"},
+        {"u":  8, "v":  7, "a":  -90, "s": "arrow"},
+        {"u":  8, "v":  8, "a": -105, "s": "arrow"},
+        {"u":  8, "v":  9, "a": -120, "s": "arrow"},
+        {"u":  8, "v": 10, "a": -135, "s": "arrow"},
+        {"u":  8, "v": 11, "a": -150, "s": "arrow"},
+        {"u":  8, "v": 12, "a": -165, "s": "arrow"},
+        {"u":  8, "v": 13, "a": -180, "s": "arrow"}
+      ]
+    }
+  ],
+
+  "scales": [
+    {
+      "name": "xscale",
+      "type": "band",
+      "range": {"step": 50},
+      "domain": {"data": "table", "field": "v"}
+    },
+    {
+      "name": "yscale",
+      "type": "band",
+      "range": {"step": 50},
+      "domain": {"data": "table", "field": "u"}
+    }
+  ],
+
+  "marks": [
+    {
+      "type": "symbol",
+      "from": {"data": "table"},
+      "encode": {
+        "enter": {
+          "shape": {"field": "s"},
+          "x": {"scale": "xscale", "field": "v"},
+          "y": {"scale": "yscale", "field": "u"},
+          "size": {"value": 1000}
+        },
+        "update": {
+          "fill": {"value": "steelblue"},
+          "angle": {"field": "a", "offset": {"signal": "baseAngle"}}
+        },
+        "hover": {
+          "fill": {"value": "firebrick"}
+        }
+      }
+    },
+    {
+      "type": "symbol",
+      "from": {"data": "table"},
+      "interactive": false,
+      "encode": {
+        "enter": {
+          "shape": {"value": "circle"},
+          "x": {"scale": "xscale", "field": "v"},
+          "y": {"scale": "yscale", "field": "u"},
+          "size": {"value": 9},
+          "fill": {"value": "#000"}
+        }
+      }
+    }
+  ]
+};

--- a/packages/vega-typings/tests/spec/valid/tree-cluster.ts
+++ b/packages/vega-typings/tests/spec/valid/tree-cluster.ts
@@ -65,7 +65,7 @@ export const spec: Spec = {
   "scales": [
     {
       "name": "color",
-      "type": "sequential",
+      "type": "linear",
       "range": {"scheme": "magma"},
       "domain": {"data": "tree", "field": "depth"},
       "zero": true

--- a/packages/vega-typings/tests/spec/valid/tree-radial.ts
+++ b/packages/vega-typings/tests/spec/valid/tree-radial.ts
@@ -100,7 +100,7 @@ export const spec: Spec = {
   "scales": [
     {
       "name": "color",
-      "type": "sequential",
+      "type": "linear",
       "range": {"scheme": "magma"},
       "domain": {"data": "tree", "field": "depth"},
       "zero": true

--- a/packages/vega-typings/types/spec/axis.d.ts
+++ b/packages/vega-typings/types/spec/axis.d.ts
@@ -374,6 +374,11 @@ export interface BaseAxis<
   labelFlushOffset?: NS;
 
   /**
+   * TODO: add docs.
+   */
+  labelSeparation?: NS;
+
+  /**
    * The strategy to use for resolving overlap of axis labels. If `false` (the default), no overlap reduction is attempted. If set to `true` or `"parity"`, a strategy of removing every other label is used (this works well for standard linear axes). If set to `"greedy"`, a linear scan of the labels is performed, removing any labels that overlaps with the last visible label (this often works better for log-scaled axes).
    */
   labelOverlap?: LO;

--- a/packages/vega-typings/types/spec/data.d.ts
+++ b/packages/vega-typings/types/spec/data.d.ts
@@ -9,7 +9,7 @@ export type Parse =
 export interface FormatJSON {
   type: 'json';
   parse?: Parse;
-  property?: string;
+  property?: string | SignalRef;
   copy?: boolean;
 }
 export interface FormatSV {

--- a/packages/vega-typings/types/spec/scale.d.ts
+++ b/packages/vega-typings/types/spec/scale.d.ts
@@ -16,7 +16,7 @@ export type RangeScheme =
   | RangeRaw
   | SignalRef
   | {
-      scheme: string | SignalRef | ColorScheme;
+      scheme: string | string[] | SignalRef | ColorScheme;
       count?: number | SignalRef;
       extent?: (number | SignalRef)[] | SignalRef;
     };
@@ -75,14 +75,17 @@ export type MultiDataRef =
 export type ScaleData =
   | (DataRef & { sort?: SortField })
   | (MultiDataRef & { sort?: UnionSortField });
-export type QuantScaleType = 'linear' | 'pow' | 'sqrt' | 'log' | 'time' | 'utc' | 'sequential';
+export type QuantScaleType =
+  | 'linear'
+  | 'pow'
+  | 'sqrt'
+  | 'log'
+  | 'symlog'
+  | 'time'
+  | 'utc'
+  | 'sequential';
 export type DiscreteScaleType = 'ordinal' | 'band' | 'point';
-export type DiscretizingScaleType =
-  | 'quantile'
-  | 'quantize'
-  | 'threshold'
-  | 'bin-linear'
-  | 'bin-ordinal';
+export type DiscretizingScaleType = 'quantile' | 'quantize' | 'threshold' | 'bin-ordinal';
 export type ScaleType = QuantScaleType | DiscreteScaleType | DiscretizingScaleType | 'identity';
 export interface BaseScale {
   name: string;
@@ -98,6 +101,7 @@ export interface BaseScale {
 export interface OrdinalScale extends BaseScale {
   type: 'ordinal';
   range?: RangeScheme | ScaleData;
+  interpolate?: ScaleInterpolate;
 }
 export interface BandScale extends BaseScale {
   type: 'band';
@@ -114,6 +118,8 @@ export interface PointScale extends BaseScale {
   paddingOuter?: number | SignalRef;
   align?: number | SignalRef;
 }
+
+// note: deprecated
 export interface SequentialScale extends BaseScale {
   type: 'sequential';
   range: RangeScheme;
@@ -156,6 +162,7 @@ export interface LinearScale extends BaseScale {
   padding?: number | SignalRef;
   nice?: boolean | number | SignalRef;
   zero?: boolean | SignalRef;
+  bins?: number | SignalRef;
 }
 export interface LogScale extends BaseScale {
   type: 'log';
@@ -165,6 +172,18 @@ export interface LogScale extends BaseScale {
   clamp?: boolean | SignalRef;
   padding?: number | SignalRef;
   nice?: boolean | number | SignalRef;
+  zero?: false; // zero has to be false or undefined
+}
+
+export interface SymLogScale extends BaseScale {
+  type: 'symlog';
+  range?: RangeScheme;
+  interpolate?: ScaleInterpolate;
+  base?: number | SignalRef;
+  clamp?: boolean | SignalRef;
+  padding?: number | SignalRef;
+  nice?: boolean | number | SignalRef;
+  zero?: false; // zero has to be false or undefined
 }
 export interface PowScale extends BaseScale {
   type: 'pow';
@@ -188,6 +207,7 @@ export interface SqrtScale extends BaseScale {
 export interface QuantileScale extends BaseScale {
   type?: 'quantile';
   range?: RangeScheme;
+  interpolate?: ScaleInterpolate;
   nice?: boolean | number | SignalRef;
   zero?: boolean | SignalRef;
 }
@@ -205,15 +225,10 @@ export interface ThresholdScale extends BaseScale {
   nice?: boolean | number | SignalRef;
   zero?: boolean | SignalRef;
 }
-export interface BinLinearScale extends BaseScale {
-  type: 'bin-linear';
-  range?: RangeScheme;
-  padding?: number | SignalRef;
-  interpolate?: ScaleInterpolate;
-}
 export interface BinOrdinalScale extends BaseScale {
   type: 'bin-ordinal';
   range?: RangeScheme | ScaleData;
+  interpolate?: ScaleInterpolate;
 }
 export type Scale =
   | OrdinalScale
@@ -225,10 +240,10 @@ export type Scale =
   | DiscretizingScale
   | LinearScale
   | LogScale
+  | SymLogScale
   | PowScale
   | SqrtScale
   | QuantileScale
   | QuantizeScale
   | ThresholdScale
-  | BinLinearScale
   | BinOrdinalScale;


### PR DESCRIPTION
I've created a [script to update the tests](https://github.com/vega/vega/blob/master/packages/vega-typings/build-tests.sh) for the typings with new examples. You can run it to make it easier to see what changes may require typings changes. I don't know what would be the best way to automatically call this script. 