### PR TITLE
Add config signal definition support.

### DIFF
--- a/packages/vega-parser/src/config.js
+++ b/packages/vega-parser/src/config.js
@@ -3,9 +3,13 @@ import {isArray, isObject} from 'vega-util';
 export default function(configs) {
   return (configs || []).reduce((out, config) => {
     for (var key in config) {
-      var r = key === 'legend' ? {'layout': 1}
-        : key === 'style' ? true : null;
-      copy(out, key, config[key], r);
+      if (key === 'signals') {
+        out.signals = mergeNamed(out.signals, config.signals);
+      } else {
+        var r = key === 'legend' ? {'layout': 1}
+          : key === 'style' ? true : null;
+        copy(out, key, config[key], r);
+      }
     }
     return out;
   }, defaults());
@@ -25,6 +29,23 @@ function copy(output, key, value, recurse) {
   } else {
     output[key] = value;
   }
+}
+
+function mergeNamed(a, b) {
+  if (a == null) return b;
+
+  const map = {}, out = [];
+
+  function add(_) {
+    if (!map[_.name]) {
+      map[_.name] = 1;
+      out.push(_);
+    }
+  }
+
+  b.forEach(add);
+  a.forEach(add);
+  return out;
 }
 
 var defaultFont = 'sans-serif',

--- a/packages/vega-parser/src/parsers/encode/encode-util.js
+++ b/packages/vega-parser/src/parsers/encode/encode-util.js
@@ -51,7 +51,7 @@ export function encoders(encode, type, role, style, scope, params) {
 }
 
 function applyDefaults(encode, type, role, style, config) {
-  var enter = {}, key, skip, props;
+  var defaults = {}, enter = {}, update, key, skip, props;
 
   // ignore legend and axis
   if (role == 'legend' || String(role).indexOf('axis') === 0) {
@@ -69,7 +69,7 @@ function applyDefaults(encode, type, role, style, config) {
       || (key === 'fill' || key === 'stroke')
       && (has('fill', encode) || has('stroke', encode));
 
-    if (!skip) enter[key] = defaultEncode(props[key]);
+    if (!skip) applyDefault(defaults, key, props[key]);
   }
 
   // resolve styles, apply with increasing precedence
@@ -77,21 +77,31 @@ function applyDefaults(encode, type, role, style, config) {
     var props = config.style && config.style[name];
     for (var key in props) {
       if (!has(key, encode)) {
-        enter[key] = defaultEncode(props[key]);
+        applyDefault(defaults, key, props[key]);
       }
     }
   });
 
   encode = extend({}, encode); // defensive copy
+  for (key in defaults) {
+    props = defaults[key];
+    if (props.signal) {
+      (update = update || {})[key] = props;
+    } else {
+      enter[key] = props;
+    }
+  }
+
   encode.enter = extend(enter, encode.enter);
+  if (update) encode.update = extend(update, encode.update);
 
   return encode;
 }
 
-function defaultEncode(value) {
-  return value && value.signal
+function applyDefault(defaults, key, value) {
+  defaults[key] = value && value.signal
     ? {signal: value.signal}
-    : {value: value};
+    : {value: value}
 }
 
 export function has(key, encode) {

--- a/packages/vega-parser/src/parsers/spec.js
+++ b/packages/vega-parser/src/parsers/spec.js
@@ -33,7 +33,7 @@ export default function(spec, scope, preprocessed) {
     parseScale(_, scope);
   });
 
-  signals.forEach(function(_) {
+  (preprocessed || signals).forEach(function(_) {
     parseSignalUpdates(_, scope);
   });
 

--- a/packages/vega-parser/src/parsers/view.js
+++ b/packages/vega-parser/src/parsers/view.js
@@ -14,7 +14,7 @@ var defined = toSet(['width', 'height', 'padding', 'autosize']);
 
 export default function parseView(spec, scope) {
   var config = scope.config,
-      op, input, encode, parent, root;
+      op, input, encode, parent, root, signals;
 
   scope.background = spec.background || config.background;
   scope.eventConfig = config.events;
@@ -25,9 +25,7 @@ export default function parseView(spec, scope) {
   scope.addSignal('autosize', parseAutosize(spec.autosize, config));
   scope.legends = scope.objectProperty(config.legend && config.legend.layout);
 
-  array(spec.signals).forEach(function(_) {
-    if (!defined[_.name]) parseSignal(_, scope);
-  });
+  signals = addSignals(scope, spec.signals, config.signals);
 
   // Store root group item
   input = scope.add(Collect());
@@ -54,7 +52,7 @@ export default function parseView(spec, scope) {
 
   // Parse remainder of specification
   scope.pushState(ref(encode), ref(parent), null);
-  parseSpec(spec, scope, true);
+  parseSpec(spec, scope, signals);
   scope.operators.push(parent);
 
   // Bound / render / sieve root item
@@ -66,4 +64,23 @@ export default function parseView(spec, scope) {
   scope.addData('root', new DataScope(scope, input, input, op));
 
   return scope;
+}
+
+function addSignals(scope, spec, config) {
+  const names = {}, out = [];
+
+  function add(_) {
+    const name = _.name;
+    if (!names[name]) {
+      names[name] = 1;
+      if (!defined[name]) parseSignal(_, scope);
+      out.push(_);
+    }
+  }
+
+  // signals defined in the spec take priority
+  // add config signals if not already defined
+  array(spec).forEach(add);
+  array(config).forEach(add);
+  return out;
 }

--- a/packages/vega-typings/types/spec/config.d.ts
+++ b/packages/vega-typings/types/spec/config.d.ts
@@ -14,7 +14,7 @@ import {
 import { BaseAxis, LabelOverlap } from './axis';
 import { LayoutAlign, LayoutBounds } from './layout';
 import { BaseLegend, LegendOrient } from './legend';
-import { SignalRef } from './signal';
+import { InitSignal, NewSignal, SignalRef } from './signal';
 import { BaseTitle, TitleAnchor } from './title';
 import {
   AlignValue,
@@ -55,6 +55,7 @@ export interface Config
     ramp?: RangeScheme | string[];
     symbol?: SymbolShape[];
   };
+  signals?: (InitSignal | NewSignal)[];
 }
 
 export type DefaultsConfig = Record<'prevent' | 'allow', boolean | EventType[]>;

--- a/packages/vega-typings/types/spec/signal.d.ts
+++ b/packages/vega-typings/types/spec/signal.d.ts
@@ -9,7 +9,7 @@ export interface BaseSignal {
   on?: OnEvent[];
 }
 export interface PushSignal extends BaseSignal {
-  push?: 'outer';
+  push: 'outer';
 }
 export interface NewSignal extends BaseSignal {
   value?: SignalValue;


### PR DESCRIPTION
**vega-parser**
- Add config signal definition support.
- Update default value assignment to put signal values in `update` set.
- Update config merge logic to support signal definitions.

**vega-typings**
- Add config signal definition typings.

Close #1904.
Close #1959.