### PR TITLE
Add explicit linear and radial gradient color support.

### DIFF
--- a/packages/vega-scenegraph/schema.js
+++ b/packages/vega-scenegraph/schema.js
@@ -83,7 +83,8 @@ var BASE = {
     "paint": {
       "oneOf": [
         { "$ref": "#/refs/color" },
-        { "$ref": "#/refs/linear-gradient" }
+        { "$ref": "#/refs/gradientLinear" },
+        { "$ref": "#/refs/gradientRadial" }
       ]
     },
     "color": {
@@ -110,27 +111,48 @@ var BASE = {
         }
       ]
     },
-    "linear-gradient": {
+    "gradientStop": {
       "type": "object",
       "properties": {
+        "offset": { "type": "number" },
+        "color": { "$ref": "#/refs/color" }
+      },
+      "required": ["offset", "color"]
+    },
+    "gradientLinear": {
+      "type": "object",
+      "properties": {
+        "gradient": { "enum": [ "linear" ] },
         "id": { "type": "string" },
-        "type": { "enum": [ "linear" ] },
         "x1": { "type": "number" },
         "y1": { "type": "number" },
         "x2": { "type": "number" },
         "y2": { "type": "number" },
         "stops": {
           "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "offset": { "type": "number" },
-              "color": { "$ref": "#/refs/color" }
-            }
-          }
+          "items": { "$ref": "#/refs/gradientStop" }
         }
       },
-      "required": ["id", "type", "x1", "y1", "x2", "y2", "stops"],
+      "required": ["gradient", "stops"],
+      "additionalProperties": false
+    },
+    "gradientRadial": {
+      "type": "object",
+      "properties": {
+        "gradient": { "enum": [ "radial" ] },
+        "id": { "type": "string" },
+        "x1": { "type": "number" },
+        "y1": { "type": "number" },
+        "r1": { "type": "number" },
+        "x2": { "type": "number" },
+        "y2": { "type": "number" },
+        "r2": { "type": "number" },
+        "stops": {
+          "type": "array",
+          "items": { "$ref": "#/refs/gradientStop" }
+        }
+      },
+      "required": ["gradient", "stops"],
       "additionalProperties": false
     }
   }

--- a/packages/vega-scenegraph/src/Gradient.js
+++ b/packages/vega-scenegraph/src/Gradient.js
@@ -1,9 +1,50 @@
 var gradient_id = 0;
 
