### PR TITLE
Fix ViewLayout to respect clipped groups.

### DIFF
--- a/packages/vega-view-transforms/src/ViewLayout.js
+++ b/packages/vega-view-transforms/src/ViewLayout.js
@@ -133,6 +133,11 @@ function layoutGroup(view, group, _) {
     viewBounds.union(titleLayout(view, title, width, height, viewBounds));
   }
 
+  // override aggregated view bounds if content is clipped
+  if (group.clip) {
+    viewBounds.set(0, 0, group.width || 0, group.height || 0);
+  }
+
   // perform size adjustment
   viewSizeLayout(view, group, viewBounds, _);
 }


### PR DESCRIPTION
If a group mark item has a truthy `clip` property, then the vega-view-transforms ViewLayout logic should limit the calculated view bounds to the group's width and height.

Fix #1829.