### PR TITLE
Protect against Safari typed array sort bug.

### DIFF
--- a/packages/vega-statistics/src/bootstrapCI.js
+++ b/packages/vega-statistics/src/bootstrapCI.js
@@ -17,8 +17,10 @@ export default function(array, samples, alpha, f) {
     mu[j] = a / n;
   }
 
+  mu.sort(ascending);
+
   return [
-    quantile(mu.sort(ascending), alpha/2),
+    quantile(mu, alpha/2),
     quantile(mu, 1-(alpha/2))
   ];
 }

--- a/packages/vega-statistics/src/quartiles.js
+++ b/packages/vega-statistics/src/quartiles.js
@@ -4,8 +4,12 @@ import {quantile, ascending} from 'd3-array';
 export default function(array, f) {
   var values = Float64Array.from(numbers(array, f));
 
+  // don't depend on return value from typed array sort call
+  // protects against undefined sort results in Safari (vega/vega-lite#4964)
+  values.sort(ascending);
+
   return [
-    quantile(values.sort(ascending), 0.25),
+    quantile(values, 0.25),
     quantile(values, 0.50),
     quantile(values, 0.75)
   ];

--- a/packages/vega-statistics/src/sampleCurve.js
+++ b/packages/vega-statistics/src/sampleCurve.js
@@ -34,11 +34,17 @@ export default function(f, extent, minSteps, maxSteps) {
       p1 = next[next.length - 1];
 
   while (p1) {
+    // midpoint for potential curve subdivision
     const pm = point((p0[0] + p1[0]) / 2);
 
     if (pm[0] - p0[0] >= stop && angleDelta(p0, pm, p1) > MIN_RADIANS) {
+      // maximum resolution has not yet been met, and
+      // subdivision midpoint sufficiently different from endpoint
+      // save subdivision, push midpoint onto the visitation stack
       next.push(pm);
     } else {
+      // subdivision midpoint sufficiently similar to endpoint
+      // skip subdivision, store endpoint, move to next point on the stack
       p0 = p1;
       prev.push(p1);
       next.pop();


### PR DESCRIPTION
Changes:

**vega-statistics**
- Update sort calls to typed arrays to avoid vendor-specific bugs. See vega/vega-lite#4964.
- Improve comments within sampleCurve method.
