### PR TITLE
Add value update checks to encoder functions.

### DIFF
--- a/packages/vega-force/src/Force.js
+++ b/packages/vega-force/src/Force.js
@@ -30,6 +30,7 @@ var Forces = 'forces',
  */
 export default function Force(params) {
   Transform.call(this, null, params);
+  this.modified(true);
 }
 
 Force.Definition = {
@@ -130,7 +131,7 @@ prototype.transform = function(_, pulse) {
 
   // run simulation
   if (params || change || _.modified(ForceConfig)
-      || (pulse.changed() && _.restart))
+      || (_.restart && (pulse.changed() || _.modified('restart'))))
   {
     sim.alpha(Math.max(sim.alpha(), _.alpha || 1))
        .alphaDecay(1 - Math.pow(sim.alphaMin(), 1 / iters));

--- a/packages/vega-parser/src/parsers/encode.js
+++ b/packages/vega-parser/src/parsers/encode.js
@@ -6,7 +6,7 @@ import {isArray} from 'vega-util';
 
 export default function parseEncode(encode, marktype, params, scope) {
   var fields = {},
-      code = 'var o=item,datum=o.datum,$;',
+      code = 'var o=item,datum=o.datum,m=0,$;',
       channel, enc, value;
 
   for (channel in encode) {
@@ -20,7 +20,7 @@ export default function parseEncode(encode, marktype, params, scope) {
   }
 
   code += adjustSpatial(encode, marktype);
-  code += 'return 1;';
+  code += 'return m;';
 
   return {
     $expr:   code,

--- a/packages/vega-parser/src/parsers/encode/set.js
+++ b/packages/vega-parser/src/parsers/encode/set.js
@@ -1,5 +1,6 @@
 import {stringValue} from 'vega-util';
 
 export default function(obj, key, value) {
-  return obj + '[' + stringValue(key) + ']=' + value + ';';
+  const o = obj + '[' + stringValue(key) + ']';
+  return `$=${value};if(${o}!==$)${o}=$,m=1;`;
 }

--- a/packages/vega/test/index.html
+++ b/packages/vega/test/index.html
@@ -62,14 +62,14 @@ select.addEventListener('change', function() {
 
 const render = document.querySelector('#render');
 render.addEventListener('change', function() {
-  renderType = render.options[render.selectedIndex].value;
-  if (view) view.renderer(renderType).runAsync();
+  options.renderer = render.options[render.selectedIndex].value;
+  if (view) view.renderer(options.renderer).runAsync();
 });
 
 const level = document.querySelector('#level');
 level.addEventListener('change', function() {
-  logLevel = +level.options[level.selectedIndex].value;
-  if (view) view.logLevel(logLevel);
+  options.logLevel = +level.options[level.selectedIndex].value;
+  if (view) view.logLevel(options.logLevel);
 });
 
 async function init() {


### PR DESCRIPTION
Changes:

**vega-encode**
- Add logic to `Encode` transform to avoid suppression of unchanged `mod` tuples if non-datum fields have been flagged as modified (e.g., as the result of a `modify` trigger).

**vega-force**
- Update `Force` transform so that it is always flagged as modified. This ensures that downstream operators (namely `linkpath`) can always re-evaluate in response.
- Update `Force` to re-initialize when the `restart` parameter turns on, regardless of tuple change status.

**vega-parser**
- Add value update checks to generated encoder functions, add only updated items to the `mod` set. Results in more efficient re-rendering when only a subset of items have encoded values modified.