### PR TITLE
Incorrect types for Legend typings

### DIFF
--- a/packages/vega-typings/types/spec/legend.d.ts
+++ b/packages/vega-typings/types/spec/legend.d.ts
@@ -53,13 +53,13 @@ export type LegendOrient =
   | 'bottom-right';
 
 export interface Legend extends BaseLegend {
-  size?: string;
-  shape?: string;
+  size?: number;
+  shape?: SymbolShape;
   fill?: string;
   stroke?: string;
-  strokeDash?: string;
-  strokeWidth?: string;
-  opacity?: string;
+  strokeDash?: number[];
+  strokeWidth?: number;
+  opacity?: number;
 
   /**
    * The type of legend to include. One of `"symbol"` for discrete symbol legends, or `"gradient"` for a continuous color gradient. If gradient is used only the fill or stroke scale parameters are considered. If unspecified, the type will be inferred based on the scale parameters used and their backing scale types.


### PR DESCRIPTION
The `Legend` typings `size`, `shape`, `strokeDash`, `strokeWidth`, and `opacity` are all `string`, which seems incorrect. I believe this is what leads to the vega-lite schema for `Legend` not showing `strokeWidth`, even though it is present in `LegendConfig`: https://github.com/vega/vega-lite/blob/f72d8be7fba154437ceaf51ec332d066c1e89313/build/vega-lite-schema.json#L7311