### PR TITLE
add scale method type to runtime

### DIFF
--- a/packages/vega-typings/types/runtime/index.d.ts
+++ b/packages/vega-typings/types/runtime/index.d.ts
@@ -1,4 +1,4 @@
-import { DataType, EncodeEntryName, Format, SignalValue, Spec, Scale } from '../spec';
+import { DataType, EncodeEntryName, Format, SignalValue, Spec } from '../spec';
 import { Renderers } from './renderer';
 
 // TODO

--- a/packages/vega-typings/types/runtime/index.d.ts
+++ b/packages/vega-typings/types/runtime/index.d.ts
@@ -1,4 +1,4 @@
-import { DataType, EncodeEntryName, Format, SignalValue, Spec } from '../spec';
+import { DataType, EncodeEntryName, Format, SignalValue, Spec, Scale } from '../spec';
 import { Renderers } from './renderer';
 
 // TODO
@@ -54,6 +54,7 @@ export class View {
 
   signal(name: string, value: SignalValue): this;
   signal(name: string): SignalValue;
+  scale(scaleName: string): (value: any) => number | undefined;
   container(): HTMLElement | null;
   addEventListener(type: string, handler: EventListenerHandler): this;
   removeEventListener(type: string, handler: EventListenerHandler): this;


### PR DESCRIPTION
Hi,

I'm new to Vega; really just experimenting with it at the moment.

I noticed that the typescript definitions is missing the scale method on a Vega view, as documented here: https://vega.github.io/vega/docs/api/view/#view_scale

I'm not sure I have the return type correct; but the `Scale` type from `vega-typings/types/spec/scale.d.ts` doesn't seems to be what is being returned when I check at run time (for example, I am able to run the following: `view.scale('x')(new Date("2019-04-17"))` and get back a number, but the Scale type looks to be something else..)

Happy to make or accept changes on my fork; for now my workaround is to cast the view to any which is not ideal (`(view as any).scale('x')`)

Cheers,
Daniel