### PR TITLE
Add naturalEarth1 projection type

### DIFF
--- a/packages/vega-typings/types/spec/projection.d.ts
+++ b/packages/vega-typings/types/spec/projection.d.ts
@@ -15,6 +15,7 @@ export type ProjectionType =
   | 'gnomonic'
   | 'identity'
   | 'mercator'
+  | 'naturalEarth1'
   | 'orthographic'
   | 'stereographic'
   | 'transverseMercator';


### PR DESCRIPTION
Vega's [projection types](https://vega.github.io/vega/docs/projections/#projection-types) support `naturalEarth1` but it was missing in the typings.

I discovered this bug while using the Vega-Lite schema, so this may be an additional data point to discussion #1502 .