### PR TITLE
Add expr-valued sort fields.

### DIFF
--- a/packages/vega-parser/src/Scope.js
+++ b/packages/vega-parser/src/Scope.js
@@ -1,7 +1,7 @@
 import DataScope from './DataScope';
 import {
-  aggrField, Ascending, compareRef, Entry,
-  fieldRef, keyRef, tupleidRef, isSignal, operator, ref
+  aggrField, Ascending, compareRef, Entry, isExpr, isSignal,
+  fieldRef, keyRef, tupleidRef, operator, ref
 } from './util';
 import parseExpression from './parsers/expression';
 import {Compare, Expression, Field, Key, Projection, Proxy, Scale, Sieve} from './transforms';
@@ -211,6 +211,9 @@ prototype.compareRef = function(cmp, stable) {
     if (isSignal(_)) {
       signal = true;
       return scope.signalRef(_.signal);
+    } else if (isExpr(_)) {
+      signal = true;
+      return scope.exprRef(_.expr);
     } else {
       return _;
     }

--- a/packages/vega-parser/src/util.js
+++ b/packages/vega-parser/src/util.js
@@ -74,6 +74,10 @@ export function isSignal(_) {
   return _ && _.signal;
 }
 
+export function isExpr(_) {
+  return _ && _.expr;
+}
+
 export function hasSignal(_) {
   if (isSignal(_)) return true;
   if (isObject(_)) for (var key in _) {

--- a/packages/vega-schema/src/mark.js
+++ b/packages/vega-schema/src/mark.js
@@ -6,15 +6,16 @@ import {
 // types defined elsewhere
 const sortOrderRef = ref('sortOrder');
 const marktypeRef = ref('marktype');
+const sortField = oneOf(ref('scaleField'), ref('expr'));
 
 const compareRef = ref('compare');
 const compare = oneOf(
   object({
-    field: stringOrSignal,
+    field: sortField,
     order: sortOrderRef
   }),
   object({
-    field: array(stringOrSignal),
+    field: array(sortField),
     order: array(sortOrderRef)
   })
 );

--- a/packages/vega-transforms/src/Compare.js
+++ b/packages/vega-transforms/src/Compare.js
@@ -5,7 +5,7 @@ import {inherits, compare} from 'vega-util';
  * Generates a comparator function.
  * @constructor
  * @param {object} params - The parameters for this operator.
- * @param {Array<string>} params.fields - The fields to compare.
+ * @param {Array<string|function>} params.fields - The fields to compare.
  * @param {Array<string>} [params.orders] - The sort orders.
  *   Each entry should be one of "ascending" (default) or "descending".
  */

--- a/packages/vega-transforms/src/Expression.js
+++ b/packages/vega-transforms/src/Expression.js
@@ -22,7 +22,7 @@ function update(_) {
   return this.value && !_.modified('expr')
     ? this.value
     : accessor(
-        function(datum) { return expr(datum, _); },
+        datum => expr(datum, _),
         accessorFields(expr),
         accessorName(expr)
       );

--- a/packages/vega-typings/types/spec/mark.d.ts
+++ b/packages/vega-typings/types/spec/mark.d.ts
@@ -1,4 +1,5 @@
 import * as Encode from './encode';
+import { ExprRef } from './expr';
 import { SortOrder, Scope, SignalRef, Transforms, OnMarkTrigger } from '.';
 
 export type Facet =
@@ -36,11 +37,11 @@ export type Clip =
     };
 export type Compare =
   | {
-      field: string | SignalRef;
+      field: string | ExprRef | SignalRef;
       order?: SortOrder;
     }
   | {
-      field: (string | SignalRef)[];
+      field: (string | ExprRef | SignalRef)[];
       order?: SortOrder[];
     };
 export interface BaseMark {


### PR DESCRIPTION
Changes:

**vega-parser**
- Add support for `expr`-valued sort fields.

**vega-schema**
- Add `expr`-valued sort fields to schema.

**vega-transforms**
- Minor updates to `Compare` transform.

**vega-typings**
- Add `expr`-valued sort fields to typings.
