### PR TITLE
remove sudo:false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 os: osx
-sudo: false
 node_js:
   - "8"
   - "10"


### PR DESCRIPTION
`sudo:false` is not recommended  anymore https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration