### PR TITLE
Manually list the keys for EventStream type

### DIFF
--- a/packages/vega-typings/types/spec/stream.d.ts
+++ b/packages/vega-typings/types/spec/stream.d.ts
@@ -1,4 +1,5 @@
 import { Expr, MarkType } from '.';
+import { type } from 'os';
 
 export type EventSource = EventStream['source'] & {};
 export type EventType =
@@ -21,6 +22,96 @@ export type EventType =
   | 'touchmove'
   | 'touchstart'
   | 'wheel';
+
+export type HTMLBodyEventType =
+  | EventType
+  | 'abort'
+  | 'afterprint'
+  | 'animationcancel'
+  | 'animationend'
+  | 'animationiteration'
+  | 'animationstart'
+  | 'auxclick'
+  | 'beforeprint'
+  | 'beforeunload'
+  | 'blur'
+  | 'cancel'
+  | 'canplay'
+  | 'canplaythrough'
+  | 'change'
+  | 'close'
+  | 'copy'
+  | 'contextmenu'
+  | 'cuechange'
+  | 'cut'
+  | 'drag'
+  | 'dragexit'
+  | 'dragstart'
+  | 'drop'
+  | 'durationchange'
+  | 'emptied'
+  | 'ended'
+  | 'error'
+  | 'focus'
+  | 'fullscreenchange'
+  | 'fullscreenerror'
+  | 'gotpointercapture'
+  | 'hashchange'
+  | 'input'
+  | 'invalid'
+  | 'languagechange'
+  | 'load'
+  | 'loadeddata'
+  | 'loadedmetadata'
+  | 'loadend'
+  | 'loadstart'
+  | 'lostpointercapture'
+  | 'message'
+  | 'messageerror'
+  | 'rejectionhandled'
+  | 'storage'
+  | 'unhandledrejection'
+  | 'unload'
+  | 'offline'
+  | 'online'
+  | 'orientationchange'
+  | 'paste'
+  | 'pause'
+  | 'pagehide'
+  | 'pageshow'
+  | 'play'
+  | 'playing'
+  | 'pointercancel'
+  | 'pointerdown'
+  | 'pointerenter'
+  | 'pointerleave'
+  | 'pointermove'
+  | 'pointerout'
+  | 'pointerover'
+  | 'pointerup'
+  | 'popstate'
+  | 'progress'
+  | 'ratechange'
+  | 'reset'
+  | 'resize'
+  | 'scroll'
+  | 'securitypolicyviolation'
+  | 'seeked'
+  | 'seeking'
+  | 'select'
+  | 'stalled'
+  | 'submit'
+  | 'suspend'
+  | 'timeupdate'
+  | 'toggle'
+  | 'touchcancel'
+  | 'transitioncancel'
+  | 'transitionend'
+  | 'transitionrun'
+  | 'transitionstart'
+  | 'volumechange'
+  | 'waiting';
+
 export interface StreamParameters {
   between?: Stream[];
   marktype?: MarkType;
@@ -38,7 +129,7 @@ export type EventStream = StreamParameters &
       }
     | {
         source: 'window';
-        type: keyof HTMLBodyElementEventMap;
+        type: HTMLBodyEventType;
       });
 export interface DerivedStream extends StreamParameters {
   stream: Stream;


### PR DESCRIPTION
As mentioned in vega/vega-lite#4620, we may need to manually list the keys to avoid ts json schema building error.