### PR TITLE
Selection fields are flattened, so should be directly accessed.

### DIFF
--- a/packages/vega-selections/src/selectionTest.js
+++ b/packages/vega-selections/src/selectionTest.js
@@ -17,8 +17,7 @@ function testPoint(datum, entry) {
 
   for (; i<n; ++i) {
     f = fields[i];
-    f.getter = field.getter || field(f.field);
-    dval = f.getter(datum);
+    dval = datum[f.field];  // Fields are flattened, so no accessor function needed.
 
     if (isDate(dval)) dval = toNumber(dval);
     if (isDate(values[i])) values[i] = toNumber(values[i]);


### PR DESCRIPTION
As of vega/vega-lite#3676 and then vega/vega-lite#5351, data fields in Vega-Lite are flattened (i.e., `datum["nested"]["a"]` becomes `datum["nested.a"]`). As a result, using vega-util's `field` accessor will yield the wrong behavior and we, instead, want to directly access fields on the datum. 