### PR TITLE
Make statistics tests deterministic.

### DIFF
--- a/packages/vega-statistics/test/kde-test.js
+++ b/packages/vega-statistics/test/kde-test.js
@@ -1,16 +1,8 @@
 var tape = require('tape'),
     d3 = require('d3-array'),
+    lcg = require('./lcg'),
     stats = require('../'),
     gaussian = stats.randomNormal();
-
-function lcg(seed) {
-  // Random numbers using a Linear Congruential Generator with seed value
-  // Uses glibc values from https://en.wikipedia.org/wiki/Linear_congruential_generator
-  return function() {
-    seed = (1103515245 * seed + 12345) % 2147483647;
-    return seed / 2147483647;
-  };
-}
 
 // seeded RNG for deterministic tests
 stats.setRandom(lcg(123456789));

--- a/packages/vega-statistics/test/kde-test.js
+++ b/packages/vega-statistics/test/kde-test.js
@@ -3,6 +3,18 @@ var tape = require('tape'),
     stats = require('../'),
     gaussian = stats.randomNormal();
 
+function lcg(seed) {
+  // Random numbers using a Linear Congruential Generator with seed value
+  // Uses glibc values from https://en.wikipedia.org/wiki/Linear_congruential_generator
+  return function() {
+    seed = (1103515245 * seed + 12345) % 2147483647;
+    return seed / 2147483647;
+  };
+}
+
+// seeded RNG for deterministic tests
+stats.setRandom(lcg(123456789));
+
 function closeTo(t, a, b, delta) {
   t.equal(Math.abs(a-b) < delta, true);
 }

--- a/packages/vega-statistics/test/lcg.js
+++ b/packages/vega-statistics/test/lcg.js
@@ -1,0 +1,8 @@
+module.exports = function lcg(seed) {
+  // Random numbers using a Linear Congruential Generator with seed value
+  // Uses glibc values from https://en.wikipedia.org/wiki/Linear_congruential_generator
+  return function() {
+    seed = (1103515245 * seed + 12345) % 2147483647;
+    return seed / 2147483647;
+  };
+};

--- a/packages/vega-statistics/test/mixture-test.js
+++ b/packages/vega-statistics/test/mixture-test.js
@@ -1,7 +1,11 @@
 var tape = require('tape'),
     d3 = require('d3-array'),
+    lcg = require('./lcg'),
     stats = require('../'),
     gaussian = stats.randomNormal();
+
+// seeded RNG for deterministic tests
+stats.setRandom(lcg(123456789));
 
 function closeTo(t, a, b, delta) {
   t.equal(Math.abs(a-b) < delta, true);

--- a/packages/vega-statistics/test/normal-test.js
+++ b/packages/vega-statistics/test/normal-test.js
@@ -1,5 +1,10 @@
 var tape = require('tape'),
-    normal = require('../').randomNormal;
+    lcg = require('./lcg'),
+    stats = require('../'),
+    normal = stats.randomNormal;
+
+// seeded RNG for deterministic tests
+stats.setRandom(lcg(123456789));
 
 function closeTo(t, a, b, delta) {
   t.equal(Math.abs(a-b) < delta, true);


### PR DESCRIPTION
Changes:

**vega-statistics**:

- Use seeded random number generator for deterministic testing of statistical routines. This should prevent spurious test run failures.