### PR TITLE
Set the typings version in Vega package

### DIFF
--- a/packages/vega/package.json
+++ b/packages/vega/package.json
@@ -47,7 +47,7 @@
     "vega-scenegraph": "^4.1.0",
     "vega-statistics": "^1.3.1",
     "vega-transforms": "^4.0.2",
-    "vega-typings": "*",
+    "vega-typings": "^0.6.2",
     "vega-util": "^1.10.0",
     "vega-view": "^5.2.1",
     "vega-view-transforms": "^4.3.0",


### PR DESCRIPTION
This will avoid version mismatches in libraries that depend on Vega. 