### PR TITLE
isNumber: add documented values and missing one to tests

### DIFF
--- a/packages/vega-util/test/type-check-test.js
+++ b/packages/vega-util/test/type-check-test.js
@@ -35,9 +35,12 @@ tape('isFunction tests functions', function(t) {
 tape('isNumber tests numbers', function(t) {
   t.equal(vega.isNumber(0), true);
   t.equal(vega.isNumber(1e5), true);
+  t.equal(vega.isNumber(NaN), true);
+  t.equal(vega.isNumber(Infinity), true);
   t.equal(vega.isNumber(null), false);
   t.equal(vega.isNumber('a'), false);
   t.equal(vega.isNumber('1'), false);
+  t.equal(vega.isNumber(''), false);
   t.end();
 });
 


### PR DESCRIPTION
On https://vega.github.io/vega/docs/expressions/#isNumber it states

> NaN and Infinity are considered numbers.

So let's add those.

~~I myself found empty string allowed by isNumber so hope this PR will fail.~~
PR should pass (as empty strings are false under isNumber)