### PR TITLE
Add value update checks / mod filtering to encoder functions.

### DIFF
--- a/packages/vega-geo/src/GeoShape.js
+++ b/packages/vega-geo/src/GeoShape.js
@@ -19,7 +19,7 @@ export default function GeoShape(params) {
 
 GeoShape.Definition = {
   "type": "GeoShape",
-  "metadata": {"modifies": true},
+  "metadata": {"modifies": true, "nomod": true},
   "params": [
     { "name": "projection", "type": "projection" },
     { "name": "field", "type": "field", "default": "datum" },
@@ -33,15 +33,14 @@ var prototype = inherits(GeoShape, Transform);
 prototype.transform = function(_, pulse) {
   var out = pulse.fork(pulse.ALL),
       shape = this.value,
-      datum = _.field || field('datum'),
       as = _.as || 'shape',
-      flag = out.ADD_MOD;
+      flag = out.ADD;
 
   if (!shape || _.modified()) {
     // parameters updated, reset and reflow
     this.value = shape = shapeGenerator(
       getProjectionPath(_.projection),
-      datum,
+      _.field || field('datum'),
       _.pointRadius
     );
     out.materialize().reflow();

--- a/packages/vega-parser/src/parsers/encode.js
+++ b/packages/vega-parser/src/parsers/encode.js
@@ -6,7 +6,7 @@ import {isArray} from 'vega-util';
 
 export default function parseEncode(encode, marktype, params, scope) {
   var fields = {},
-      code = 'var o=item,datum=o.datum,$;',
+      code = 'var o=item,datum=o.datum,m=0,$;',
       channel, enc, value;
 
   for (channel in encode) {
@@ -20,7 +20,7 @@ export default function parseEncode(encode, marktype, params, scope) {
   }
 
   code += adjustSpatial(encode, marktype);
-  code += 'return 1;';
+  code += 'return m;';
 
   return {
     $expr:   code,

--- a/packages/vega-parser/src/parsers/encode/set.js
+++ b/packages/vega-parser/src/parsers/encode/set.js
@@ -1,5 +1,6 @@
 import {stringValue} from 'vega-util';
 
 export default function(obj, key, value) {
-  return obj + '[' + stringValue(key) + ']=' + value + ';';
+  const o = obj + '[' + stringValue(key) + ']';
+  return `$=${value};if(${o}!==$)${o}=$,m=1;`;
 }


### PR DESCRIPTION
Changes:

**vega-encode**
- Add `mod` parameter to `Encode` transform to control inclusion of `mod` tuples that are not updated by the encoders.

**vega-geo**
- Add `nomod` metadata flag to `GeoShape` transform.

**vega-parser**
- Add value update checks to generated encoder functions, add only updated items to the `mod` set. Results in more efficient re-rendering when only a subset of items have encoded values modified. If a mark includes a post-encoding transform that lacks a `nomod` metadata flag, disable `mod` set filtering by the encoder to ensure proper pulse propagation.

Close #1786.