### PR TITLE
Fix parsing of scale bin objects.

### DIFF
--- a/packages/vega-parser/src/parsers/scale.js
+++ b/packages/vega-parser/src/parsers/scale.js
@@ -34,17 +34,17 @@ export function parseScale(spec, scope) {
   }
 
   if (spec.nice != null) {
-    parseScaleNice(spec.nice, params);
+    params.nice = parseScaleNice(spec.nice);
+  }
+
+  if (spec.bins != null) {
+    params.bins = parseScaleBins(spec.bins, scope);
   }
 
   for (key in spec) {
     if (params.hasOwnProperty(key) || key === 'name') continue;
-    params[key] = parseProperty(key, spec[key], scope);
+    params[key] = parseLiteral(spec[key], scope);
   }
-}
-
-function parseProperty(name, v, scope) {
-  return (name === 'bins' ? parseArray : parseLiteral)(v, scope);
 }
 
 function parseLiteral(v, scope) {
@@ -194,10 +194,18 @@ function numericMultipleDomain(domain, scope, fields) {
   return ref(scope.add(MultiExtent({extents: extents})));
 }
 
+// -- SCALE BINS -----
+
+function parseScaleBins(v, scope) {
+  return v.signal || isArray(v)
+    ? parseArray(v, scope)
+    : scope.objectProperty(v);
+}
+
 // -- SCALE NICE -----
 
-function parseScaleNice(nice, params) {
-  params.nice = isObject(nice)
+function parseScaleNice(nice) {
+  return isObject(nice)
     ? {
         interval: parseLiteral(nice.interval),
         step: parseLiteral(nice.step)

--- a/packages/vega-typings/tests/spec/valid/scales-bin.ts
+++ b/packages/vega-typings/tests/spec/valid/scales-bin.ts
@@ -80,7 +80,11 @@ export const spec: Spec = {
       "name": "color",
       "type": "bin-ordinal",
       "range": {"scheme": "purpleorange"},
-      "bins": {"signal": "bins"}
+      "bins": {
+        "start": {"signal": "bins.start"},
+        "stop": {"signal": "bins.stop"},
+        "step": {"signal": "bins.step"}
+      }
     }
   ],
 

--- a/packages/vega/test/specs-valid/scales-bin.vg.json
+++ b/packages/vega/test/specs-valid/scales-bin.vg.json
@@ -77,7 +77,11 @@
       "name": "color",
       "type": "bin-ordinal",
       "range": {"scheme": "purpleorange"},
-      "bins": {"signal": "bins"}
+      "bins": {
+        "start": {"signal": "bins.start"},
+        "stop": {"signal": "bins.stop"},
+        "step": {"signal": "bins.step"}
+      }
     }
   ],
 


### PR DESCRIPTION
Changes:

**vega** / **vega-typings**:

- Update `scales-bin` test specification to test use of scale `bins` object literal.

**vega-parser**

- Fix parsing of scale bin objects.
