### PR TITLE
Update mark bounds after removing overlapping labels.

### DIFF
--- a/packages/vega-view-transforms/package.json
+++ b/packages/vega-view-transforms/package.json
@@ -18,7 +18,7 @@
     "build": "yarn rollup",
     "postbuild": "terser build/vega-view-transforms.js -c -m -o build/vega-view-transforms.min.js",
     "pretest": "yarn prebuild && yarn rollup",
-    "test": "tape 'test/**/*-test.js' && eslint index.js src",
+    "test": "tape 'test/**/*-test.js' && eslint index.js src test",
     "prepublishOnly": "yarn test && yarn build",
     "postpublish": "git push && git push --tags"
   },
@@ -26,5 +26,8 @@
     "vega-dataflow": "^5.1.1",
     "vega-scenegraph": "^4.1.0",
     "vega-util": "^1.8.0"
+  },
+  "devDependencies": {
+    "vega-transforms": "*"
   }
 }

--- a/packages/vega-view-transforms/test/overlap-test.js
+++ b/packages/vega-view-transforms/test/overlap-test.js
@@ -1,0 +1,63 @@
+var tape = require('tape'),
+    vega = require('vega-dataflow'),
+    Bounds = require('vega-scenegraph').Bounds,
+    Collect = require('vega-transforms').collect,
+    tx = require('../'),
+    Overlap = tx.overlap;
+
+function items() {
+  var mark = {bounds: new Bounds(0, 0, 20, 10)};
+  return [
+    {opacity: 1, mark: mark, bounds: new Bounds().set( 0, 0,  3, 10)},
+    {opacity: 1, mark: mark, bounds: new Bounds().set( 5, 0, 20, 10)},
+    {opacity: 1, mark: mark, bounds: new Bounds().set(10, 0, 18, 10)}
+  ];
+}
+
+tape('Overlap removes overlapping items (parity)', function(t) {
+  var data = items(),
+      df = new vega.Dataflow(),
+      co = df.add(Collect),
+      ov = df.add(Overlap, {method: 'parity', pulse: co});
+
+  df.pulse(co, df.changeset().insert(data)).run();
+
+  // overlap sets proper opacity values
+  t.equal(ov.pulse.add.length, 3);
+  t.equal(data[0].opacity, 1);
+  t.equal(data[1].opacity, 0);
+  t.equal(data[2].opacity, 1);
+
+  // overlap updates mark bounds
+  t.deepEqual(data[0].mark.bounds, {x1: 0, y1: 0, x2: 18, y2: 10});
+
+  t.end();
+});
+
+tape('Overlap removes overlapping items (greedy)', function(t) {
+  var data = items(),
+      df = new vega.Dataflow(),
+      co = df.add(Collect),
+      ov = df.add(Overlap, {method: 'greedy', pulse: co});
+
+  // add extra item to test greedy strategy
+  data.push({
+    opacity: 1,
+    mark: data[0].mark,
+    bounds: new Bounds().set(30, 0, 35, 10)
+  });
+
+  df.pulse(co, df.changeset().insert(data)).run();
+
+  // overlap sets proper opacity values
+  t.equal(ov.pulse.add.length, 4);
+  t.equal(data[0].opacity, 1);
+  t.equal(data[1].opacity, 1);
+  t.equal(data[2].opacity, 0);
+  t.equal(data[3].opacity, 1);
+
+  // overlap updates mark bounds
+  t.deepEqual(data[0].mark.bounds, {x1: 0, y1: 0, x2: 35, y2: 10});
+
+  t.end();
+});


### PR DESCRIPTION
Changes:

**vega-view-transforms**
- Fix mark bounds for removed label overlaps. Add tests. (Fix #1747)