### PR TITLE
Expand scale bins options.

### DIFF
--- a/packages/vega-encode/src/labels.js
+++ b/packages/vega-encode/src/labels.js
@@ -1,20 +1,18 @@
 import {Symbols, Discrete} from './legend-types';
 import {tickValues} from './ticks';
 
-import {Quantile, Quantize, Threshold, BinOrdinal} from 'vega-scale';
+import {Quantile, Quantize, Threshold} from 'vega-scale';
 import {peek} from 'vega-util';
 
 const symbols = {
   [Quantile]:   quantileSymbols,
   [Quantize]:   quantizeSymbols,
-  [Threshold]:  thresholdSymbols,
-  [BinOrdinal]: binSymbols
+  [Threshold]:  thresholdSymbols
 };
 
 export function labelValues(scale, count) {
-  var values = symbols[scale.type];
-  return values ? values(scale)
-    : scale.bins ? binValues(scale.bins.slice())
+  return scale.bins ? binValues(scale.bins.slice())
+    : symbols[scale.type] ? symbols[scale.type](scale)
     : tickValues(scale, count);
 }
 
@@ -45,10 +43,6 @@ function thresholdSymbols(scale) {
   values.max = +Infinity;
 
   return values;
-}
-
-function binSymbols(scale) {
-  return binValues(scale.domain());
 }
 
 function binValues(bins) {

--- a/packages/vega-schema/src/scale.js
+++ b/packages/vega-schema/src/scale.js
@@ -70,7 +70,15 @@ const bandRange = oneOf(
 );
 
 const scaleBinsRef = ref('scaleBins');
-const scaleBins = orSignal(array(numberOrSignal));
+const scaleBins = oneOf(
+  array(numberOrSignal),
+  object({
+    _step_: numberOrSignal,
+    start: numberOrSignal,
+    stop: numberOrSignal
+  }),
+  signalRef
+);
 
 const scaleInterpolateRef = ref('scaleInterpolate');
 const scaleInterpolate = oneOf(
@@ -198,7 +206,14 @@ const scale = oneOf(
     ...scaleDomainProps
   }),
   object({
-    _type_: enums([Quantile, BinOrdinal]),
+    _type_: enums([Quantile]),
+    range: schemeRange,
+    interpolate: scaleInterpolateRef,
+    ...scaleDomainProps
+  }),
+  object({
+    _type_: enums([BinOrdinal]),
+    bins: scaleBinsRef,
     range: schemeRange,
     interpolate: scaleInterpolateRef,
     ...scaleDomainProps

--- a/packages/vega-typings/tests/spec/valid/nulls-histogram.ts
+++ b/packages/vega-typings/tests/spec/valid/nulls-histogram.ts
@@ -14,19 +14,15 @@ export const spec: Spec = {
       "bind": {"input": "select", "options": [5, 10, 20]}
     },
     {
-      "name": "binValues",
-      "update": "sequence(bins.start, bins.stop + bins.step, bins.step)"
-    },
-    {
-      "name": "binDomain",
-      "update": "[bins.start, bins.stop]"
+      "name": "binCount",
+      "update": "(bins.stop - bins.start) / bins.step"
     },
     {
       "name": "nullGap", "value": 10
     },
     {
       "name": "barStep",
-      "update": "binValues.length ? (width - nullGap) / binValues.length : 0"
+      "update": "(width - nullGap) / (1 + binCount)"
     }
   ],
 
@@ -93,8 +89,8 @@ export const spec: Spec = {
       "type": "linear",
       "range": [{"signal": "barStep + nullGap"}, {"signal": "width"}],
       "round": true,
-      "domain": {"signal": "binDomain"},
-      "bins": {"signal": "binValues"}
+      "domain": {"signal": "[bins.start, bins.stop]"},
+      "bins": {"signal": "bins"}
     },
     {
       "name": "xscale-null",

--- a/packages/vega-typings/tests/spec/valid/scales-bin.ts
+++ b/packages/vega-typings/tests/spec/valid/scales-bin.ts
@@ -10,16 +10,12 @@ export const spec: Spec = {
 
   "signals": [
     {
-      "name": "binValues",
-      "update": "sequence(bins.start, bins.stop + bins.step, bins.step)"
+      "name": "maxbins", "value": 10,
+      "bind": {"input": "select", "options": [5, 10, 20, 50]}
     },
     {
       "name": "binDomain",
       "update": "[bins.start, bins.stop]"
-    },
-    {
-      "name": "maxbins", "value": 10,
-      "bind": {"input": "select", "options": [5, 10, 20, 50]}
     }
   ],
 
@@ -70,7 +66,7 @@ export const spec: Spec = {
       "range": "width",
       "round": true,
       "domain": {"signal": "binDomain"},
-      "bins": {"signal": "binValues"}
+      "bins": {"signal": "bins"}
     },
     {
       "name": "size",
@@ -78,13 +74,13 @@ export const spec: Spec = {
       "range": [10, 100],
       "round": true,
       "domain": {"signal": "binDomain"},
-      "bins": {"signal": "binValues"}
+      "bins": {"signal": "bins"}
     },
     {
       "name": "color",
       "type": "bin-ordinal",
       "range": {"scheme": "purpleorange"},
-      "domain": {"signal": "binValues"}
+      "bins": {"signal": "bins"}
     }
   ],
 

--- a/packages/vega-typings/types/spec/scale.d.ts
+++ b/packages/vega-typings/types/spec/scale.d.ts
@@ -46,6 +46,15 @@ export type UnionSortField =
     };
 export type ScaleField = string | SignalRef;
 
+export type ScaleBins =
+  | (number | SignalRef)[]
+  | SignalRef
+  | {
+      step: number | SignalRef;
+      start?: number | SignalRef;
+      stop?: number | SignalRef;
+    };
+
 export type ScaleInterpolate =
   | 'rgb'
   | 'lab'
@@ -100,7 +109,7 @@ export interface BaseScale {
 }
 export interface ContinuousScale extends BaseScale {
   range?: RangeScheme;
-  bins?: (number | SignalRef)[] | SignalRef;
+  bins?: ScaleBins;
   interpolate?: ScaleInterpolate;
   clamp?: boolean | SignalRef;
   padding?: number | SignalRef;
@@ -193,6 +202,7 @@ export interface QuantileScale extends BaseScale {
 }
 export interface BinOrdinalScale extends BaseScale {
   type: 'bin-ordinal';
+  bins?: ScaleBins;
   range?: RangeScheme | ScaleData;
   interpolate?: ScaleInterpolate;
 }

--- a/packages/vega/test/specs-valid/nulls-histogram.vg.json
+++ b/packages/vega/test/specs-valid/nulls-histogram.vg.json
@@ -11,19 +11,15 @@
       "bind": {"input": "select", "options": [5, 10, 20]}
     },
     {
-      "name": "binValues",
-      "update": "sequence(bins.start, bins.stop + bins.step, bins.step)"
-    },
-    {
-      "name": "binDomain",
-      "update": "[bins.start, bins.stop]"
+      "name": "binCount",
+      "update": "(bins.stop - bins.start) / bins.step"
     },
     {
       "name": "nullGap", "value": 10
     },
     {
       "name": "barStep",
-      "update": "binValues.length ? (width - nullGap) / binValues.length : 0"
+      "update": "(width - nullGap) / (1 + binCount)"
     }
   ],
 
@@ -90,8 +86,8 @@
       "type": "linear",
       "range": [{"signal": "barStep + nullGap"}, {"signal": "width"}],
       "round": true,
-      "domain": {"signal": "binDomain"},
-      "bins": {"signal": "binValues"}
+      "domain": {"signal": "[bins.start, bins.stop]"},
+      "bins": {"signal": "bins"}
     },
     {
       "name": "xscale-null",

--- a/packages/vega/test/specs-valid/scales-bin.vg.json
+++ b/packages/vega/test/specs-valid/scales-bin.vg.json
@@ -7,16 +7,12 @@
 
   "signals": [
     {
-      "name": "binValues",
-      "update": "sequence(bins.start, bins.stop + bins.step, bins.step)"
+      "name": "maxbins", "value": 10,
+      "bind": {"input": "select", "options": [5, 10, 20, 50]}
     },
     {
       "name": "binDomain",
       "update": "[bins.start, bins.stop]"
-    },
-    {
-      "name": "maxbins", "value": 10,
-      "bind": {"input": "select", "options": [5, 10, 20, 50]}
     }
   ],
 
@@ -67,7 +63,7 @@
       "range": "width",
       "round": true,
       "domain": {"signal": "binDomain"},
-      "bins": {"signal": "binValues"}
+      "bins": {"signal": "bins"}
     },
     {
       "name": "size",
@@ -75,13 +71,13 @@
       "range": [10, 100],
       "round": true,
       "domain": {"signal": "binDomain"},
-      "bins": {"signal": "binValues"}
+      "bins": {"signal": "bins"}
     },
     {
       "name": "color",
       "type": "bin-ordinal",
       "range": {"scheme": "purpleorange"},
-      "domain": {"signal": "binValues"}
+      "bins": {"signal": "bins"}
     }
   ],
 


### PR DESCRIPTION
Changes:

**vega**
- Update `nulls-histogram` and `scales-bin` test specifications.

**vega-encode**
- Add bin boundary generation from `bins` parameter object.
- Add domain specification using `bins` property for `BinOrdinal` scales.
- Drop `BinOrdinal` special case for legend label generation, use `bins` instead.

**vega-schema**
- Add scale `bins` object to schema.

**vega-typings**
- Add scale `bins` object to typings.

Closes #1607. Closes #1601.