### PR TITLE
Fix null handling for GeoJSON projection fit. (#1770)

### DIFF
--- a/packages/vega-geo/src/Projection.js
+++ b/packages/vega-geo/src/Projection.js
@@ -63,7 +63,7 @@ export function collectGeoJSON(data) {
 function featurize(f) {
   return f.type === FeatureCollection
     ? f.features
-    : array(f).map(
+    : array(f).filter(d => d != null).map(
         d => d.type === Feature ? d : {type: Feature, geometry: d}
       );
 }

--- a/packages/vega-geo/test/projection-test.js
+++ b/packages/vega-geo/test/projection-test.js
@@ -22,3 +22,22 @@ tape('Projection transform fits parameters to GeoJSON data', function(t) {
 
   t.end();
 });
+
+tape('Projection transform handles fit input with null data', function(t) {
+  var df = new vega.Dataflow(),
+      gr = df.add(Graticule),
+      pr = df.add(Projection, {
+        type: 'orthographic',
+        size: [500, 500],
+        fit: [[null], gr, {type: 'Sphere'}]
+      });
+
+  df.run();
+
+  var proj = pr.value;
+  t.equal(proj.scale(), 250);
+  t.equal(Math.round(proj.translate()[0]), 250);
+  t.equal(Math.round(proj.translate()[1]), 250);
+
+  t.end();
+});


### PR DESCRIPTION
Changes:

**vega-geo**
- Add `null` value filter when marshaling GeoJSON data for projection `fit`.
- Add test case for `null` GeoJSON values.

Fix #1170.