### PR TITLE
update d3-format to 1.4.1

### DIFF
--- a/packages/vega-encode/package.json
+++ b/packages/vega-encode/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "d3-array": "^2.3.1",
-    "d3-format": "^1.3.2",
+    "d3-format": "^1.4.1",
     "d3-interpolate": "^1.3.2",
     "d3-time-format": "^2.1.3",
     "vega-dataflow": "^5.4.0",

--- a/packages/vega-functions/package.json
+++ b/packages/vega-functions/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "d3-array": "^2.3.1",
     "d3-color": "^1.3.0",
-    "d3-format": "^1.3.2",
+    "d3-format": "^1.4.1",
     "d3-geo": "^1.11.6",
     "d3-time-format": "^2.1.3",
     "vega-dataflow": "^5.2.1",


### PR DESCRIPTION
This PR updates d3-format to v1.4.1

The main reason for this update is to allow a custom minus character used as the prefix for negativ numbers, see https://github.com/d3/d3-format#locales

This allows charts with negative numbers prefixed by the typographically much nicer minus-sign (U+2212) instead of the hyphen-minus which makes people caring about typesetting happy.

Also `nan` is available as a property in the d3 locale to allow the configuration of the string used when d3-format is used to format a value that is `NaN`.