### PR TITLE
Fix bin calculation for zero-span extent.

### DIFF
--- a/packages/vega-statistics/src/bin.js
+++ b/packages/vega-statistics/src/bin.js
@@ -6,7 +6,7 @@ export default function(_) {
       div  = _.divide || [5, 2],
       min  = _.extent[0],
       max  = _.extent[1],
-      span = max - min,
+      span = (max - min) || Math.abs(min) || 1,
       step, level, minstep, precision, v, i, n, eps;
 
   if (_.step) {
@@ -48,7 +48,7 @@ export default function(_) {
 
   return {
     start: min,
-    stop:  max,
+    stop:  max === min ? min + step : max,
     step:  step
   };
 }

--- a/packages/vega-statistics/test/bin-test.js
+++ b/packages/vega-statistics/test/bin-test.js
@@ -20,6 +20,30 @@ tape('bin generates boundaries for exact step size', function(t) {
   t.end();
 });
 
+tape('bin generates boundaries for zero-span extent', function (t) {
+  var b = bin({extent: [1, 1], maxbins: 1});
+  t.equal(b.start, 1);
+  t.equal(b.stop, 2);
+  t.equal(b.step, 1);
+
+  b = bin({extent: [0, 0], maxbins: 1});
+  t.equal(b.start, 0);
+  t.equal(b.stop, 1);
+  t.equal(b.step, 1);
+
+  b = bin({extent: [1, 1], maxbins: 10});
+  t.equal(b.start, 1);
+  t.equal(b.stop, 1.1);
+  t.equal(b.step, 0.1);
+
+  b = bin({extent: [0, 0], maxbins: 10});
+  t.equal(b.start, 0);
+  t.equal(b.stop, 0.1);
+  t.equal(b.step, 0.1);
+
+  t.end();
+});
+
 tape('bin generates boundaries for inferred step size', function(t) {
   var b = bin({extent:[1.3, 10.2], maxbins:10, nice:false});
   t.equal(b.start, 1.3);


### PR DESCRIPTION
Changes:

**vega-statistics**
- Fix bin calculation for zero-span extent. (vega/vega-lite#4717)
