### PR TITLE
Update typings for v5 scales

### DIFF
--- a/packages/vega-typings/types/spec/scale.d.ts
+++ b/packages/vega-typings/types/spec/scale.d.ts
@@ -98,35 +98,40 @@ export interface BaseScale {
   reverse?: boolean | SignalRef;
   round?: boolean | SignalRef;
 }
+interface ContinuousScale extends BaseScale {
+  range?: RangeScheme;
+  bins: (number | SignalRef)[] | SignalRef;
+  interpolate?: ScaleInterpolate;
+  clamp?: boolean | SignalRef;
+  padding?: number | SignalRef;
+}
+interface NumericScale extends ContinuousScale {
+  nice?: boolean | number | SignalRef;
+  zero?: boolean | SignalRef;
+}
 export interface OrdinalScale extends BaseScale {
   type: 'ordinal';
   range?: RangeScheme | ScaleData;
   interpolate?: ScaleInterpolate;
+  domainImplicit: boolean | SignalRef;
 }
-export interface BandScale extends BaseScale {
+interface BaseBandScale extends BaseScale {
+  range?: RangeBand;
+  padding?: number | SignalRef;
+  paddingOuter?: number | SignalRef;
+  align?: number | SignalRef;
+}
+export interface BandScale extends BaseBandScale {
   type: 'band';
-  range?: RangeBand;
-  padding?: number | SignalRef;
   paddingInner?: number | SignalRef;
-  paddingOuter?: number | SignalRef;
-  align?: number | SignalRef;
 }
-export interface PointScale extends BaseScale {
+export interface PointScale extends BaseBandScale {
   type: 'point';
-  range?: RangeBand;
-  padding?: number | SignalRef;
-  paddingOuter?: number | SignalRef;
-  align?: number | SignalRef;
 }
 
 // note: deprecated
-export interface SequentialScale extends BaseScale {
+export interface SequentialScale extends NumericScale {
   type: 'sequential';
-  range: RangeScheme;
-  clamp?: boolean | SignalRef;
-  padding?: number | SignalRef;
-  zero?: boolean | SignalRef;
-  nice?: boolean | TimeInterval | SignalRef;
 }
 export type TimeInterval =
   | 'millisecond'
@@ -137,16 +142,13 @@ export type TimeInterval =
   | 'week'
   | 'month'
   | 'year';
-export interface TimeScale extends BaseScale {
+export interface TimeScale extends ContinuousScale {
   type: 'time' | 'utc';
-  range?: RangeScheme;
-  clamp?: boolean | SignalRef;
-  padding?: number | SignalRef;
   nice?: boolean | TimeInterval | SignalRef;
 }
 export interface IdentityScale extends BaseScale {
   type: 'identity';
-  nice?: TimeInterval;
+  nice?: boolean | SignalRef;
 }
 export interface DiscretizingScale extends BaseScale {
   type: DiscreteScaleType;
@@ -154,55 +156,26 @@ export interface DiscretizingScale extends BaseScale {
   nice?: boolean | TimeInterval | SignalRef;
   zero?: boolean | SignalRef;
 }
-export interface LinearScale extends BaseScale {
+export interface LinearScale extends NumericScale {
   type?: 'linear'; // optional because it's the default
-  range?: RangeScheme;
-  interpolate?: ScaleInterpolate;
-  clamp?: boolean | SignalRef;
-  padding?: number | SignalRef;
-  nice?: boolean | number | SignalRef;
-  zero?: boolean | SignalRef;
-  bins?: number | SignalRef;
 }
-export interface LogScale extends BaseScale {
+export interface LogScale extends ContinuousScale {
   type: 'log';
-  range?: RangeScheme;
-  interpolate?: ScaleInterpolate;
   base?: number | SignalRef;
-  clamp?: boolean | SignalRef;
-  padding?: number | SignalRef;
   nice?: boolean | number | SignalRef;
   zero?: false; // zero has to be false or undefined
 }
 
-export interface SymLogScale extends BaseScale {
+export interface SymLogScale extends NumericScale {
   type: 'symlog';
-  range?: RangeScheme;
-  interpolate?: ScaleInterpolate;
-  base?: number | SignalRef;
-  clamp?: boolean | SignalRef;
-  padding?: number | SignalRef;
-  nice?: boolean | number | SignalRef;
-  zero?: false; // zero has to be false or undefined
+  constant?: number | SignalRef;
 }
-export interface PowScale extends BaseScale {
+export interface PowScale extends NumericScale {
   type: 'pow';
-  exponent: number;
-  range?: RangeScheme;
-  interpolate?: ScaleInterpolate;
-  clamp?: boolean | SignalRef;
-  padding?: number | SignalRef;
-  nice?: boolean | number | SignalRef;
-  zero?: boolean | SignalRef;
+  exponent: number | SignalRef;
 }
-export interface SqrtScale extends BaseScale {
+export interface SqrtScale extends NumericScale {
   type: 'sqrt';
-  range?: RangeScheme;
-  interpolate?: ScaleInterpolate;
-  clamp?: boolean | SignalRef;
-  padding?: number | SignalRef;
-  nice?: boolean | number | SignalRef;
-  zero?: boolean | SignalRef;
 }
 export interface QuantileScale extends BaseScale {
   type?: 'quantile';

--- a/packages/vega-typings/types/spec/scale.d.ts
+++ b/packages/vega-typings/types/spec/scale.d.ts
@@ -98,28 +98,29 @@ export interface BaseScale {
   reverse?: boolean | SignalRef;
   round?: boolean | SignalRef;
 }
-interface ContinuousScale extends BaseScale {
+export interface ContinuousScale extends BaseScale {
   range?: RangeScheme;
-  bins: (number | SignalRef)[] | SignalRef;
+  bins?: (number | SignalRef)[] | SignalRef;
   interpolate?: ScaleInterpolate;
   clamp?: boolean | SignalRef;
   padding?: number | SignalRef;
 }
-interface NumericScale extends ContinuousScale {
+export interface NumericScale extends ContinuousScale {
   nice?: boolean | number | SignalRef;
   zero?: boolean | SignalRef;
 }
-export interface OrdinalScale extends BaseScale {
-  type: 'ordinal';
-  range?: RangeScheme | ScaleData;
-  interpolate?: ScaleInterpolate;
-  domainImplicit: boolean | SignalRef;
-}
-interface BaseBandScale extends BaseScale {
+export interface BaseBandScale extends BaseScale {
   range?: RangeBand;
   padding?: number | SignalRef;
   paddingOuter?: number | SignalRef;
   align?: number | SignalRef;
+}
+// concrete scales
+export interface OrdinalScale extends BaseScale {
+  type: 'ordinal';
+  range?: RangeScheme | ScaleData;
+  interpolate?: ScaleInterpolate;
+  domainImplicit?: boolean | SignalRef;
 }
 export interface BandScale extends BaseBandScale {
   type: 'band';
@@ -150,12 +151,6 @@ export interface IdentityScale extends BaseScale {
   type: 'identity';
   nice?: boolean | SignalRef;
 }
-export interface DiscretizingScale extends BaseScale {
-  type: DiscreteScaleType;
-  range?: RangeScheme;
-  nice?: boolean | TimeInterval | SignalRef;
-  zero?: boolean | SignalRef;
-}
 export interface LinearScale extends NumericScale {
   type?: 'linear'; // optional because it's the default
 }
@@ -177,13 +172,6 @@ export interface PowScale extends NumericScale {
 export interface SqrtScale extends NumericScale {
   type: 'sqrt';
 }
-export interface QuantileScale extends BaseScale {
-  type?: 'quantile';
-  range?: RangeScheme;
-  interpolate?: ScaleInterpolate;
-  nice?: boolean | number | SignalRef;
-  zero?: boolean | SignalRef;
-}
 export interface QuantizeScale extends BaseScale {
   type?: 'quantize';
   range?: RangeScheme;
@@ -198,6 +186,11 @@ export interface ThresholdScale extends BaseScale {
   nice?: boolean | number | SignalRef;
   zero?: boolean | SignalRef;
 }
+export interface QuantileScale extends BaseScale {
+  type?: 'quantile';
+  range?: RangeScheme;
+  interpolate?: ScaleInterpolate;
+}
 export interface BinOrdinalScale extends BaseScale {
   type: 'bin-ordinal';
   range?: RangeScheme | ScaleData;
@@ -210,7 +203,6 @@ export type Scale =
   | SequentialScale
   | TimeScale
   | IdentityScale
-  | DiscretizingScale
   | LinearScale
   | LogScale
   | SymLogScale


### PR DESCRIPTION
I forgot to update them earlier since I already hacked the types to make the tests pass. 