### PR TITLE
Revise dataflow pulse assignment.

### DIFF
--- a/packages/vega-dataflow/src/Operator.js
+++ b/packages/vega-dataflow/src/Operator.js
@@ -223,7 +223,7 @@ prototype.evaluate = function(pulse) {
  * @return the output pulse for this operator (or StopPropagation)
  */
 prototype.run = function(pulse) {
-  if (pulse.stamp <= this.stamp) return pulse.StopPropagation;
+  if (pulse.stamp < this.stamp) return pulse.StopPropagation;
   var rv;
   if (this.skip()) {
     this.skip(false);
@@ -231,6 +231,5 @@ prototype.run = function(pulse) {
   } else {
     rv = this.evaluate(pulse);
   }
-  this.stamp = pulse.stamp;
   return (this.pulse = rv || pulse);
 };

--- a/packages/vega-dataflow/src/Transform.js
+++ b/packages/vega-dataflow/src/Transform.js
@@ -24,7 +24,7 @@ var prototype = inherits(Transform, Operator);
  * @return the output pulse for this operator (or StopPropagation)
  */
 prototype.run = function(pulse) {
-  if (pulse.stamp <= this.stamp) return pulse.StopPropagation;
+  if (pulse.stamp < this.stamp) return pulse.StopPropagation;
 
   var rv;
   if (this.skip()) {
@@ -33,8 +33,6 @@ prototype.run = function(pulse) {
     rv = this.evaluate(pulse);
   }
   rv = rv || pulse;
-
-  this.stamp = pulse.stamp;
 
   if (rv.then) {
     rv = rv.then(_ => this.pulse =_);

--- a/packages/vega-dataflow/src/dataflow/Dataflow.js
+++ b/packages/vega-dataflow/src/dataflow/Dataflow.js
@@ -29,7 +29,7 @@ export default function Dataflow() {
   }
 
   this._touched = UniqueList(id);
-  this._pulses = {};
+  this._input = {};
   this._pulse = null;
 
   this._heap = Heap((a, b) => a.qrank - b.qrank);

--- a/packages/vega-dataflow/src/dataflow/update.js
+++ b/packages/vega-dataflow/src/dataflow/update.js
@@ -65,8 +65,9 @@ export function pulse(op, changeset, options) {
 
   var p = new Pulse(this, this._clock + (this._pulse ? 0 : 1)),
       t = op.pulse && op.pulse.source || [];
+
   p.target = op;
-  this._pulses[op.id] = changeset.pulse(p, t);
+  this._input[op.id] = changeset.pulse(p, t);
 
   return this;
 }

--- a/packages/vega-dataflow/src/util/Heap.js
+++ b/packages/vega-dataflow/src/util/Heap.js
@@ -1,6 +1,7 @@
 export default function Heap(cmp) {
   var nodes = [];
   return {
+    clear: () => nodes = [],
     size: () => nodes.length,
     peek: () => nodes[0],
     push: x => {

--- a/packages/vega-dataflow/test/dataflow-test.js
+++ b/packages/vega-dataflow/test/dataflow-test.js
@@ -101,7 +101,8 @@ tape('Dataflow handles errors', function(t) {
 
   t.equal(error, 1);
   t.equal(df._pulse, null);
-  t.equal(Object.keys(df._pulses).length, 0);
+  t.equal(Object.keys(df._input).length, 0);
   t.equal(df._postrun.length, 0);
+  t.equal(df._heap.size(), 0);
   t.end();
 });


### PR DESCRIPTION
Updates how the dataflow internally tracks and assigns pulses to operators.
- Removes dataflow `_pulses` hash, replaces it will `_input` hash for incoming changesets only.
- Use operator timestamp to indicate dataflow queueing status.
- Assign a forked pulse to operators that do not "inherit" from a tuple source.

Fix #1906 