### PR TITLE
Support es5 in vega-util

### DIFF
--- a/packages/vega-util/src/logger.js
+++ b/packages/vega-util/src/logger.js
@@ -1,6 +1,6 @@
 function log(method, level, input) {
-  var msg = [level].concat([].slice.call(input));
-  console[method](...msg); // eslint-disable-line no-console
+  var args = [level].concat([].slice.call(input));
+  console[method].apply(console, args); // eslint-disable-line no-console
 }
 
 export var None  = 0;


### PR DESCRIPTION
We need to make a minor release to maintain es5 compatibility before we can change this in the next major version. 

Currently Vega-Lite 2 and Vega before 5 (I think) are not es5 compatible. 