### PR TITLE
Hierarchy layouts should count leaf nodes if no value field is provided.

### DIFF
--- a/packages/vega-hierarchy/src/HierarchyLayout.js
+++ b/packages/vega-hierarchy/src/HierarchyLayout.js
@@ -23,7 +23,7 @@ prototype.transform = function(_, pulse) {
       root = pulse.source.root,
       as = _.as || fields;
 
-  if (_.field) root.sum(_.field);
+  if (_.field) root.sum(_.field); else root.count();
   if (_.sort) root.sort(_.sort);
 
   setParams(layout, this.params, _);


### PR DESCRIPTION
**vega-hierarchy**
- Fix hierarchy layouts to use leaf counts if no value field is provided.

Close #1863.