### PR TITLE
fix: check date formatting for integer inputs

### DIFF
--- a/packages/vega-functions/src/format.js
+++ b/packages/vega-functions/src/format.js
@@ -43,7 +43,7 @@ export function utcParse(_, specifier) {
 var dateObj = new Date(2000, 0, 1);
 
 function time(month, day, specifier) {
-  if ( !Number.isInteger(month) || !Number.isInteger(day) ) return ""
+  if (!Number.isInteger(month) || !Number.isInteger(day)) return '';
   dateObj.setMonth(month);
   dateObj.setDate(day);
   return timeFormat(dateObj, specifier);

--- a/packages/vega-functions/src/format.js
+++ b/packages/vega-functions/src/format.js
@@ -43,6 +43,7 @@ export function utcParse(_, specifier) {
 var dateObj = new Date(2000, 0, 1);
 
 function time(month, day, specifier) {
+  if ( !Number.isInteger(month) || !Number.isInteger(day) ) return ""
   dateObj.setMonth(month);
   dateObj.setDate(day);
   return timeFormat(dateObj, specifier);

--- a/packages/vega-functions/test/month-abbrev-test.js
+++ b/packages/vega-functions/test/month-abbrev-test.js
@@ -1,0 +1,10 @@
+var tape = require('tape'),
+    {monthAbbrevFormat} = require('../');
+
+tape('monthAbbrevFormat handles bad data', function(t) {
+  t.equal(monthAbbrevFormat(0), "Jan")
+  t.equal(monthAbbrevFormat("Missing"), "")
+  t.equal(monthAbbrevFormat(1), "Feb")
+
+  t.end()
+})

--- a/packages/vega-functions/test/month-abbrev-test.js
+++ b/packages/vega-functions/test/month-abbrev-test.js
@@ -1,10 +1,11 @@
 var tape = require('tape'),
     {monthAbbrevFormat} = require('../');
 
-tape('monthAbbrevFormat handles bad data', function(t) {
-  t.equal(monthAbbrevFormat(0), "Jan")
-  t.equal(monthAbbrevFormat("Missing"), "")
-  t.equal(monthAbbrevFormat(1), "Feb")
-
+tape('monthAbbrevFormat returns empty string for non-integer values', function(t) {
+  t.equal(monthAbbrevFormat(0), 'Jan');
+  t.equal(monthAbbrevFormat(NaN), '');
+  t.equal(monthAbbrevFormat(1.1), '');
+  t.equal(monthAbbrevFormat('Missing'), '');
+  t.equal(monthAbbrevFormat(1), 'Feb');
   t.end()
-})
+});


### PR DESCRIPTION
closes #1896

Adds check to the date formatting functions to make sure an integer is passed as the month/day.  This avoids a scenario where the date object these functions rely on is corrupted and then the functions return `""`

An alternate solution is to create a date object for each function call - I presumed the current strategy was chosen for performance reasons, so I added numeric checks instead.