### PR TITLE
Fix typo in the Airport tutorial

### DIFF
--- a/docs/tutorials/airports/index.md
+++ b/docs/tutorials/airports/index.md
@@ -616,7 +616,7 @@ Next, we add the Voronoi cells to the visualization as an invisible set of `path
 
 We set the `fill` to `transparent` to ensure that the Voronoi cells can't be seen, but still receive input events. We also specify a `name` property so that we can refer to these marks elsewhere.
 
-Next, we add `"autosize": "none"` to keep the size of the visualization solely determined by the provided width, height, and paddings. Without this, the Voronoi cells will trigger unwanted automatic resizing:
+Next, we add `"autosize": "none"` to keep the size of the visualization solely determined by the provided width, height, and padding. Without this, the Voronoi cells can trigger unwanted automatic resizing:
 
 {: .suppress-error}
 ```json

--- a/docs/tutorials/airports/index.md
+++ b/docs/tutorials/airports/index.md
@@ -616,6 +616,15 @@ Next, we add the Voronoi cells to the visualization as an invisible set of `path
 
 We set the `fill` to `transparent` to ensure that the Voronoi cells can't be seen, but still receive input events. We also specify a `name` property so that we can refer to these marks elsewhere.
 
+Next, we add `"autosize": "none"` to keep the size of the visualization solely determined by the provided width, height, and paddings. Without this, the Voronoi cells will trigger unwanted automatic resizing:
+
+{: .suppress-error}
+```json
+"padding": {...},
+"autosize": "none",
+"signals": [...],
+```
+
 Finally, we update our `hover` signal to respond to mouse events on the Voronoi cells instead of on the circle `symbol` marks:
 
 {: .suppress-error}

--- a/docs/tutorials/airports/index.md
+++ b/docs/tutorials/airports/index.md
@@ -520,7 +520,7 @@ Now we can add a new `path` mark to the `marks` array to visualize the routes:
   "from": {"data": "routes"},
   "encode": {
     "enter": {
-      "path": {"field": "layout_path"},
+      "path": {"field": "path"},
       "stroke": {"value": "black"},
       "strokeOpacity": {"value": 0.15}
     }


### PR DESCRIPTION
Changed a name of field from `layout_path` to `path`.