### PR TITLE
Add intersection hit testing.

### DIFF
--- a/packages/vega-functions/src/codegen.js
+++ b/packages/vega-functions/src/codegen.js
@@ -95,6 +95,10 @@ import {
 } from './inscope';
 
 import {
+  default as intersect
+} from './intersect';
+
+import {
   warn,
   info,
   debug
@@ -190,6 +194,7 @@ export const functionContext = {
   debug,
   extent,
   inScope,
+  intersect,
   clampRange,
   pinchDistance,
   pinchAngle,

--- a/packages/vega-functions/src/intersect.js
+++ b/packages/vega-functions/src/intersect.js
@@ -1,0 +1,24 @@
+import {Bounds, intersect} from 'vega-scenegraph';
+import {array} from 'vega-util';
+
+export default function(b, opt, group) {
+  if (!b) return [];
+
+  const scene = group || this.context.dataflow.scenegraph().root;
+  const box = new Bounds().set(b[0], b[1], b[2], b[3]);
+
+  return intersect(scene, box, filter(opt));
+}
+
+function filter(opt) {
+  let p = null;
+
+  if (opt) {
+    const types = array(opt.marktype),
+          names = array(opt.markname);
+    p = _ => (!types.length || types.some(t => _.marktype === t))
+          && (!names.length || names.some(s => _.name === s));
+  }
+
+  return p;
+}

--- a/packages/vega-scenegraph/index.js
+++ b/packages/vega-scenegraph/index.js
@@ -13,6 +13,7 @@ export {default as SVGHandler} from './src/SVGHandler';
 export {default as SVGRenderer} from './src/SVGRenderer';
 export {default as SVGStringRenderer} from './src/SVGStringRenderer';
 export {RenderType, renderModule} from './src/modules';
+export {intersect} from './src/intersect';
 
 export {default as Marks} from './src/marks/index';
 
@@ -37,6 +38,12 @@ export {resetSVGClipId} from './src/util/svg/clip';
 
 export {sceneEqual, pathEqual} from './src/util/equal';
 export {sceneToJSON, sceneFromJSON} from './src/util/serialize';
+export {
+  intersectPath,
+  intersectPoint,
+  intersectRule,
+  intersectBoxLine
+} from './src/util/intersect';
 export {
   zorder as sceneZOrder,
   visit as sceneVisit,

--- a/packages/vega-scenegraph/src/Bounds.js
+++ b/packages/vega-scenegraph/src/Bounds.js
@@ -77,18 +77,27 @@ prototype.translate = function(dx, dy) {
 };
 
 prototype.rotate = function(angle, x, y) {
-  var cos = Math.cos(angle),
+  const p = this.rotatedPoints(angle, x, y);
+  return this.clear()
+    .add(p[0], p[1])
+    .add(p[2], p[3])
+    .add(p[4], p[5])
+    .add(p[6], p[7]);
+};
+
+prototype.rotatedPoints = function(angle, x, y) {
+  var {x1, y1, x2, y2} = this,
+      cos = Math.cos(angle),
       sin = Math.sin(angle),
       cx = x - x*cos + y*sin,
-      cy = y - x*sin - y*cos,
-      x1 = this.x1, x2 = this.x2,
-      y1 = this.y1, y2 = this.y2;
+      cy = y - x*sin - y*cos;
 
-  return this.clear()
-    .add(cos*x1 - sin*y1 + cx,  sin*x1 + cos*y1 + cy)
-    .add(cos*x1 - sin*y2 + cx,  sin*x1 + cos*y2 + cy)
-    .add(cos*x2 - sin*y1 + cx,  sin*x2 + cos*y1 + cy)
-    .add(cos*x2 - sin*y2 + cx,  sin*x2 + cos*y2 + cy);
+  return [
+    cos*x1 - sin*y1 + cx, sin*x1 + cos*y1 + cy,
+    cos*x1 - sin*y2 + cx, sin*x1 + cos*y2 + cy,
+    cos*x2 - sin*y1 + cx, sin*x2 + cos*y1 + cy,
+    cos*x2 - sin*y2 + cx, sin*x2 + cos*y2 + cy
+  ];
 };
 
 prototype.union = function(b) {
@@ -96,14 +105,6 @@ prototype.union = function(b) {
   if (b.y1 < this.y1) this.y1 = b.y1;
   if (b.x2 > this.x2) this.x2 = b.x2;
   if (b.y2 > this.y2) this.y2 = b.y2;
-  return this;
-};
-
-prototype.intersect = function(b) {
-  if (b.x1 > this.x1) this.x1 = b.x1;
-  if (b.y1 > this.y1) this.y1 = b.y1;
-  if (b.x2 < this.x2) this.x2 = b.x2;
-  if (b.y2 < this.y2) this.y2 = b.y2;
   return this;
 };
 

--- a/packages/vega-scenegraph/src/intersect.js
+++ b/packages/vega-scenegraph/src/intersect.js
@@ -1,0 +1,78 @@
+import Marks from './marks/index';
+import {error} from 'vega-util';
+import Bounds from './Bounds';
+
+export function intersect(scene, bounds, filter) {
+  const hits = [], // intersection results
+        box = new Bounds().union(bounds), // defensive copy
+        type = scene.marktype;
+
+  return type ? intersectMark(scene, box, filter, hits)
+    : type === 'group' ? intersectGroup(scene, box, filter, hits)
+    : error('Intersect scene must be mark node or group item.');
+}
+
+function intersectMark(mark, box, filter, hits) {
+  if (visitMark(mark, box, filter)) {
+    const items = mark.items,
+          type = mark.marktype,
+          n = items.length;
+
+    let i = 0;
+
+    if (type === 'group') {
+      for (; i<n; ++i) {
+        intersectGroup(items[i], box, filter, hits);
+      }
+    } else {
+      for (const test = Marks[type].isect; i<n; ++i) {
+        let item = items[i];
+        if (intersectItem(item, box, test)) hits.push(item);
+      }
+    }
+  }
+  return hits;
+}
+
+function visitMark(mark, box, filter) {
+  // process if bounds intersect and if
+  // (1) mark is a group mark (so we must recurse), or
+  // (2) mark is interactive and passes filter
+  return mark.bounds && box.intersects(mark.bounds) && (
+    mark.marktype === 'group' ||
+    mark.interactive !== false && (!filter || filter(mark))
+  );
+}
+
+function intersectGroup(group, box, filter, hits) {
+  // test intersect against group
+  // skip groups by default unless filter says otherwise
+  if ((filter && filter(group.mark)) &&
+      intersectItem(group, box, Marks.group.isect)) {
+    hits.push(group);
+  }
+
+  // recursively test children marks
+  // translate box to group coordinate space
+  const marks = group.items,
+        n = marks && marks.length;
+
+  if (n) {
+    const x = group.x || 0,
+          y = group.y || 0;
+    box.translate(-x, -y);
+    for (let i=0; i<n; ++i) {
+      intersectMark(marks[i], box, filter, hits);
+    }
+    box.translate(x, y);
+  }
+
+  return hits;
+}
+
+function intersectItem(item, box, test) {
+  // test bounds enclosure, bounds intersection, then detailed test
+  const bounds = item.bounds;
+  return box.encloses(bounds) || (box.intersects(bounds) && test(item, box));
+}
+

--- a/packages/vega-scenegraph/src/marks/group.js
+++ b/packages/vega-scenegraph/src/marks/group.js
@@ -1,5 +1,6 @@
 import {rectangle} from '../path/shapes';
 import boundStroke from '../bound/boundStroke';
+import {intersectRect} from '../util/intersect';
 import {visit, pickVisit} from '../util/visit';
 import stroke from '../util/canvas/stroke';
 import fill from '../util/canvas/fill';
@@ -155,6 +156,7 @@ export default {
   bound:      bound,
   draw:       draw,
   pick:       pick,
+  isect:      intersectRect,
   background: background,
   foreground: foreground
 };

--- a/packages/vega-scenegraph/src/marks/image.js
+++ b/packages/vega-scenegraph/src/marks/image.js
@@ -1,6 +1,7 @@
 import {visit} from '../util/visit';
 import {pick} from '../util/canvas/pick';
 import {translate} from '../util/svg/transform';
+import {truthy} from 'vega-util';
 
 function getImage(item, renderer) {
   var image = item.image;
@@ -100,6 +101,7 @@ export default {
   bound:    bound,
   draw:     draw,
   pick:     pick(),
+  isect:    truthy, // bounds check is sufficient
   get:      getImage,
   xOffset:  imageXOffset,
   yOffset:  imageYOffset

--- a/packages/vega-scenegraph/src/marks/markItemPath.js
+++ b/packages/vega-scenegraph/src/marks/markItemPath.js
@@ -1,11 +1,12 @@
 import boundStroke from '../bound/boundStroke';
 import context from '../bound/boundContext';
+import {intersectPath} from '../util/intersect';
 import {drawAll} from '../util/canvas/draw';
 import {pickPath} from '../util/canvas/pick';
 import {transformItem} from '../util/svg/transform';
 import {DegToRad} from '../util/constants';
 
-export default function(type, shape) {
+export default function(type, shape, isect) {
 
   function attr(emit, item) {
     emit('transform', transformItem(item));
@@ -45,7 +46,8 @@ export default function(type, shape) {
     attr:   attr,
     bound:  bound,
     draw:   drawAll(draw),
-    pick:   pickPath(draw)
+    pick:   pickPath(draw),
+    isect:  isect || intersectPath(draw)
   };
 
 }

--- a/packages/vega-scenegraph/src/marks/markMultiItemPath.js
+++ b/packages/vega-scenegraph/src/marks/markMultiItemPath.js
@@ -1,5 +1,6 @@
 import boundStroke from '../bound/boundStroke';
 import context from '../bound/boundContext';
+import {intersectPoint} from '../util/intersect';
 import {drawOne} from '../util/canvas/draw';
 import {hitPath} from '../util/canvas/pick';
 
@@ -48,6 +49,7 @@ export default function(type, shape, tip) {
     bound:  bound,
     draw:   drawOne(draw),
     pick:   pick,
+    isect:  intersectPoint,
     tip:    tip
   };
 

--- a/packages/vega-scenegraph/src/marks/path.js
+++ b/packages/vega-scenegraph/src/marks/path.js
@@ -2,6 +2,7 @@ import boundStroke from '../bound/boundStroke';
 import context from '../bound/boundContext';
 import pathParse from '../path/parse';
 import pathRender from '../path/render';
+import {intersectPath} from '../util/intersect';
 import {drawAll} from '../util/canvas/draw';
 import {pickPath} from '../util/canvas/pick';
 import {translateItem} from '../util/svg/transform';
@@ -35,5 +36,6 @@ export default {
   attr:   attr,
   bound:  bound,
   draw:   drawAll(path),
-  pick:   pickPath(path)
+  pick:   pickPath(path),
+  isect:  intersectPath(path)
 };

--- a/packages/vega-scenegraph/src/marks/rect.js
+++ b/packages/vega-scenegraph/src/marks/rect.js
@@ -1,5 +1,6 @@
 import boundStroke from '../bound/boundStroke';
 import {rectangle} from '../path/shapes';
+import {intersectRect} from '../util/intersect';
 import {drawAll} from '../util/canvas/draw';
 import {pickPath} from '../util/canvas/pick';
 
@@ -29,5 +30,6 @@ export default {
   attr:   attr,
   bound:  bound,
   draw:   drawAll(draw),
-  pick:   pickPath(draw)
+  pick:   pickPath(draw),
+  isect:  intersectRect
 };

--- a/packages/vega-scenegraph/src/marks/rule.js
+++ b/packages/vega-scenegraph/src/marks/rule.js
@@ -1,4 +1,5 @@
 import boundStroke from '../bound/boundStroke';
+import {intersectRule} from '../util/intersect';
 import {visit} from '../util/visit';
 import {pick} from '../util/canvas/pick';
 import stroke from '../util/canvas/stroke';
@@ -58,5 +59,6 @@ export default {
   attr:   attr,
   bound:  bound,
   draw:   draw,
-  pick:   pick(hit)
+  pick:   pick(hit),
+  isect:  intersectRule
 };

--- a/packages/vega-scenegraph/src/marks/symbol.js
+++ b/packages/vega-scenegraph/src/marks/symbol.js
@@ -1,4 +1,5 @@
 import {symbol} from '../path/shapes';
+import {intersectPoint} from '../util/intersect';
 import markItemPath from './markItemPath';
 
-export default markItemPath('symbol', symbol);
+export default markItemPath('symbol', symbol, intersectPoint);

--- a/packages/vega-scenegraph/src/util/canvas/context.js
+++ b/packages/vega-scenegraph/src/util/canvas/context.js
@@ -1,0 +1,5 @@
+import {canvas} from 'vega-canvas';
+
+export var context = (context = canvas(1,1))
+  ? context.getContext('2d')
+  : null;

--- a/packages/vega-scenegraph/src/util/canvas/pick.js
+++ b/packages/vega-scenegraph/src/util/canvas/pick.js
@@ -1,9 +1,8 @@
 import {pickVisit} from '../visit';
-
-var trueFunc = function() { return true; };
+import {truthy} from 'vega-util';
 
 export function pick(test) {
-  if (!test) test = trueFunc;
+  test = test || truthy;
 
   return function(context, scene, x, y, gx, gy) {
     x *= context.pixelRatio;

--- a/packages/vega-scenegraph/src/util/intersect.js
+++ b/packages/vega-scenegraph/src/util/intersect.js
@@ -1,0 +1,80 @@
+import {context} from './canvas/context';
+import Bounds from '../Bounds';
+
+const b = new Bounds();
+
+export function intersectPath(draw) {
+  return function(item, brush) {
+    // rely on (inaccurate) bounds intersection if no context
+    if (!context) return true;
+
+    // add path to offscreen graphics context
+    draw(context, item);
+
+    // get bounds intersection region
+    b.clear().union(item.bounds).intersect(brush).round();
+    const {x1, y1, x2, y2} = b;
+
+    // iterate over intersection region
+    // perform fine grained inclusion test
+    for (let y = y1; y <= y2; ++y) {
+      for (let x = x1; x <= x2; ++x) {
+        if (context.isPointInPath(x, y)) {
+          return true;
+        }
+      }
+    }
+
+    // false if no hits in intersection region
+    return false;
+  }
+}
+
+export function intersectPoint(item, box) {
+  return box.contains(item.x || 0, item.y || 0);
+}
+
+export function intersectRect(item, box) {
+  const x = item.x || 0,
+        y = item.y || 0,
+        w = item.width || 0,
+        h = item.height || 0;
+  return box.intersects(b.set(x, y, x + w, y + h));
+}
+
+export function intersectRule(item, box) {
+  const x = item.x || 0,
+        y = item.y || 0,
+        x2 = item.x2 != null ? item.x2 : x,
+        y2 = item.y2 != null ? item.y2 : y;
+  return intersectBoxLine(box, x, y, x2, y2);
+}
+
+export function intersectBoxLine(box, x, y, u, v) {
+  const {x1, y1, x2, y2} = box,
+        dx = u - x,
+        dy = v - y;
+
+  let t0 = 0, t1 = 1, p, q, r, e;
+
+  for (e=0; e<4; ++e) {
+    if (e === 0) { p = -dx; q = -(x1 - x); }
+    if (e === 1) { p =  dx; q =  (x2 - x); }
+    if (e === 2) { p = -dy; q = -(y1 - y); }
+    if (e === 3) { p =  dy; q =  (y2 - y); }
+
+    if (Math.abs(p) < 1e-10 && q < 0) return false;
+
+    r = q / p;
+
+    if (p < 0) {
+      if (r > t1) return false;
+      else if (r > t0) t0 = r;
+    } else if (p > 0) {
+      if (r < t0) return false;
+      else if (r < t1) t1 = r;
+    }
+  }
+
+  return true;
+}

--- a/packages/vega-scenegraph/src/util/text.js
+++ b/packages/vega-scenegraph/src/util/text.js
@@ -1,7 +1,6 @@
-import {canvas} from 'vega-canvas';
+import {context} from './canvas/context';
 
-var context,
-    currFontHeight;
+var currFontHeight;
 
 export var textMetrics = {
   height: fontSize,
@@ -38,8 +37,7 @@ export function fontSize(item) {
 }
 
 function useCanvas(use) {
-  context = use && (context = canvas(1,1)) ? context.getContext('2d') : null;
-  textMetrics.width = context ? measureWidth : estimateWidth;
+  textMetrics.width = (use && context) ? measureWidth : estimateWidth;
 }
 
 export function textValue(item) {

--- a/packages/vega-scenegraph/src/util/text.js
+++ b/packages/vega-scenegraph/src/util/text.js
@@ -54,10 +54,12 @@ export function truncate(item) {
       text = item.text + '',
       width;
 
-  if (context) {
+  if (textMetrics.width === measureWidth) {
+    // we are using canvas
     context.font = font(item);
     width = measure;
   } else {
+    // we are relying on estimates
     currFontHeight = fontSize(item);
     width = estimate;
   }

--- a/packages/vega-scenegraph/test/canvas-handler-test.js
+++ b/packages/vega-scenegraph/test/canvas-handler-test.js
@@ -280,7 +280,8 @@ tape('CanvasHandler should pick text mark', function(t) {
   var handler = new Handler().initialize(render(mark, 500, 500));
   t.ok(handler.pick(mark, 3, 45, 3, 45));
   t.ok(handler.pick(mark, 140, 160, 140, 160));
-  t.notOk(handler.pick(mark, 50, 120, 50, 120));
+  t.ok(handler.pick(mark, 49, 120, 49, 120));
+  t.notOk(handler.pick(mark, 52, 120, 52, 120));
   t.notOk(handler.pick(mark, 800, 800, 800, 800));
   t.end();
 });

--- a/packages/vega-scenegraph/test/intersect-test.js
+++ b/packages/vega-scenegraph/test/intersect-test.js
@@ -1,0 +1,112 @@
+var tape = require('tape'),
+    vega = require('../');
+
+function draw(context) {
+  context.beginPath();
+  context.moveTo(  0,   0);
+  context.lineTo(-10, -10);
+  context.lineTo(-10,  10);
+  context.lineTo( 10, -10);
+  context.lineTo( 10,  10);
+  context.closePath();
+}
+
+tape('intersectPath should intersect paths', function(test) {
+  const b = new vega.Bounds(),
+        p = vega.intersectPath(draw),
+        s = {bounds: new vega.Bounds()};
+
+  draw(vega.boundContext(s.bounds)); // calc item bounds
+
+  test.ok(p(s, b.set(-11, -11,  11,  11))); // enclose
+  test.ok(p(s, b.set( -1,  -1,   1,   1))); // middle
+  test.ok(p(s, b.set( -8, -.1,  -7,  .1))); // left
+  test.ok(p(s, b.set(  7, -.1,   8,  .1))); // right
+  test.ok(p(s, b.set(-11, -11, -10, -10))); // upper-left
+  test.ok(p(s, b.set( 10, -11,  11, -10))); // upper-right
+  test.ok(p(s, b.set(-11,  10, -10,  11))); // lower-left
+  test.ok(p(s, b.set( 10,  10,  11,  11))); // lower-right
+
+  test.notOk(p(s, b.set( -1, -10,   1,  -5))); // middle
+  test.notOk(p(s, b.set( -1,   5,   1,  10))); // middle
+  test.notOk(p(s, b.set(-12, -12, -11, -11))); // upper-left
+  test.notOk(p(s, b.set( 11, -12,  12, -11))); // upper-right
+  test.notOk(p(s, b.set(-12,  11, -11,  12))); // lower-left
+  test.notOk(p(s, b.set( 11,  11,  12,  12))); // lower-right
+
+  test.end();
+});
+
+tape('intersectPoint should intersect point items', function(test) {
+  const b = new vega.Bounds(),
+        p = {x: 10, y: 10, size: 1000},
+        q = {x: 10, size: 1000};
+
+  // specified coordinates
+  test.ok(vega.intersectPoint(p, b.set( 0,  0, 20, 20))); // enclose
+  test.ok(vega.intersectPoint(p, b.set( 9,  0, 10, 20))); // horiz
+  test.ok(vega.intersectPoint(p, b.set( 0,  9, 30, 10))); // vert
+  test.notOk(vega.intersectPoint(p, b.set( 0,  0,  9,  9))); // upper-left
+  test.notOk(vega.intersectPoint(p, b.set(11, 11, 20, 20))); // lower-right
+  test.notOk(vega.intersectPoint(p, b.set(11,  0, 20,  9))); // upper-right
+  test.notOk(vega.intersectPoint(p, b.set( 0, 11,  9, 20))); // lower-left
+
+  // missing coordinates
+  test.ok(vega.intersectPoint(q, b.set( 0, -5, 20, 20))); // enclose
+  test.ok(vega.intersectPoint(q, b.set( 9, -5, 10,  5))); // horiz
+  test.ok(vega.intersectPoint(q, b.set( 0, -5, 30,  0))); // vert
+  test.notOk(vega.intersectPoint(q, b.set( 0, -5,  9, -1))); // upper-left
+  test.notOk(vega.intersectPoint(q, b.set(11,  1, 20, 10))); // lower-right
+  test.notOk(vega.intersectPoint(q, b.set(11, -5, 20, -1))); // upper-right
+  test.notOk(vega.intersectPoint(q, b.set( 0,  1,  9, 10))); // lower-left
+
+  test.end();
+});
+
+tape('intersectLine should intersect rule items', function(test) {
+  const b = new vega.Bounds(),
+        r = {x: 10, y: 10, x2: 50, y2: 50},
+        s = {x: 10, y2: 50};
+
+  // specified coordinates
+  test.ok(vega.intersectRule(r, b.set( 0,  0, 60, 60))); // enclose
+  test.ok(vega.intersectRule(r, b.set(20, 20, 30, 30))); // midline
+  test.ok(vega.intersectRule(r, b.set( 0,  0, 10, 10))); // start
+  test.ok(vega.intersectRule(r, b.set(50, 50, 60, 60))); // end
+  test.notOk(vega.intersectRule(r, b.set( 0,  0,  9,  9))); // upper-left
+  test.notOk(vega.intersectRule(r, b.set(51, 51, 60, 60))); // lower-right
+  test.notOk(vega.intersectRule(r, b.set(25, 10, 50, 20))); // upper-right
+  test.notOk(vega.intersectRule(r, b.set(10, 25, 20, 50))); // lower-left
+
+  // missing coordinates
+  test.ok(vega.intersectRule(s, b.set( 0,  0, 60, 60))); // enclose
+  test.ok(vega.intersectRule(s, b.set( 0, 20, 30, 30))); // midline
+  test.ok(vega.intersectRule(s, b.set( 0, -5, 10,  5))); // start
+  test.ok(vega.intersectRule(s, b.set( 0, 50, 10, 60))); // end
+  test.notOk(vega.intersectRule(s, b.set( 0,  0, -1, -1))); // upper-left
+  test.notOk(vega.intersectRule(s, b.set(51, 51, 60, 60))); // lower-right
+  test.notOk(vega.intersectRule(s, b.set(25, 10, 50, 20))); // upper-right
+  test.notOk(vega.intersectRule(s, b.set(11, 25, 20, 50))); // lower-left
+
+  test.end();
+});
+
+tape('intersectBoxLine should compute box/line intersection', function(test) {
+  const b = new vega.Bounds(),
+        x = 10, y = 10,
+        u = 50, v = 50;
+
+  test.ok(vega.intersectBoxLine(b.set( 0,  0, 60, 60), x, y, u, v)); // enclose
+  test.ok(vega.intersectBoxLine(b.set(20, 20, 30, 30), x, y, u, v)); // midline
+  test.ok(vega.intersectBoxLine(b.set( 0,  0, 10, 10), x, y, u, v)); // start
+  test.ok(vega.intersectBoxLine(b.set(50, 50, 60, 60), x, y, u, v)); // end
+
+  test.notOk(vega.intersectBoxLine(b.set( 0,  0,  9,  9), x, y, u, v)); // upper-left
+  test.notOk(vega.intersectBoxLine(b.set(51, 51, 60, 60), x, y, u, v)); // lower-right
+  test.notOk(vega.intersectBoxLine(b.set(25, 10, 50, 20), x, y, u, v)); // upper-right
+  test.notOk(vega.intersectBoxLine(b.set(10, 25, 20, 50), x, y, u, v)); // lower-left
+
+  test.ok(vega.intersectBoxLine(b.set(10, 10, 10, 10), x, y, u, v)); // singularity
+
+  test.end();
+});


### PR DESCRIPTION
Changes:

**vega-functions**

- Add `intersect` expression function, with signature `intersect(box, options, group)`, where:
  - `box` is a brush defined as `[x1, y1, x2, y2]`
  - `options` is an optional object with `marktype` or `markname` properties (strings or arrays) for limiting the intersection tests to specific marks.
  - `group` is an optional scenegraph group item that should serve as the root of the search.

**vega-scenegraph**

- Add intersection hit testing between marks and a rectangular brush.
- Add `rotatedPoints` method to `Bounds`.
- Fix picking calculation for `text` marks.
- Code clean-up.