### PR TITLE
Dataflow signal dependency fixes.

### DIFF
--- a/packages/vega-dataflow/src/dataflow/on.js
+++ b/packages/vega-dataflow/src/dataflow/on.js
@@ -78,12 +78,13 @@ function onOperator(df, source, target, update, params, options) {
 
     op = new Operator(null, update, params, false);
     op.modified(options && options.force);
-    op.rank = 0;
+    op.rank = source.rank; // immediately follow source
 
     if (target) {
       op.skip(true); // skip first invocation
       op.value = target.value;
       op.targets().add(target);
+      df.connect(target, [op]); // rerank as needed, #1672
     }
   }
 

--- a/packages/vega-functions/src/scale.js
+++ b/packages/vega-functions/src/scale.js
@@ -34,7 +34,7 @@ export function copy(name, group) {
 
 export function scale(name, value, group) {
   const s = getScale(name, (group || this).context);
-  return s ? s(value) : undefined;
+  return s && value !== undefined ? s(value) : undefined;
 }
 
 export function invert(name, range, group) {


### PR DESCRIPTION
Changes:

**vega-dataflow**
- Fix topological sort (rank) for signal listener operators. (#1672)

**vega-functions**
- Safeguard scale function, return undefined for undefined input.

**vega-parser**
- Fix double invocation by merging signal/scale event streams. (#1672)

Closes #1672.