### PR TITLE
Correct typings for `array()`

### DIFF
--- a/packages/vega-util/index.d.ts
+++ b/packages/vega-util/index.d.ts
@@ -67,8 +67,7 @@ export function fastmap(_?: object): FastMap;
 
 // Arrays
 
-export function array<T extends any[]>(v: T): T;
-export function array<T>(v: T): T[];
+export function array<T>(v: T | T[]): T[];
 
 export function clampRange(range: number[], min: number, max: number): number[];
 


### PR DESCRIPTION
This simpler typing should match the use case for array better 