### PR TITLE
Add runQueue to View API.

### DIFF
--- a/packages/vega-view/src/View.js
+++ b/packages/vega-view/src/View.js
@@ -123,6 +123,20 @@ prototype.runAsync = async function(encode) {
   return this;
 };
 
+prototype.runQueue = async function(f) {
+  // await previously queued functions
+  while (this._running) await this._running;
+
+  // invoke function, trapping errors
+  if (f) try { f(); } catch (err) { this.error(err); }
+
+  // run dataflow, manage running promise
+  (this._running = this.runAsync())
+    .then(() => this._running = null);
+
+  return this;
+};
+
 prototype.dirty = function(item) {
   this._redraw = true;
   this._renderer && this._renderer.dirty(item);

--- a/packages/vega-view/src/bind.js
+++ b/packages/vega-view/src/bind.js
@@ -33,8 +33,10 @@ export default function(view, el, binding) {
       set: null,
       update: function(value) {
         if (value !== view.signal(param.signal)) {
-          bind.source = true;
-          view.signal(param.signal, value).run();
+          view.runQueue(function() {
+            bind.source = true;
+            view.signal(param.signal, value);
+          });
         }
       }
     };


### PR DESCRIPTION
Changes:

**vega-view**

- Add `runQueue` method for queueing run invocations and preparation functions.
- Update internal event handling and signal bindings to use `runQueue`.