### PR TITLE
Support angle encoding for symbol marks.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,16 +19,16 @@
     "eslint": "^5.13.0",
     "http-server": "^0.11.1",
     "jsdom": "^13.2.0",
-    "lerna": "^3.10.8",
-    "prettier": "^1.16.3",
+    "lerna": "^3.11.1",
+    "prettier": "^1.16.4",
     "rimraf": "^2.6.3",
     "rollup": "1.1.2",
     "rollup-plugin-json": "^3.1.0",
     "rollup-plugin-node-resolve": "^4.0.0",
-    "tape": "^4.9.2",
-    "terser": "^3.16.0",
+    "tape": "^4.10.0",
+    "terser": "^3.16.1",
     "tv4": "^1.3.0",
-    "typescript": "^3.3.1"
+    "typescript": "^3.3.3"
   },
   "workspaces": [
     "packages/*"

--- a/packages/vega-scenegraph/package.json
+++ b/packages/vega-scenegraph/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "d3-path": "^1.0.7",
-    "d3-shape": "^1.2.2",
+    "d3-shape": "^1.3.4",
     "vega-canvas": "^1.1.0",
     "vega-loader": "^3.1.0",
     "vega-util": "^1.7.1"

--- a/packages/vega-scenegraph/src/bound/boundContext.js
+++ b/packages/vega-scenegraph/src/bound/boundContext.js
@@ -1,7 +1,7 @@
+import {HalfPi, Tau} from '../util/constants';
+
 var bounds,
-    tau = Math.PI * 2,
-    halfPi = tau / 4,
-    circleThreshold = tau - 1e-8;
+    circleThreshold = Tau - 1e-8;
 
 export default function context(_) {
   bounds = _;
@@ -61,8 +61,8 @@ context.arc = function(cx, cy, r, sa, ea, ccw) {
   update(ea);
 
   if (ea !== sa) {
-    sa = sa % tau; if (sa < 0) sa += tau;
-    ea = ea % tau; if (ea < 0) ea += tau;
+    sa = sa % Tau; if (sa < 0) sa += Tau;
+    ea = ea % Tau; if (ea < 0) ea += Tau;
 
     if (ea < sa) {
       ccw = !ccw; // flip direction
@@ -70,12 +70,12 @@ context.arc = function(cx, cy, r, sa, ea, ccw) {
     }
 
     if (ccw) {
-      ea -= tau;
-      s = sa - (sa % halfPi);
-      for (i=0; i<4 && s>ea; ++i, s-=halfPi) update(s);
+      ea -= Tau;
+      s = sa - (sa % HalfPi);
+      for (i=0; i<4 && s>ea; ++i, s-=HalfPi) update(s);
     } else {
-      s = sa - (sa % halfPi) + halfPi;
-      for (i=0; i<4 && s<ea; ++i, s=s+halfPi) update(s);
+      s = sa - (sa % HalfPi) + HalfPi;
+      for (i=0; i<4 && s<ea; ++i, s=s+HalfPi) update(s);
     }
   }
 

--- a/packages/vega-scenegraph/src/marks/group.js
+++ b/packages/vega-scenegraph/src/marks/group.js
@@ -5,7 +5,7 @@ import stroke from '../util/canvas/stroke';
 import fill from '../util/canvas/fill';
 import {hitPath} from '../util/canvas/pick';
 import clip from '../util/svg/clip';
-import translateItem from '../util/svg/translateItem';
+import {translateItem} from '../util/svg/transform';
 
 var StrokeOffset = 0.5;
 

--- a/packages/vega-scenegraph/src/marks/image.js
+++ b/packages/vega-scenegraph/src/marks/image.js
@@ -1,6 +1,6 @@
 import {visit} from '../util/visit';
 import {pick} from '../util/canvas/pick';
-import translate from '../util/svg/translate';
+import {translate} from '../util/svg/transform';
 
 function getImage(item, renderer) {
   var image = item.image;

--- a/packages/vega-scenegraph/src/marks/markItemPath.js
+++ b/packages/vega-scenegraph/src/marks/markItemPath.js
@@ -2,27 +2,39 @@ import boundStroke from '../bound/boundStroke';
 import context from '../bound/boundContext';
 import {drawAll} from '../util/canvas/draw';
 import {pickPath} from '../util/canvas/pick';
-import translateItem from '../util/svg/translateItem';
+import {transformItem} from '../util/svg/transform';
+import {DegToRad} from '../util/constants';
 
 export default function(type, shape) {
 
   function attr(emit, item) {
-    emit('transform', translateItem(item));
+    emit('transform', transformItem(item));
     emit('d', shape(null, item));
   }
 
   function bound(bounds, item) {
+    var x = item.x || 0,
+        y = item.y || 0;
+
     shape(context(bounds), item);
-    return boundStroke(bounds, item)
-      .translate(item.x || 0, item.y || 0);
+    boundStroke(bounds, item).translate(x, y);
+    if (item.angle) {
+      bounds.rotate(item.angle * DegToRad, x, y);
+    }
+
+    return bounds;
   }
 
   function draw(context, item) {
     var x = item.x || 0,
-        y = item.y || 0;
+        y = item.y || 0,
+        a = item.angle || 0;
+
     context.translate(x, y);
+    if (a) context.rotate(a *= DegToRad);
     context.beginPath();
     shape(context, item);
+    if (a) context.rotate(-a);
     context.translate(-x, -y);
   }
 

--- a/packages/vega-scenegraph/src/marks/path.js
+++ b/packages/vega-scenegraph/src/marks/path.js
@@ -4,7 +4,7 @@ import pathParse from '../path/parse';
 import pathRender from '../path/render';
 import {drawAll} from '../util/canvas/draw';
 import {pickPath} from '../util/canvas/pick';
-import translateItem from '../util/svg/translateItem';
+import {translateItem} from '../util/svg/transform';
 
 function attr(emit, item) {
   emit('transform', translateItem(item));

--- a/packages/vega-scenegraph/src/marks/rule.js
+++ b/packages/vega-scenegraph/src/marks/rule.js
@@ -2,12 +2,12 @@ import boundStroke from '../bound/boundStroke';
 import {visit} from '../util/visit';
 import {pick} from '../util/canvas/pick';
 import stroke from '../util/canvas/stroke';
-import translateItem from '../util/svg/translateItem';
+import {translateItem} from '../util/svg/transform';
 
 function attr(emit, item) {
   emit('transform', translateItem(item));
-  emit('x2', item.x2 != null ? item.x2 - (item.x||0) : 0);
-  emit('y2', item.y2 != null ? item.y2 - (item.y||0) : 0);
+  emit('x2', item.x2 != null ? item.x2 - (item.x || 0) : 0);
+  emit('y2', item.y2 != null ? item.y2 - (item.y || 0) : 0);
 }
 
 function bound(bounds, item) {

--- a/packages/vega-scenegraph/src/marks/text.js
+++ b/packages/vega-scenegraph/src/marks/text.js
@@ -1,10 +1,11 @@
 import Bounds from '../Bounds';
+import {DegToRad, HalfPi} from '../util/constants';
 import {font, offset, textMetrics, textValue} from '../util/text';
 import {visit} from '../util/visit';
 import fill from '../util/canvas/fill';
 import {pick} from '../util/canvas/pick';
 import stroke from '../util/canvas/stroke';
-import translate from '../util/svg/translate';
+import {translate, rotate} from '../util/svg/transform';
 
 var textAlign = {
   'left':   'start',
@@ -23,7 +24,7 @@ function attr(emit, item) {
       r = item.radius || 0, t;
 
   if (r) {
-    t = (item.theta || 0) - Math.PI/2;
+    t = (item.theta || 0) - HalfPi;
     x += r * Math.cos(t);
     y += r * Math.sin(t);
   }
@@ -31,7 +32,7 @@ function attr(emit, item) {
   emit('text-anchor', textAlign[item.align] || 'start');
 
   if (a) {
-    t = translate(x, y) + ' rotate('+a+')';
+    t = translate(x, y) + ' ' + rotate(a);
     if (dx || dy) t += ' ' + translate(dx, dy);
   } else {
     t = translate(x + dx, y + dy);
@@ -50,7 +51,7 @@ function bound(bounds, item, noRotate) {
       w, t;
 
   if (r) {
-    t = (item.theta || 0) - Math.PI/2;
+    t = (item.theta || 0) - HalfPi;
     x += r * Math.cos(t);
     y += r * Math.sin(t);
   }
@@ -67,7 +68,7 @@ function bound(bounds, item, noRotate) {
 
   bounds.set(dx+=x, dy+=y, dx+w, dy+h);
   if (item.angle && !noRotate) {
-    bounds.rotate(item.angle*Math.PI/180, x, y);
+    bounds.rotate(item.angle * DegToRad, x, y);
   }
   return bounds.expand(noRotate || !w ? 0 : 1);
 }
@@ -87,7 +88,7 @@ function draw(context, scene, bounds) {
     x = item.x || 0;
     y = item.y || 0;
     if ((r = item.radius)) {
-      t = (item.theta || 0) - Math.PI/2;
+      t = (item.theta || 0) - HalfPi;
       x += r * Math.cos(t);
       y += r * Math.sin(t);
     }
@@ -95,7 +96,7 @@ function draw(context, scene, bounds) {
     if (item.angle) {
       context.save();
       context.translate(x, y);
-      context.rotate(item.angle * Math.PI/180);
+      context.rotate(item.angle * DegToRad);
       x = y = 0; // reset x, y
     }
     x += (item.dx || 0);
@@ -117,7 +118,7 @@ function hit(context, item, x, y, gx, gy) {
 
   // project point into space of unrotated bounds
   var b = bound(tempBounds, item, true),
-      a = -item.angle * Math.PI / 180,
+      a = -item.angle * DegToRad,
       cos = Math.cos(a),
       sin = Math.sin(a),
       ix = item.x,

--- a/packages/vega-scenegraph/src/path/arc.js
+++ b/packages/vega-scenegraph/src/path/arc.js
@@ -1,3 +1,5 @@
+import {DegToRad, HalfPi, Tau} from '../util/constants';
+
 export var segmentCache = {};
 export var bezierCache = {};
 
@@ -10,7 +12,7 @@ export function segments(x, y, rx, ry, large, sweep, rotateX, ox, oy) {
     return segmentCache[key];
   }
 
-  var th = rotateX * (Math.PI/180);
+  var th = rotateX * DegToRad;
   var sin_th = Math.sin(th);
   var cos_th = Math.cos(th);
   rx = Math.abs(rx);
@@ -46,12 +48,12 @@ export function segments(x, y, rx, ry, large, sweep, rotateX, ox, oy) {
 
   var th_arc = th1-th0;
   if (th_arc < 0 && sweep === 1) {
-    th_arc += 2 * Math.PI;
+    th_arc += Tau;
   } else if (th_arc > 0 && sweep === 0) {
-    th_arc -= 2 * Math.PI;
+    th_arc -= Tau;
   }
 
-  var segs = Math.ceil(Math.abs(th_arc / (Math.PI * 0.5 + 0.001)));
+  var segs = Math.ceil(Math.abs(th_arc / (HalfPi + 0.001)));
   var result = [];
   for (var i=0; i<segs; ++i) {
     var th2 = th0 + i * th_arc / segs;

--- a/packages/vega-scenegraph/src/path/symbols.js
+++ b/packages/vega-scenegraph/src/path/symbols.js
@@ -1,15 +1,15 @@
 import pathParse from './parse';
 import pathRender from './render';
+import {Tau, HalfSqrt3} from '../util/constants';
 
-var tau = 2 * Math.PI,
-    halfSqrt3 = Math.sqrt(3) / 2;
+var Tan30 = 0.5773502691896257;
 
 var builtins = {
   'circle': {
     draw: function(context, size) {
       var r = Math.sqrt(size) / 2;
       context.moveTo(r, 0);
-      context.arc(0, 0, r, 0, tau);
+      context.arc(0, 0, r, 0, Tau);
     }
   },
   'cross': {
@@ -48,10 +48,49 @@ var builtins = {
       context.rect(x, x, w, w);
     }
   },
+  'arrow': {
+    draw: function(context, size) {
+      var r = Math.sqrt(size) / 2,
+          s = r / 3,
+          v = s / 2,
+          t = 2 * s;
+      context.moveTo(-s, r);
+      context.lineTo(s, r);
+      context.lineTo(s, -v);
+      context.lineTo(t, -v);
+      context.lineTo(0, -r);
+      context.lineTo(-t, -v);
+      context.lineTo(-s, -v);
+      context.closePath();
+    }
+  },
+  'wedge': {
+    draw: function(context, size) {
+      var r = Math.sqrt(size) / 2,
+          h = HalfSqrt3 * r,
+          o = (h - r * Tan30),
+          b = r / 2;
+      context.moveTo(0, -h - o);
+      context.lineTo(-b, h - o);
+      context.lineTo(b, h - o);
+      context.closePath();
+    }
+  },
+  'triangle': {
+    draw: function(context, size) {
+      var r = Math.sqrt(size) / 2,
+          h = HalfSqrt3 * r,
+          o = (h - r * Tan30);
+      context.moveTo(0, -h - o);
+      context.lineTo(-r, h - o);
+      context.lineTo(r, h - o);
+      context.closePath();
+    }
+  },
   'triangle-up': {
     draw: function(context, size) {
       var r = Math.sqrt(size) / 2,
-          h = halfSqrt3 * r;
+          h = HalfSqrt3 * r;
       context.moveTo(0, -h);
       context.lineTo(-r, h);
       context.lineTo(r, h);
@@ -61,7 +100,7 @@ var builtins = {
   'triangle-down': {
     draw: function(context, size) {
       var r = Math.sqrt(size) / 2,
-          h = halfSqrt3 * r;
+          h = HalfSqrt3 * r;
       context.moveTo(0, h);
       context.lineTo(-r, -h);
       context.lineTo(r, -h);
@@ -71,7 +110,7 @@ var builtins = {
   'triangle-right': {
     draw: function(context, size) {
       var r = Math.sqrt(size) / 2,
-          h = halfSqrt3 * r;
+          h = HalfSqrt3 * r;
       context.moveTo(h, 0);
       context.lineTo(-h, -r);
       context.lineTo(-h, r);
@@ -81,11 +120,18 @@ var builtins = {
   'triangle-left': {
     draw: function(context, size) {
       var r = Math.sqrt(size) / 2,
-          h = halfSqrt3 * r;
+          h = HalfSqrt3 * r;
       context.moveTo(-h, 0);
       context.lineTo(h, -r);
       context.lineTo(h, r);
       context.closePath();
+    }
+  },
+  'stroke': {
+    draw: function(context, size) {
+      var r = Math.sqrt(size) / 2;
+      context.moveTo(-r, 0);
+      context.lineTo(r, 0);
     }
   }
 };

--- a/packages/vega-scenegraph/src/path/trail.js
+++ b/packages/vega-scenegraph/src/path/trail.js
@@ -1,6 +1,5 @@
+import {Tau} from '../util/constants';
 import {path} from 'd3-path';
-
-var pi = Math.PI;
 
 export default function() {
   var x,
@@ -27,11 +26,11 @@ export default function() {
         // draw segment
         context.moveTo(x1 - rx, y1 - ry);
         context.lineTo(x2 - ux * r2, y2 - uy * r2);
-        context.arc(x2, y2, r2, t - pi, t);
+        context.arc(x2, y2, r2, t - Math.PI, t);
         context.lineTo(x1 + rx, y1 + ry);
-        context.arc(x1, y1, r1, t, t + pi);
+        context.arc(x1, y1, r1, t, t + Math.PI);
       } else {
-        context.arc(x2, y2, r2, 0, 2*pi);
+        context.arc(x2, y2, r2, 0, Tau);
       }
       context.closePath();
     } else {

--- a/packages/vega-scenegraph/src/util/constants.js
+++ b/packages/vega-scenegraph/src/util/constants.js
@@ -1,0 +1,4 @@
+export var DegToRad = Math.PI / 180;
+export var HalfPi = Math.PI / 2;
+export var Tau = Math.PI * 2;
+export var HalfSqrt3 = Math.sqrt(3) / 2;

--- a/packages/vega-scenegraph/src/util/svg/transform.js
+++ b/packages/vega-scenegraph/src/util/svg/transform.js
@@ -1,0 +1,16 @@
+export function translate(x, y) {
+  return 'translate(' + x + ',' + y + ')';
+}
+
+export function rotate(a) {
+  return 'rotate(' + a + ')';
+}
+
+export function translateItem(item) {
+  return translate(item.x || 0, item.y || 0);
+}
+
+export function transformItem(item) {
+  return translate(item.x || 0, item.y || 0)
+    + (item.angle ? ' ' + rotate(item.angle) : '');
+}

--- a/packages/vega-scenegraph/src/util/svg/translate.js
+++ b/packages/vega-scenegraph/src/util/svg/translate.js
@@ -1,3 +1,0 @@
-export default function(x, y) {
-  return 'translate(' + x + ',' + y + ')';
-}

--- a/packages/vega-scenegraph/src/util/svg/translateItem.js
+++ b/packages/vega-scenegraph/src/util/svg/translateItem.js
@@ -1,5 +1,0 @@
-import translate from './translate';
-
-export default function(item) {
-  return translate(item.x || 0, item.y || 0);
-}

--- a/packages/vega-schema/src/encode.js
+++ b/packages/vega-schema/src/encode.js
@@ -141,6 +141,9 @@ const encodeEntry = object({
   // Group-mark properties
   clip: booleanValueRef,
 
+  // Symbol- and text-mark properties
+  angle: numberValueRef,
+
   // Symbol-mark properties
   size: numberValueRef,
   shape: stringValueRef,
@@ -173,7 +176,6 @@ const encodeEntry = object({
   dy: numberValueRef,
   radius:numberValueRef,
   theta: numberValueRef,
-  angle: numberValueRef,
   font: stringValueRef,
   fontSize: numberValueRef,
   fontWeight: ref('fontWeightValue'),

--- a/packages/vega/test/scenegraphs/symbol-angle.json
+++ b/packages/vega/test/scenegraphs/symbol-angle.json
@@ -1,0 +1,1596 @@
+{
+  "marktype": "group",
+  "name": "root",
+  "role": "frame",
+  "interactive": true,
+  "clip": false,
+  "items": [
+    {
+      "items": [
+        {
+          "marktype": "symbol",
+          "role": "mark",
+          "interactive": true,
+          "clip": false,
+          "items": [
+            {
+              "x": 0,
+              "y": 0,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "cross",
+              "angle": 0
+            },
+            {
+              "x": 50,
+              "y": 0,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "cross",
+              "angle": 15
+            },
+            {
+              "x": 100,
+              "y": 0,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "cross",
+              "angle": 30
+            },
+            {
+              "x": 150,
+              "y": 0,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "cross",
+              "angle": 45
+            },
+            {
+              "x": 200,
+              "y": 0,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "cross",
+              "angle": 60
+            },
+            {
+              "x": 250,
+              "y": 0,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "cross",
+              "angle": 75
+            },
+            {
+              "x": 300,
+              "y": 0,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "cross",
+              "angle": 90
+            },
+            {
+              "x": 350,
+              "y": 0,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "cross",
+              "angle": 105
+            },
+            {
+              "x": 400,
+              "y": 0,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "cross",
+              "angle": 120
+            },
+            {
+              "x": 450,
+              "y": 0,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "cross",
+              "angle": 135
+            },
+            {
+              "x": 500,
+              "y": 0,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "cross",
+              "angle": 150
+            },
+            {
+              "x": 550,
+              "y": 0,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "cross",
+              "angle": 165
+            },
+            {
+              "x": 600,
+              "y": 0,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "cross",
+              "angle": 180
+            },
+            {
+              "x": 0,
+              "y": 50,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "cross",
+              "angle": 0
+            },
+            {
+              "x": 50,
+              "y": 50,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "cross",
+              "angle": -15
+            },
+            {
+              "x": 100,
+              "y": 50,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "cross",
+              "angle": -30
+            },
+            {
+              "x": 150,
+              "y": 50,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "cross",
+              "angle": -45
+            },
+            {
+              "x": 200,
+              "y": 50,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "cross",
+              "angle": -60
+            },
+            {
+              "x": 250,
+              "y": 50,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "cross",
+              "angle": -75
+            },
+            {
+              "x": 300,
+              "y": 50,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "cross",
+              "angle": -90
+            },
+            {
+              "x": 350,
+              "y": 50,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "cross",
+              "angle": -105
+            },
+            {
+              "x": 400,
+              "y": 50,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "cross",
+              "angle": -120
+            },
+            {
+              "x": 450,
+              "y": 50,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "cross",
+              "angle": -135
+            },
+            {
+              "x": 500,
+              "y": 50,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "cross",
+              "angle": -150
+            },
+            {
+              "x": 550,
+              "y": 50,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "cross",
+              "angle": -165
+            },
+            {
+              "x": 600,
+              "y": 50,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "cross",
+              "angle": -180
+            },
+            {
+              "x": 0,
+              "y": 100,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "triangle",
+              "angle": 0
+            },
+            {
+              "x": 50,
+              "y": 100,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "triangle",
+              "angle": 15
+            },
+            {
+              "x": 100,
+              "y": 100,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "triangle",
+              "angle": 30
+            },
+            {
+              "x": 150,
+              "y": 100,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "triangle",
+              "angle": 45
+            },
+            {
+              "x": 200,
+              "y": 100,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "triangle",
+              "angle": 60
+            },
+            {
+              "x": 250,
+              "y": 100,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "triangle",
+              "angle": 75
+            },
+            {
+              "x": 300,
+              "y": 100,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "triangle",
+              "angle": 90
+            },
+            {
+              "x": 350,
+              "y": 100,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "triangle",
+              "angle": 105
+            },
+            {
+              "x": 400,
+              "y": 100,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "triangle",
+              "angle": 120
+            },
+            {
+              "x": 450,
+              "y": 100,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "triangle",
+              "angle": 135
+            },
+            {
+              "x": 500,
+              "y": 100,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "triangle",
+              "angle": 150
+            },
+            {
+              "x": 550,
+              "y": 100,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "triangle",
+              "angle": 165
+            },
+            {
+              "x": 600,
+              "y": 100,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "triangle",
+              "angle": 180
+            },
+            {
+              "x": 0,
+              "y": 150,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "triangle",
+              "angle": 0
+            },
+            {
+              "x": 50,
+              "y": 150,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "triangle",
+              "angle": -15
+            },
+            {
+              "x": 100,
+              "y": 150,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "triangle",
+              "angle": -30
+            },
+            {
+              "x": 150,
+              "y": 150,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "triangle",
+              "angle": -45
+            },
+            {
+              "x": 200,
+              "y": 150,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "triangle",
+              "angle": -60
+            },
+            {
+              "x": 250,
+              "y": 150,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "triangle",
+              "angle": -75
+            },
+            {
+              "x": 300,
+              "y": 150,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "triangle",
+              "angle": -90
+            },
+            {
+              "x": 350,
+              "y": 150,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "triangle",
+              "angle": -105
+            },
+            {
+              "x": 400,
+              "y": 150,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "triangle",
+              "angle": -120
+            },
+            {
+              "x": 450,
+              "y": 150,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "triangle",
+              "angle": -135
+            },
+            {
+              "x": 500,
+              "y": 150,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "triangle",
+              "angle": -150
+            },
+            {
+              "x": 550,
+              "y": 150,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "triangle",
+              "angle": -165
+            },
+            {
+              "x": 600,
+              "y": 150,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "triangle",
+              "angle": -180
+            },
+            {
+              "x": 0,
+              "y": 200,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "wedge",
+              "angle": 0
+            },
+            {
+              "x": 50,
+              "y": 200,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "wedge",
+              "angle": 15
+            },
+            {
+              "x": 100,
+              "y": 200,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "wedge",
+              "angle": 30
+            },
+            {
+              "x": 150,
+              "y": 200,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "wedge",
+              "angle": 45
+            },
+            {
+              "x": 200,
+              "y": 200,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "wedge",
+              "angle": 60
+            },
+            {
+              "x": 250,
+              "y": 200,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "wedge",
+              "angle": 75
+            },
+            {
+              "x": 300,
+              "y": 200,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "wedge",
+              "angle": 90
+            },
+            {
+              "x": 350,
+              "y": 200,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "wedge",
+              "angle": 105
+            },
+            {
+              "x": 400,
+              "y": 200,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "wedge",
+              "angle": 120
+            },
+            {
+              "x": 450,
+              "y": 200,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "wedge",
+              "angle": 135
+            },
+            {
+              "x": 500,
+              "y": 200,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "wedge",
+              "angle": 150
+            },
+            {
+              "x": 550,
+              "y": 200,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "wedge",
+              "angle": 165
+            },
+            {
+              "x": 600,
+              "y": 200,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "wedge",
+              "angle": 180
+            },
+            {
+              "x": 0,
+              "y": 250,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "wedge",
+              "angle": 0
+            },
+            {
+              "x": 50,
+              "y": 250,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "wedge",
+              "angle": -15
+            },
+            {
+              "x": 100,
+              "y": 250,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "wedge",
+              "angle": -30
+            },
+            {
+              "x": 150,
+              "y": 250,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "wedge",
+              "angle": -45
+            },
+            {
+              "x": 200,
+              "y": 250,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "wedge",
+              "angle": -60
+            },
+            {
+              "x": 250,
+              "y": 250,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "wedge",
+              "angle": -75
+            },
+            {
+              "x": 300,
+              "y": 250,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "wedge",
+              "angle": -90
+            },
+            {
+              "x": 350,
+              "y": 250,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "wedge",
+              "angle": -105
+            },
+            {
+              "x": 400,
+              "y": 250,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "wedge",
+              "angle": -120
+            },
+            {
+              "x": 450,
+              "y": 250,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "wedge",
+              "angle": -135
+            },
+            {
+              "x": 500,
+              "y": 250,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "wedge",
+              "angle": -150
+            },
+            {
+              "x": 550,
+              "y": 250,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "wedge",
+              "angle": -165
+            },
+            {
+              "x": 600,
+              "y": 250,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "wedge",
+              "angle": -180
+            },
+            {
+              "x": 0,
+              "y": 300,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "arrow",
+              "angle": 0
+            },
+            {
+              "x": 50,
+              "y": 300,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "arrow",
+              "angle": 15
+            },
+            {
+              "x": 100,
+              "y": 300,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "arrow",
+              "angle": 30
+            },
+            {
+              "x": 150,
+              "y": 300,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "arrow",
+              "angle": 45
+            },
+            {
+              "x": 200,
+              "y": 300,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "arrow",
+              "angle": 60
+            },
+            {
+              "x": 250,
+              "y": 300,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "arrow",
+              "angle": 75
+            },
+            {
+              "x": 300,
+              "y": 300,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "arrow",
+              "angle": 90
+            },
+            {
+              "x": 350,
+              "y": 300,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "arrow",
+              "angle": 105
+            },
+            {
+              "x": 400,
+              "y": 300,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "arrow",
+              "angle": 120
+            },
+            {
+              "x": 450,
+              "y": 300,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "arrow",
+              "angle": 135
+            },
+            {
+              "x": 500,
+              "y": 300,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "arrow",
+              "angle": 150
+            },
+            {
+              "x": 550,
+              "y": 300,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "arrow",
+              "angle": 165
+            },
+            {
+              "x": 600,
+              "y": 300,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "arrow",
+              "angle": 180
+            },
+            {
+              "x": 0,
+              "y": 350,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "arrow",
+              "angle": 0
+            },
+            {
+              "x": 50,
+              "y": 350,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "arrow",
+              "angle": -15
+            },
+            {
+              "x": 100,
+              "y": 350,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "arrow",
+              "angle": -30
+            },
+            {
+              "x": 150,
+              "y": 350,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "arrow",
+              "angle": -45
+            },
+            {
+              "x": 200,
+              "y": 350,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "arrow",
+              "angle": -60
+            },
+            {
+              "x": 250,
+              "y": 350,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "arrow",
+              "angle": -75
+            },
+            {
+              "x": 300,
+              "y": 350,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "arrow",
+              "angle": -90
+            },
+            {
+              "x": 350,
+              "y": 350,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "arrow",
+              "angle": -105
+            },
+            {
+              "x": 400,
+              "y": 350,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "arrow",
+              "angle": -120
+            },
+            {
+              "x": 450,
+              "y": 350,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "arrow",
+              "angle": -135
+            },
+            {
+              "x": 500,
+              "y": 350,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "arrow",
+              "angle": -150
+            },
+            {
+              "x": 550,
+              "y": 350,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "arrow",
+              "angle": -165
+            },
+            {
+              "x": 600,
+              "y": 350,
+              "fill": "steelblue",
+              "size": 1000,
+              "shape": "arrow",
+              "angle": -180
+            }
+          ],
+          "zindex": 0
+        },
+        {
+          "marktype": "symbol",
+          "role": "mark",
+          "interactive": false,
+          "clip": false,
+          "items": [
+            {
+              "x": 0,
+              "y": 0,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 50,
+              "y": 0,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 100,
+              "y": 0,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 150,
+              "y": 0,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 200,
+              "y": 0,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 250,
+              "y": 0,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 300,
+              "y": 0,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 350,
+              "y": 0,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 400,
+              "y": 0,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 450,
+              "y": 0,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 500,
+              "y": 0,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 550,
+              "y": 0,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 600,
+              "y": 0,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 0,
+              "y": 50,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 50,
+              "y": 50,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 100,
+              "y": 50,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 150,
+              "y": 50,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 200,
+              "y": 50,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 250,
+              "y": 50,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 300,
+              "y": 50,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 350,
+              "y": 50,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 400,
+              "y": 50,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 450,
+              "y": 50,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 500,
+              "y": 50,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 550,
+              "y": 50,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 600,
+              "y": 50,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 0,
+              "y": 100,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 50,
+              "y": 100,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 100,
+              "y": 100,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 150,
+              "y": 100,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 200,
+              "y": 100,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 250,
+              "y": 100,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 300,
+              "y": 100,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 350,
+              "y": 100,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 400,
+              "y": 100,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 450,
+              "y": 100,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 500,
+              "y": 100,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 550,
+              "y": 100,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 600,
+              "y": 100,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 0,
+              "y": 150,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 50,
+              "y": 150,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 100,
+              "y": 150,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 150,
+              "y": 150,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 200,
+              "y": 150,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 250,
+              "y": 150,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 300,
+              "y": 150,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 350,
+              "y": 150,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 400,
+              "y": 150,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 450,
+              "y": 150,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 500,
+              "y": 150,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 550,
+              "y": 150,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 600,
+              "y": 150,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 0,
+              "y": 200,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 50,
+              "y": 200,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 100,
+              "y": 200,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 150,
+              "y": 200,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 200,
+              "y": 200,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 250,
+              "y": 200,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 300,
+              "y": 200,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 350,
+              "y": 200,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 400,
+              "y": 200,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 450,
+              "y": 200,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 500,
+              "y": 200,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 550,
+              "y": 200,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 600,
+              "y": 200,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 0,
+              "y": 250,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 50,
+              "y": 250,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 100,
+              "y": 250,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 150,
+              "y": 250,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 200,
+              "y": 250,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 250,
+              "y": 250,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 300,
+              "y": 250,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 350,
+              "y": 250,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 400,
+              "y": 250,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 450,
+              "y": 250,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 500,
+              "y": 250,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 550,
+              "y": 250,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 600,
+              "y": 250,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 0,
+              "y": 300,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 50,
+              "y": 300,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 100,
+              "y": 300,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 150,
+              "y": 300,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 200,
+              "y": 300,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 250,
+              "y": 300,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 300,
+              "y": 300,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 350,
+              "y": 300,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 400,
+              "y": 300,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 450,
+              "y": 300,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 500,
+              "y": 300,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 550,
+              "y": 300,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 600,
+              "y": 300,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 0,
+              "y": 350,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 50,
+              "y": 350,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 100,
+              "y": 350,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 150,
+              "y": 350,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 200,
+              "y": 350,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 250,
+              "y": 350,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 300,
+              "y": 350,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 350,
+              "y": 350,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 400,
+              "y": 350,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 450,
+              "y": 350,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 500,
+              "y": 350,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 550,
+              "y": 350,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            },
+            {
+              "x": 600,
+              "y": 350,
+              "fill": "#000",
+              "size": 9,
+              "shape": "circle"
+            }
+          ],
+          "zindex": 0
+        }
+      ],
+      "x": 0,
+      "y": 0,
+      "width": 0,
+      "height": 0
+    }
+  ],
+  "zindex": 0
+}

--- a/packages/vega/test/specs-valid.json
+++ b/packages/vega/test/specs-valid.json
@@ -75,6 +75,7 @@
   "stacked-area",
   "stacked-bar",
   "stocks-index",
+  "symbol-angle",
   "titles",
   "tree-cluster",
   "tree-nest",

--- a/packages/vega/test/specs-valid/symbol-angle.vg.json
+++ b/packages/vega/test/specs-valid/symbol-angle.vg.json
@@ -1,0 +1,174 @@
+{
+  "$schema": "https://vega.github.io/schema/vega/v4.json",
+  "padding": 5,
+
+  "signals": [
+    {
+      "name": "baseAngle", "value": 0,
+      "bind": {"input": "range", "min": -180, "max": 180, "step": 1}
+    }
+  ],
+
+  "data": [
+    {
+      "name": "table",
+      "values": [
+        {"u":  1, "v":  1, "a":    0, "s": "cross"},
+        {"u":  1, "v":  2, "a":   15, "s": "cross"},
+        {"u":  1, "v":  3, "a":   30, "s": "cross"},
+        {"u":  1, "v":  4, "a":   45, "s": "cross"},
+        {"u":  1, "v":  5, "a":   60, "s": "cross"},
+        {"u":  1, "v":  6, "a":   75, "s": "cross"},
+        {"u":  1, "v":  7, "a":   90, "s": "cross"},
+        {"u":  1, "v":  8, "a":  105, "s": "cross"},
+        {"u":  1, "v":  9, "a":  120, "s": "cross"},
+        {"u":  1, "v": 10, "a":  135, "s": "cross"},
+        {"u":  1, "v": 11, "a":  150, "s": "cross"},
+        {"u":  1, "v": 12, "a":  165, "s": "cross"},
+        {"u":  1, "v": 13, "a":  180, "s": "cross"},
+        {"u":  2, "v":  1, "a":    0, "s": "cross"},
+        {"u":  2, "v":  2, "a":  -15, "s": "cross"},
+        {"u":  2, "v":  3, "a":  -30, "s": "cross"},
+        {"u":  2, "v":  4, "a":  -45, "s": "cross"},
+        {"u":  2, "v":  5, "a":  -60, "s": "cross"},
+        {"u":  2, "v":  6, "a":  -75, "s": "cross"},
+        {"u":  2, "v":  7, "a":  -90, "s": "cross"},
+        {"u":  2, "v":  8, "a": -105, "s": "cross"},
+        {"u":  2, "v":  9, "a": -120, "s": "cross"},
+        {"u":  2, "v": 10, "a": -135, "s": "cross"},
+        {"u":  2, "v": 11, "a": -150, "s": "cross"},
+        {"u":  2, "v": 12, "a": -165, "s": "cross"},
+        {"u":  2, "v": 13, "a": -180, "s": "cross"},
+        {"u":  3, "v":  1, "a":    0, "s": "triangle"},
+        {"u":  3, "v":  2, "a":   15, "s": "triangle"},
+        {"u":  3, "v":  3, "a":   30, "s": "triangle"},
+        {"u":  3, "v":  4, "a":   45, "s": "triangle"},
+        {"u":  3, "v":  5, "a":   60, "s": "triangle"},
+        {"u":  3, "v":  6, "a":   75, "s": "triangle"},
+        {"u":  3, "v":  7, "a":   90, "s": "triangle"},
+        {"u":  3, "v":  8, "a":  105, "s": "triangle"},
+        {"u":  3, "v":  9, "a":  120, "s": "triangle"},
+        {"u":  3, "v": 10, "a":  135, "s": "triangle"},
+        {"u":  3, "v": 11, "a":  150, "s": "triangle"},
+        {"u":  3, "v": 12, "a":  165, "s": "triangle"},
+        {"u":  3, "v": 13, "a":  180, "s": "triangle"},
+        {"u":  4, "v":  1, "a":   0,  "s": "triangle"},
+        {"u":  4, "v":  2, "a":  -15, "s": "triangle"},
+        {"u":  4, "v":  3, "a":  -30, "s": "triangle"},
+        {"u":  4, "v":  4, "a":  -45, "s": "triangle"},
+        {"u":  4, "v":  5, "a":  -60, "s": "triangle"},
+        {"u":  4, "v":  6, "a":  -75, "s": "triangle"},
+        {"u":  4, "v":  7, "a":  -90, "s": "triangle"},
+        {"u":  4, "v":  8, "a": -105, "s": "triangle"},
+        {"u":  4, "v":  9, "a": -120, "s": "triangle"},
+        {"u":  4, "v": 10, "a": -135, "s": "triangle"},
+        {"u":  4, "v": 11, "a": -150, "s": "triangle"},
+        {"u":  4, "v": 12, "a": -165, "s": "triangle"},
+        {"u":  4, "v": 13, "a": -180, "s": "triangle"},
+        {"u":  5, "v":  1, "a":    0, "s": "wedge"},
+        {"u":  5, "v":  2, "a":   15, "s": "wedge"},
+        {"u":  5, "v":  3, "a":   30, "s": "wedge"},
+        {"u":  5, "v":  4, "a":   45, "s": "wedge"},
+        {"u":  5, "v":  5, "a":   60, "s": "wedge"},
+        {"u":  5, "v":  6, "a":   75, "s": "wedge"},
+        {"u":  5, "v":  7, "a":   90, "s": "wedge"},
+        {"u":  5, "v":  8, "a":  105, "s": "wedge"},
+        {"u":  5, "v":  9, "a":  120, "s": "wedge"},
+        {"u":  5, "v": 10, "a":  135, "s": "wedge"},
+        {"u":  5, "v": 11, "a":  150, "s": "wedge"},
+        {"u":  5, "v": 12, "a":  165, "s": "wedge"},
+        {"u":  5, "v": 13, "a":  180, "s": "wedge"},
+        {"u":  6, "v":  1, "a":   0,  "s": "wedge"},
+        {"u":  6, "v":  2, "a":  -15, "s": "wedge"},
+        {"u":  6, "v":  3, "a":  -30, "s": "wedge"},
+        {"u":  6, "v":  4, "a":  -45, "s": "wedge"},
+        {"u":  6, "v":  5, "a":  -60, "s": "wedge"},
+        {"u":  6, "v":  6, "a":  -75, "s": "wedge"},
+        {"u":  6, "v":  7, "a":  -90, "s": "wedge"},
+        {"u":  6, "v":  8, "a": -105, "s": "wedge"},
+        {"u":  6, "v":  9, "a": -120, "s": "wedge"},
+        {"u":  6, "v": 10, "a": -135, "s": "wedge"},
+        {"u":  6, "v": 11, "a": -150, "s": "wedge"},
+        {"u":  6, "v": 12, "a": -165, "s": "wedge"},
+        {"u":  6, "v": 13, "a": -180, "s": "wedge"},
+        {"u":  7, "v":  1, "a":    0, "s": "arrow"},
+        {"u":  7, "v":  2, "a":   15, "s": "arrow"},
+        {"u":  7, "v":  3, "a":   30, "s": "arrow"},
+        {"u":  7, "v":  4, "a":   45, "s": "arrow"},
+        {"u":  7, "v":  5, "a":   60, "s": "arrow"},
+        {"u":  7, "v":  6, "a":   75, "s": "arrow"},
+        {"u":  7, "v":  7, "a":   90, "s": "arrow"},
+        {"u":  7, "v":  8, "a":  105, "s": "arrow"},
+        {"u":  7, "v":  9, "a":  120, "s": "arrow"},
+        {"u":  7, "v": 10, "a":  135, "s": "arrow"},
+        {"u":  7, "v": 11, "a":  150, "s": "arrow"},
+        {"u":  7, "v": 12, "a":  165, "s": "arrow"},
+        {"u":  7, "v": 13, "a":  180, "s": "arrow"},
+        {"u":  8, "v":  1, "a":   0,  "s": "arrow"},
+        {"u":  8, "v":  2, "a":  -15, "s": "arrow"},
+        {"u":  8, "v":  3, "a":  -30, "s": "arrow"},
+        {"u":  8, "v":  4, "a":  -45, "s": "arrow"},
+        {"u":  8, "v":  5, "a":  -60, "s": "arrow"},
+        {"u":  8, "v":  6, "a":  -75, "s": "arrow"},
+        {"u":  8, "v":  7, "a":  -90, "s": "arrow"},
+        {"u":  8, "v":  8, "a": -105, "s": "arrow"},
+        {"u":  8, "v":  9, "a": -120, "s": "arrow"},
+        {"u":  8, "v": 10, "a": -135, "s": "arrow"},
+        {"u":  8, "v": 11, "a": -150, "s": "arrow"},
+        {"u":  8, "v": 12, "a": -165, "s": "arrow"},
+        {"u":  8, "v": 13, "a": -180, "s": "arrow"}
+      ]
+    }
+  ],
+
+  "scales": [
+    {
+      "name": "xscale",
+      "type": "band",
+      "range": {"step": 50},
+      "domain": {"data": "table", "field": "v"}
+    },
+    {
+      "name": "yscale",
+      "type": "band",
+      "range": {"step": 50},
+      "domain": {"data": "table", "field": "u"}
+    }
+  ],
+
+  "marks": [
+    {
+      "type": "symbol",
+      "from": {"data": "table"},
+      "encode": {
+        "enter": {
+          "shape": {"field": "s"},
+          "x": {"scale": "xscale", "field": "v"},
+          "y": {"scale": "yscale", "field": "u"},
+          "size": {"value": 1000}
+        },
+        "update": {
+          "fill": {"value": "steelblue"},
+          "angle": {"field": "a", "offset": {"signal": "baseAngle"}}
+        },
+        "hover": {
+          "fill": {"value": "firebrick"}
+        }
+      }
+    },
+    {
+      "type": "symbol",
+      "from": {"data": "table"},
+      "interactive": false,
+      "encode": {
+        "enter": {
+          "shape": {"value": "circle"},
+          "x": {"scale": "xscale", "field": "v"},
+          "y": {"scale": "yscale", "field": "u"},
+          "size": {"value": 9},
+          "fill": {"value": "#000"}
+        }
+      }
+    }
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -73,16 +73,16 @@
     read-package-tree "^5.1.6"
     semver "^5.5.0"
 
-"@lerna/changed@3.11.0":
-  version "3.11.0"
-  resolved "https://registry.yarnpkg.com/@lerna/changed/-/changed-3.11.0.tgz#aa164446dc175cc59b6b70f878a9ccdc52a89e4d"
-  integrity sha512-owUwGqinBx4YWRelPlYyz+F7TqoyZcYCRPQZG+8F16Bivof5yj3bdnuzx0xzeOSW3WNOWANiaD4rWGdo3rmjeQ==
+"@lerna/changed@3.11.1":
+  version "3.11.1"
+  resolved "https://registry.yarnpkg.com/@lerna/changed/-/changed-3.11.1.tgz#d8a856f8237e37e7686d17a1e13bf4d082a3e48b"
+  integrity sha512-A21h3DvMjDwhksmCmTQ1+3KPHg7gHVHFs3zC5lR9W+whYlm0JI2Yp70vYnqMv2hPAcJx+2tlCrqJkzCFkNQdqg==
   dependencies:
     "@lerna/collect-updates" "3.11.0"
     "@lerna/command" "3.11.0"
     "@lerna/listable" "3.11.0"
     "@lerna/output" "3.11.0"
-    "@lerna/version" "3.11.0"
+    "@lerna/version" "3.11.1"
 
 "@lerna/check-working-tree@3.11.0":
   version "3.11.0"
@@ -472,10 +472,10 @@
     inquirer "^6.2.0"
     npmlog "^4.1.2"
 
-"@lerna/publish@3.11.0":
-  version "3.11.0"
-  resolved "https://registry.yarnpkg.com/@lerna/publish/-/publish-3.11.0.tgz#b35460bf6f472d17d756043baedb02c6f434acf0"
-  integrity sha512-8vdb5YOnPphIig4FCXwuLAdptFNfMcCj/TMCwtsFDQqNbeCbVABkptqjfmldVmGfcxwbkqHLH7cbazVSIGPonA==
+"@lerna/publish@3.11.1":
+  version "3.11.1"
+  resolved "https://registry.yarnpkg.com/@lerna/publish/-/publish-3.11.1.tgz#06b0f646afea7f29cd820a63086692a4ac4d080e"
+  integrity sha512-UOvmSivuqzWoiTqoYWk+liPDZvC6O7NrT8DwoG2peRvjIPs5RKYMubwXPOrBBVVE+yX/vR6V1Y3o6vf3av52dg==
   dependencies:
     "@lerna/batch-packages" "3.11.0"
     "@lerna/check-working-tree" "3.11.0"
@@ -494,7 +494,7 @@
     "@lerna/run-lifecycle" "3.11.0"
     "@lerna/run-parallel-batches" "3.0.0"
     "@lerna/validation-error" "3.11.0"
-    "@lerna/version" "3.11.0"
+    "@lerna/version" "3.11.1"
     figgy-pudding "^3.5.1"
     fs-extra "^7.0.0"
     libnpmaccess "^3.0.1"
@@ -602,10 +602,10 @@
   dependencies:
     npmlog "^4.1.2"
 
-"@lerna/version@3.11.0":
-  version "3.11.0"
-  resolved "https://registry.yarnpkg.com/@lerna/version/-/version-3.11.0.tgz#84c7cb9ecbf670dc6ebb72fda9339017435b7738"
-  integrity sha512-J6Ffq1qU7hYwgmn7vM1QlhkBUH1wakG5wiHWv6Pk4XpCCA+PoHKTjCbpovmFIIYOI19QGYpdZV9C8dST/0aPiA==
+"@lerna/version@3.11.1":
+  version "3.11.1"
+  resolved "https://registry.yarnpkg.com/@lerna/version/-/version-3.11.1.tgz#c4031670838ccd5e285ec481c36e8703f4d835b2"
+  integrity sha512-+lFq4D8BpchIslIz6jyUY6TZO1kuAgQ+G1LjaYwUBiP2SzXVWgPoPoq/9dnaSq38Hhhvlf7FF6i15d+q8gk1xQ==
   dependencies:
     "@lerna/batch-packages" "3.11.0"
     "@lerna/check-working-tree" "3.11.0"
@@ -662,9 +662,9 @@
     url-template "^2.0.8"
 
 "@octokit/plugin-enterprise-rest@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@octokit/plugin-enterprise-rest/-/plugin-enterprise-rest-2.1.0.tgz#e5fa5213627a8910fd151fab2934594e66fce8fd"
-  integrity sha512-Rx7hpUsLt4MBgEuKiRFi+NNzKTeo/3YXveEDFD2xuNFmPTtgJLx580/C1Sci83kBFkMWXf6Sk57ZrBG+f5jWIw==
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-enterprise-rest/-/plugin-enterprise-rest-2.1.1.tgz#ee7b245aada06d3ffdd409205ad1b891107fee0b"
+  integrity sha512-DJNXHH0LptKCLpJ8y3vCA/O+s+3/sDU4JNN2V0M04tsMN0hVGLPzoGgejPJgaxGP8Il5aw+jA5Nl5mTfdt9NrQ==
 
 "@octokit/request@2.3.0":
   version "2.3.0"
@@ -696,10 +696,15 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
 
-"@types/node@*", "@types/node@^10.12.21":
-  version "10.12.24"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.24.tgz#b13564af612a22a20b5d95ca40f1bffb3af315cf"
-  integrity sha512-GWWbvt+z9G5otRBW8rssOFgRY87J9N/qbhqfjMZ+gUuL6zoL+Hm6gP/8qQBG4jjimqdaNLCehcVapZ/Fs2WjCQ==
+"@types/node@*":
+  version "11.9.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.9.0.tgz#35fea17653490dab82e1d5e69731abfdbf13160d"
+  integrity sha512-ry4DOrC+xenhQbzk1iIPzCZGhhPGEFv7ia7Iu6XXSLVluiJIe9FfG7Iu3mObH9mpxEXCWLCMU4JWbCCR9Oy1Zg==
+
+"@types/node@^10.12.21":
+  version "10.12.25"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.25.tgz#0d01a7dd6127de60d861ece4a650963042abb538"
+  integrity sha512-IcvnGLGSQFDvC07Bz2I8SX+QKErDZbUdiQq7S2u3XyzTyJfUmT0sWJMbeQkMzpTAkO7/N7sZpW/arUM2jfKsbQ==
 
 "@types/parsimmon@^1.3.0":
   version "1.10.0"
@@ -761,10 +766,10 @@ agentkeepalive@^3.4.1:
   dependencies:
     humanize-ms "^1.2.1"
 
-ajv@^6.5.3, ajv@^6.5.5, ajv@^6.6.1:
-  version "6.8.1"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.8.1.tgz#0890b93742985ebf8973cd365c5b23920ce3cb20"
-  integrity sha512-eqxCp82P+JfqL683wwsL73XmFs1eG6qjw+RD3YHx+Jll1r0jNd4dh8QG9NYAeNGA/hnZjeEDgtTskgJULbxpWQ==
+ajv@^6.5.3, ajv@^6.5.5, ajv@^6.9.1:
+  version "6.9.1"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.9.1.tgz#a4d3683d74abc5670e75f0b16520f70a20ea8dc1"
+  integrity sha512-XDN92U311aINL77ieWHmqCcNlwjoP5cHXDxIxbf2MaPYuCXOHS7gHH8jktxeK5omgd52XbSTX6a4Piwd1pQmzA==
   dependencies:
     fast-deep-equal "^2.0.1"
     fast-json-stable-stringify "^2.0.0"
@@ -1619,9 +1624,9 @@ d3-path@1, d3-path@^1.0.7:
   integrity sha512-q0cW1RpvA5c5ma2rch62mX8AYaiLX0+bdaSM2wxSU9tXjU4DNvkx9qiUvjkuWCj3p22UO/hlPivujqMiR9PDzA==
 
 d3-quadtree@1:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/d3-quadtree/-/d3-quadtree-1.0.5.tgz#305394840b01f51a341a0da5008585e837fe7e9b"
-  integrity sha512-U2tjwDFbZ75JRAg8A+cqMvqPg1G3BE7UTJn3h8DHjY/pnsAfWdbJKgyfcy7zKjqGtLAmI0q8aDSeG1TVIKRaHQ==
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/d3-quadtree/-/d3-quadtree-1.0.6.tgz#d1ab2a95a7f27bbde88582c94166f6ae35f32056"
+  integrity sha512-NUgeo9G+ENQCQ1LsRr2qJg3MQ4DJvxcDNCiohdJGHt5gRhBW6orIB5m5FJ9kK3HNL8g9F4ERVoBzcEwQBfXWVA==
 
 d3-scale-chromatic@^1.3.3:
   version "1.3.3"
@@ -1643,7 +1648,7 @@ d3-scale@^2.2.2:
     d3-time "1"
     d3-time-format "2"
 
-d3-shape@^1.2.2:
+d3-shape@^1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-1.3.4.tgz#358e76014645321eecc7c364e188f8ae3d2a07d4"
   integrity sha512-izaz4fOpOnY3CD17hkZWNxbaN70sIGagLR/5jb6RS96Y+6VqX+q1BQf1av6QSBRdfULi3Gb8Js4CzG4+KAPjMg==
@@ -1928,14 +1933,19 @@ ecc-jsbn@~0.1.1:
     safer-buffer "^2.1.0"
 
 ecstatic@^3.0.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/ecstatic/-/ecstatic-3.3.0.tgz#91cd417d152abf85b37b1ab3ebf3bd25cdc64e80"
-  integrity sha512-EblWYTd+wPIAMQ0U4oYJZ7QBypT9ZUIwpqli0bKDjeIIQnXDBK2dXtZ9yzRCOlkW1HkO8gn7/FxLK1yPIW17pw==
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/ecstatic/-/ecstatic-3.3.1.tgz#b15b5b036c2233defc78d7bacbd8765226c95577"
+  integrity sha512-/rrctvxZ78HMI/tPIsqdvFKHHscxR3IJuKrZI2ZoUgkt2SiufyLFBmcco+aqQBIu6P1qBsUNG3drAAGLx80vTQ==
   dependencies:
     he "^1.1.1"
     mime "^1.6.0"
     minimist "^1.1.0"
     url-join "^2.0.5"
+
+emoji-regex@^7.0.1:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
+  integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
 
 encoding@^0.1.11:
   version "0.1.12"
@@ -2613,7 +2623,7 @@ glob-to-regexp@^0.3.0:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
   integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
 
-glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@~7.1.2:
+glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@~7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
   integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
@@ -2626,9 +2636,9 @@ glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@~7.1.2:
     path-is-absolute "^1.0.0"
 
 globals@^11.7.0:
-  version "11.10.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-11.10.0.tgz#1e09776dffda5e01816b3bb4077c8b59c24eaa50"
-  integrity sha512-0GZF1RiPKU97IHUO5TORo9w1PwrH/NBPl+fS7oMLdaTRiYmYbwK4NWoZWrAdd0/abG9R2BU+OiwyQpTpE6pdfQ==
+  version "11.11.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.11.0.tgz#dcf93757fa2de5486fbeed7118538adf789e9c2e"
+  integrity sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==
 
 globby@^8.0.1:
   version "8.0.2"
@@ -3366,14 +3376,14 @@ lcid@^2.0.0:
   dependencies:
     invert-kv "^2.0.0"
 
-lerna@^3.10.8:
-  version "3.11.0"
-  resolved "https://registry.yarnpkg.com/lerna/-/lerna-3.11.0.tgz#bd2542bdd8c0bdd6e71260877224cfd56530ca5d"
-  integrity sha512-87gFkJ/E/XtWvKrnBnixfPkroAZls7Vzfhdt42gPJYaBdXBqeJWQskGB10mr80GZTm8RmMPrC8M+t7XL1g/YQA==
+lerna@^3.11.1:
+  version "3.11.1"
+  resolved "https://registry.yarnpkg.com/lerna/-/lerna-3.11.1.tgz#c3f86aaf6add615ffc172554657a139bc2360b9a"
+  integrity sha512-7an/cia9u6qVTts5PQ/adFq8QSgE7gzG1pUHhH+XKVU1seDKQ99JLu61n3/euv2qeQF+ww4WLKnFHIPa5+LJSQ==
   dependencies:
     "@lerna/add" "3.11.0"
     "@lerna/bootstrap" "3.11.0"
-    "@lerna/changed" "3.11.0"
+    "@lerna/changed" "3.11.1"
     "@lerna/clean" "3.11.0"
     "@lerna/cli" "3.11.0"
     "@lerna/create" "3.11.0"
@@ -3383,9 +3393,9 @@ lerna@^3.10.8:
     "@lerna/init" "3.11.0"
     "@lerna/link" "3.11.0"
     "@lerna/list" "3.11.0"
-    "@lerna/publish" "3.11.0"
+    "@lerna/publish" "3.11.1"
     "@lerna/run" "3.11.0"
-    "@lerna/version" "3.11.0"
+    "@lerna/version" "3.11.1"
     import-local "^1.0.0"
     npmlog "^4.1.2"
 
@@ -4059,9 +4069,9 @@ object-inspect@~1.6.0:
   integrity sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==
 
 object-keys@^1.0.12:
-  version "1.0.12"
-  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2"
-  integrity sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.0.tgz#11bd22348dd2e096a045ab06f6c85bcc340fa032"
+  integrity sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg==
 
 object-visit@^1.0.0:
   version "1.0.1"
@@ -4474,7 +4484,7 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
 
-prettier@^1.16.3:
+prettier@^1.16.4:
   version "1.16.4"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.16.4.tgz#73e37e73e018ad2db9c76742e2647e21790c9717"
   integrity sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==
@@ -5032,7 +5042,7 @@ slash@^1.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
   integrity sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=
 
-slice-ansi@^2.0.0:
+slice-ansi@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-2.1.0.tgz#cacd7693461a637a5788d92a7dd4fba068e81636"
   integrity sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==
@@ -5255,6 +5265,15 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
+string-width@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.0.0.tgz#5a1690a57cc78211fffd9bf24bbe24d090604eb1"
+  integrity sha512-rr8CUxBbvOZDUvc5lNIJ+OC1nPVpz+Siw9VBtUjB9b6jZehZLFt0JMCZzShFHIsI8cbhm0EsNIfWJMFV3cu3Ew==
+  dependencies:
+    emoji-regex "^7.0.1"
+    is-fullwidth-code-point "^2.0.0"
+    strip-ansi "^5.0.0"
+
 string.prototype.trim@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz#d04de2c89e137f4d7d206f086b5ed2fae6be8cea"
@@ -5353,25 +5372,25 @@ symbol-tree@^3.2.2:
   integrity sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=
 
 table@^5.0.2:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/table/-/table-5.2.2.tgz#61d474c9e4d8f4f7062c98c7504acb3c08aa738f"
-  integrity sha512-f8mJmuu9beQEDkKHLzOv4VxVYlU68NpdzjbGPl69i4Hx0sTopJuNxuzJd17iV2h24dAfa93u794OnDA5jqXvfQ==
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/table/-/table-5.2.3.tgz#cde0cc6eb06751c009efab27e8c820ca5b67b7f2"
+  integrity sha512-N2RsDAMvDLvYwFcwbPyF3VmVSSkuF+G1e+8inhBLtHpvwXGw4QRPEZhihQNeEN0i1up6/f6ObCJXNdlRG3YVyQ==
   dependencies:
-    ajv "^6.6.1"
+    ajv "^6.9.1"
     lodash "^4.17.11"
-    slice-ansi "^2.0.0"
-    string-width "^2.1.1"
+    slice-ansi "^2.1.0"
+    string-width "^3.0.0"
 
-tape@^4.9.2:
-  version "4.9.2"
-  resolved "https://registry.yarnpkg.com/tape/-/tape-4.9.2.tgz#f233e40f09dc7e00fcf9b26755453c3822ad28c0"
-  integrity sha512-lPXKRKILZ1kZaUy5ynWKs8ATGSUO7HAFHCFnBam6FaGSqPdOwMWbxXHq4EXFLE8WRTleo/YOMXkaUTRmTB1Fiw==
+tape@^4.10.0:
+  version "4.10.0"
+  resolved "https://registry.yarnpkg.com/tape/-/tape-4.10.0.tgz#c915fcd7595e53f089bc4f99d12c10eda9f6e4f6"
+  integrity sha512-3PgdF0vcZ1t7HEYbpTXdo58KXi19QCGcZfj07A53M2DH14P2Fw3cB3f9pF7e/Br2z+PQm7xlvhjzHH3D8ti99g==
   dependencies:
     deep-equal "~1.0.1"
     defined "~1.0.0"
     for-each "~0.3.3"
     function-bind "~1.1.1"
-    glob "~7.1.2"
+    glob "~7.1.3"
     has "~1.0.3"
     inherits "~2.0.3"
     minimist "~1.2.0"
@@ -5420,7 +5439,7 @@ temp-write@^3.4.0:
     temp-dir "^1.0.0"
     uuid "^3.0.1"
 
-terser@^3.16.0:
+terser@^3.16.1:
   version "3.16.1"
   resolved "https://registry.yarnpkg.com/terser/-/terser-3.16.1.tgz#5b0dd4fa1ffd0b0b43c2493b2c364fd179160493"
   integrity sha512-JDJjgleBROeek2iBcSNzOHLKsB/MdDf+E/BOAJ0Tk9r7p9/fVobfv7LMJ/g/k3v9SXdmjZnIlFd5nfn/Rt0Xow==
@@ -5597,15 +5616,15 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.3.1:
+typescript@^3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.3.tgz#f1657fc7daa27e1a8930758ace9ae8da31403221"
   integrity sha512-Y21Xqe54TBVp+VDSNbuDYdGw0BpoR/Q6wo/+35M8PAU0vipahnyduJWirxxdxjsAkS7hue53x2zp8gz7F05u0A==
 
 typescript@next:
-  version "3.4.0-dev.20190208"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.0-dev.20190208.tgz#72f27dec8efd931075acfa223a4b8b19861d93a3"
-  integrity sha512-TBh1xn8tw/D3oxiJHMFJbA3ANVsTqUDz/whcFCKDflztbOVsncfmIsUOkJUU+R7BsRBzGEu+sHgCsUN+52/+lQ==
+  version "3.4.0-dev.20190209"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.0-dev.20190209.tgz#a25b22726693f25ae689af867127286d6bd710f9"
+  integrity sha512-7CnV0zp1W05jFzz/Ka+WVUPbPdG9eEXUCa8g2m7kFfDaJHsHaWCIBfux4G6Q/li0zmIG8OPEenoLdpXCmgkd1Q==
 
 uglify-js@^3.1.4:
   version "3.4.9"


### PR DESCRIPTION
Changes:

**vega**
- Add test specification and scene for symbol angle.

**vega-scenegraph**
- Add support for symbol mark `angle` encoding. (#1557)
- Add new built-in symbol types: `arrow`, `triangle`, `wedge`, `stroke`
- Update dependencies.

**vega-schema**
- Update code comments to reflect angle encoding availability.