+export const patternPrefix = 'p_';
+
+export function isGradient(value) {
+  return value && value.gradient;
+}
+
+export function gradientRef(g, defs, base) {
+  let id = g.id,
+      type = g.gradient,
+      prefix = type === 'radial' ? patternPrefix : '';
+
+  // check id, assign default values as needed
+  if (!id) {
+    id = g.id = 'gradient_' + (gradient_id++);
+    if (type === 'radial') {
+      g.x1 = get(g.x1, 0.5);
+      g.y1 = get(g.y1, 0.5);
+      g.r1 = get(g.r1, 0);
+      g.x2 = get(g.x2, 0.5);
+      g.y2 = get(g.y2, 0.5);
+      g.r2 = get(g.r2, 0.5);
+      prefix = patternPrefix;
+    } else {
+      g.x1 = get(g.x1, 0);
+      g.y1 = get(g.y1, 0);
+      g.x2 = get(g.x2, 1);
+      g.y2 = get(g.y2, 0);
+    }
+  }
+
+  // register definition
+  defs[id] = g;
+
+  // return url reference
+  return 'url(' + (base || '') + '#' + prefix + id + ')';
+}
+
+function get(val, def) {
+  return val != null ? val : def;
+}
+
 export default function(p0, p1) {
   var stops = [], gradient;
   return gradient = {
-    id: 'gradient_' + (gradient_id++),
+    gradient: 'linear',
     x1: p0 ? p0[0] : 0,
     y1: p0 ? p0[1] : 0,
     x2: p1 ? p1[0] : 1,

--- a/packages/vega-scenegraph/src/util/canvas/color.js
+++ b/packages/vega-scenegraph/src/util/canvas/color.js
@@ -1,7 +1,8 @@
+import {isGradient} from '../../Gradient';
 import gradient from './gradient';
 
 export default function(context, item, value) {
-  return (value.id) ?
+  return isGradient(value) ?
     gradient(context, value, item.bounds) :
     value;
 }

--- a/packages/vega-scenegraph/src/util/canvas/gradient.js
+++ b/packages/vega-scenegraph/src/util/canvas/gradient.js
@@ -1,18 +1,28 @@
 export default function(context, gradient, bounds) {
-  var w = bounds.width(),
-      h = bounds.height(),
-      x1 = bounds.x1 + gradient.x1 * w,
-      y1 = bounds.y1 + gradient.y1 * h,
-      x2 = bounds.x1 + gradient.x2 * w,
-      y2 = bounds.y1 + gradient.y2 * h,
-      stop = gradient.stops,
-      i = 0,
-      n = stop.length,
-      linearGradient = context.createLinearGradient(x1, y1, x2, y2);
+  const w = bounds.width(),
+        h = bounds.height(),
+        stop = gradient.stops,
+        n = stop.length;
 
-  for (; i<n; ++i) {
-    linearGradient.addColorStop(stop[i].offset, stop[i].color);
+  const canvasGradient = gradient.gradient === 'radial'
+    ? context.createRadialGradient(
+        bounds.x1 + (gradient.x1 || 0.5) * w,
+        bounds.y1 + (gradient.y1 || 0.5) * h,
+        Math.max(w, h) * (gradient.r1 || 0),
+        bounds.x1 + (gradient.x2 || 0.5) * w,
+        bounds.y1 + (gradient.y2 || 0.5) * h,
+        Math.max(w, h) * (gradient.r2 || 0.5)
+      )
+    : context.createLinearGradient(
+        bounds.x1 + (gradient.x1 || 0) * w,
+        bounds.y1 + (gradient.y1 || 0) * h,
+        bounds.x1 + (gradient.x2 || 1) * w,
+        bounds.y1 + (gradient.y2 || 0) * h
+      );
+
+  for (let i=0; i<n; ++i) {
+    canvasGradient.addColorStop(stop[i].offset, stop[i].color);
   }
 
-  return linearGradient;
+  return canvasGradient;
 }

--- a/packages/vega-scenegraph/test/resources/scenegraph-defs.json
+++ b/packages/vega-scenegraph/test/resources/scenegraph-defs.json
@@ -9,8 +9,8 @@
       "height": 100,
       "clip": true,
       "fill": {
+        "gradient": "linear",
         "id": "gradient_foo",
-        "type": "linear",
         "stops": [
           {"offset": 0.0, "color": "red"},
           {"offset": 0.5, "color": "green"},

--- a/packages/vega-schema/src/encode.js
+++ b/packages/vega-schema/src/encode.js
@@ -2,7 +2,8 @@ import {
   allOf, anyOf, oneOf, ref,
   array, def, object, pattern, required, type,
   booleanType, nullType, numberType, stringType, signalRef,
-  numberValue
+  numberValue,
+  enums
 } from './util';
 
 export const fontWeightEnum = [
@@ -109,8 +110,39 @@ const colorHCL = object({
   _l_: numberValueRef
 }, undefined);
 
+const gradientStops = array(
+  object({
+  _offset_: numberType,
+  _color_: stringType
+  })
+);
+
+const gradientLinear = object({
+  _gradient_: enums(['linear']),
+  id: stringType,
+  x1: numberType,
+  y1: numberType,
+  x2: numberType,
+  y2: numberType,
+  _stops_: ref('gradientStops')
+});
+
+const gradientRadial = object({
+  _gradient_: enums(['radial']),
+  id: stringType,
+  x1: numberType,
+  y1: numberType,
+  r1: numberType,
+  x2: numberType,
+  y2: numberType,
+  r2: numberType,
+  _stops_: ref('gradientStops')
+});
+
 const colorValue = oneOf(
   ref('nullableStringValue'),
+  object({_value_: ref('gradientLinear')}),
+  object({_value_: ref('gradientRadial')}),
   object({
     _gradient_: scaleRef,
     start: array(numberType, {minItems: 2, maxItems: 2}),
@@ -225,7 +257,10 @@ export default {
     colorHSL,
     colorLAB,
     colorHCL,
-    colorValue
+    colorValue,
+    gradientStops,
+    gradientLinear,
+    gradientRadial
   },
   defs: {
     rule,

--- a/packages/vega-typings/tests/spec/valid/gradient.ts
+++ b/packages/vega-typings/tests/spec/valid/gradient.ts
@@ -3,7 +3,6 @@ import { Spec } from 'vega';
 export const spec: Spec = {
   "$schema": "https://vega.github.io/schema/vega/v5.json",
   "width": 300,
-  "height": 15,
   "padding": 5,
 
   "scales": [
@@ -21,8 +20,69 @@ export const spec: Spec = {
       "encode": {
         "update": {
           "width": {"signal": "width"},
-          "height": {"signal": "height"},
+          "height": {"value": 15},
           "fill": {"gradient": "color"}
+        }
+      }
+    },
+    {
+      "type": "rect",
+      "encode": {
+        "update": {
+          "y": {"value": 20},
+          "width": {"signal": "width"},
+          "height": {"value": 15},
+          "fill": {
+            "value": {
+              "gradient": "linear",
+              "stops": [
+                {"offset": 0.0, "color": "red"},
+                {"offset": 0.5, "color": "white"},
+                {"offset": 1.0, "color": "blue"}
+              ]
+            }
+          }
+        }
+      }
+    },
+    {
+      "type": "symbol",
+      "encode": {
+        "update": {
+          "x": {"value": 25},
+          "y": {"value": 62},
+          "size": {"value": 1900},
+          "fill": {
+            "value": {
+              "gradient": "radial",
+              "stops": [
+                {"offset": 0.0, "color": "red"},
+                {"offset": 0.5, "color": "white"},
+                {"offset": 1.0, "color": "blue"}
+              ]
+            }
+          }
+        }
+      }
+    },
+    {
+      "type": "rect",
+      "encode": {
+        "update": {
+          "x": {"value": 100},
+          "y": {"value": 40},
+          "width": {"value": 200},
+          "height": {"value": 45},
+          "fill": {
+            "value": {
+              "gradient": "radial",
+              "stops": [
+                {"offset": 0.0, "color": "red"},
+                {"offset": 0.5, "color": "white"},
+                {"offset": 1.0, "color": "blue"}
+              ]
+            }
+          }
         }
       }
     }

--- a/packages/vega-typings/types/spec/encode.d.ts
+++ b/packages/vega-typings/types/spec/encode.d.ts
@@ -79,8 +79,33 @@ export interface ColorHCL {
   c: NumericValueRef;
   l: NumericValueRef;
 }
+export interface GradientStop {
+  offset: number;
+  color: string;
+}
+export interface GradientLinear {
+  gradient: 'linear';
+  stops: GradientStop[];
+  id?: string;
+  x1?: number;
+  y1?: number;
+  x2?: number;
+  y2?: number;
+}
+export interface GradientRadial {
+  gradient: 'radial';
+  stops: GradientStop[];
+  id?: string;
+  x1?: number;
+  y1?: number;
+  r1?: number;
+  x2?: number;
+  y2?: number;
+  r2?: number;
+}
 export type ColorValueRef =
   | ScaledValueRef<string>
+  | { value: GradientLinear | GradientRadial }
   | {
       gradient: Field;
       start?: number[];

--- a/packages/vega/test/scenegraphs/gradient.json
+++ b/packages/vega/test/scenegraphs/gradient.json
@@ -23,12 +23,58 @@
             }
           ],
           "zindex": 0
+        },
+        {
+          "marktype": "rect",
+          "role": "mark",
+          "interactive": true,
+          "clip": false,
+          "items": [
+            {
+              "y": 20,
+              "width": 300,
+              "height": 15,
+              "fill": {}
+            }
+          ],
+          "zindex": 0
+        },
+        {
+          "marktype": "symbol",
+          "role": "mark",
+          "interactive": true,
+          "clip": false,
+          "items": [
+            {
+              "x": 25,
+              "y": 62,
+              "fill": {},
+              "size": 1900
+            }
+          ],
+          "zindex": 0
+        },
+        {
+          "marktype": "rect",
+          "role": "mark",
+          "interactive": true,
+          "clip": false,
+          "items": [
+            {
+              "x": 100,
+              "y": 40,
+              "width": 200,
+              "height": 45,
+              "fill": {}
+            }
+          ],
+          "zindex": 0
         }
       ],
       "x": 0,
       "y": 0,
       "width": 300,
-      "height": 15
+      "height": 0
     }
   ],
   "zindex": 0

--- a/packages/vega/test/specs-valid/gradient.vg.json
+++ b/packages/vega/test/specs-valid/gradient.vg.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://vega.github.io/schema/vega/v5.json",
   "width": 300,
-  "height": 15,
   "padding": 5,
 
   "scales": [
@@ -19,8 +18,69 @@
       "encode": {
         "update": {
           "width": {"signal": "width"},
-          "height": {"signal": "height"},
+          "height": {"value": 15},
           "fill": {"gradient": "color"}
+        }
+      }
+    },
+    {
+      "type": "rect",
+      "encode": {
+        "update": {
+          "y": {"value": 20},
+          "width": {"signal": "width"},
+          "height": {"value": 15},
+          "fill": {
+            "value": {
+              "gradient": "linear",
+              "stops": [
+                {"offset": 0.0, "color": "red"},
+                {"offset": 0.5, "color": "white"},
+                {"offset": 1.0, "color": "blue"}
+              ]
+            }
+          }
+        }
+      }
+    },
+    {
+      "type": "symbol",
+      "encode": {
+        "update": {
+          "x": {"value": 25},
+          "y": {"value": 62},
+          "size": {"value": 1900},
+          "fill": {
+            "value": {
+              "gradient": "radial",
+              "stops": [
+                {"offset": 0.0, "color": "red"},
+                {"offset": 0.5, "color": "white"},
+                {"offset": 1.0, "color": "blue"}
+              ]
+            }
+          }
+        }
+      }
+    },
+    {
+      "type": "rect",
+      "encode": {
+        "update": {
+          "x": {"value": 100},
+          "y": {"value": 40},
+          "width": {"value": 200},
+          "height": {"value": 45},
+          "fill": {
+            "value": {
+              "gradient": "radial",
+              "stops": [
+                {"offset": 0.0, "color": "red"},
+                {"offset": 0.5, "color": "white"},
+                {"offset": 1.0, "color": "blue"}
+              ]
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Changes:

**vega**
- Update `gradient` test specification.

**vega-scenegraph**
- Update gradient handling to automatically add `id` and default values, as needed.
- Add radial gradient support, via pattern wrapping.
- Update scenegraph JSON schema.

**vega-schema**
- Add explicit linear and radial gradient color values to schema.

**vega-typings**
- Add explicit linear and radial gradient color values to typings.

This PR is a 🎁 for @kanitw!