### PR TITLE
Added "source" element to schema

### DIFF
--- a/packages/vega-schema/src/schema.js
+++ b/packages/vega-schema/src/schema.js
@@ -19,6 +19,7 @@ import scale from './scale';
 import scope from './scope';
 import selector from './selector';
 import signal from './signal';
+import source from './source';
 import stream from './stream';
 import title from './title';
 import transform from './transform';
@@ -80,6 +81,7 @@ export default function(definitions) {
     scope,
     selector,
     signal,
+    source,
     stream,
     title,
     transform(definitions)

--- a/packages/vega-schema/src/source.js
+++ b/packages/vega-schema/src/source.js
@@ -1,0 +1,51 @@
+import {
+  numberValue, stringValue, stringOrSignal, anchorValue,
+  alignValue, baselineValue, colorValue, fontWeightValue,
+  def, enums, object, oneOf, pattern, ref,
+  booleanType, numberType, stringType, orSignal
+} from './util';
+
+// types defined elsewhere
+const encodeEntryRef = def('encodeEntry');
+const stringValueRef = ref('stringValue');
+const styleRef = ref('style');
+
+const sourceOrientEnum = ['none', 'left', 'right', 'top', 'bottom'];
+const sourceFrameEnum = ['group', 'bounds'];
+
+const sourceEncode = pattern({
+  '^(?!interactive|name|style).+$': encodeEntryRef,
+});
+
+const title = oneOf(
+  stringType,
+  object({
+    name: stringType,
+    orient: orSignal(enums(sourceOrientEnum, {default: 'bottom'})),
+    anchor: anchorValue,
+    frame: oneOf(enums(sourceFrameEnum), stringValueRef),
+    offset: numberValue,
+    style: styleRef,
+    text: stringOrSignal,
+    zindex: numberType,
+    interactive: booleanType,
+    align: alignValue,
+    angle: numberValue,
+    baseline: baselineValue,
+    color: colorValue,
+    dx: numberValue,
+    dy: numberValue,
+    font: stringValue,
+    fontSize: numberValue,
+    fontStyle: stringValue,
+    fontWeight: fontWeightValue,
+    limit: numberValue,
+    encode: sourceEncode
+  })
+);
+
+export default {
+  defs: {
+    title
+  }
+};

--- a/packages/vega-schema/src/source.js
+++ b/packages/vega-schema/src/source.js
@@ -17,7 +17,7 @@ const sourceEncode = pattern({
   '^(?!interactive|name|style).+$': encodeEntryRef,
 });
 
-const title = oneOf(
+const source = oneOf(
   stringType,
   object({
     name: stringType,
@@ -46,6 +46,6 @@ const title = oneOf(
 
 export default {
   defs: {
-    title
+    source
   }
 };


### PR DESCRIPTION
Many charts published today attribute sources in a small, single line of text beneath the plot. Examples can be seen below in recent plots published by major American media outlets. 

[![Screenshot from 2019-04-08 21-16-36](https://user-images.githubusercontent.com/9993/55773012-9f187680-5a43-11e9-89d3-23aca25658fc.png)](https://www.nytimes.com/interactive/2019/03/10/technology/internet-cables-oceans.html)

[![D3VpM9OW0AItzRF](https://user-images.githubusercontent.com/9993/55773038-ba838180-5a43-11e9-88d2-cc6127ee1b20.png)](https://twitter.com/sestamm/status/1113912170880880641)

[![D28x6haX0AEZtJN](https://user-images.githubusercontent.com/9993/55773089-ffa7b380-5a43-11e9-9e29-66f015155ddc.jpg)](https://twitter.com/PostGraphics/status/1112162516765945856)

I am not an expert at Vega. So I expect this pull request will fall short of your standards. However, I encourage you to considering add this as a feature, and I'd be happy to follow any instruction necessary to help it qualify.

This topic was first raised in #1458 