### PR TITLE
Change default schemes

### DIFF
--- a/packages/vega-parser/src/config.js
+++ b/packages/vega-parser/src/config.js
@@ -206,7 +206,7 @@ function defaults() {
         scheme: 'blues'
       },
       heatmap: {
-        scheme: 'greenblue'
+        scheme: 'yellowgreenblue'
       },
       ramp: {
         scheme: 'blues'

--- a/packages/vega-parser/src/config.js
+++ b/packages/vega-parser/src/config.js
@@ -206,7 +206,7 @@ function defaults() {
         scheme: 'blues'
       },
       heatmap: {
-        scheme: 'viridis'
+        scheme: 'greenblue'
       },
       ramp: {
         scheme: 'blues'


### PR DESCRIPTION
Viridis has a number of issues as the default color so we propose to switch to `yellowgreenblue`. It has good discriminability while still looking good on white background. 0 is also still visible. 

Our choice
<img width="479" alt="screen shot 2019-02-22 at 15 33 15" src="https://user-images.githubusercontent.com/589034/53277199-96e4c180-36b7-11e9-9756-ff934cdcadbc.png">

Viridis
<img width="486" alt="screen shot 2019-02-22 at 15 35 42" src="https://user-images.githubusercontent.com/589034/53277192-8fbdb380-36b7-11e9-8e22-d5136d21a6f4.png">

blueteal
<img width="487" alt="screen shot 2019-02-22 at 15 34 09" src="https://user-images.githubusercontent.com/589034/53277195-92200d80-36b7-11e9-9b6c-4fa6f88a0e6c.png">

tealblues
<img width="485" alt="screen shot 2019-02-22 at 15 34 01" src="https://user-images.githubusercontent.com/589034/53277197-94826780-36b7-11e9-81c9-e3080d896241.png">

blues
<img width="475" alt="screen shot 2019-02-22 at 15 40 37" src="https://user-images.githubusercontent.com/589034/53277338-3c983080-36b8-11e9-8b02-a37735769edf.png">
