### PR TITLE
Add luminance and contrast functions

### DIFF
--- a/packages/vega-functions/src/codegen.js
+++ b/packages/vega-functions/src/codegen.js
@@ -64,6 +64,11 @@ import {
 } from 'd3-color';
 
 import {
+  luminance,
+  contrast
+} from './luminance';
+
+import {
   data,
   indata,
   setdata
@@ -185,6 +190,8 @@ export const functionContext = {
   lab,
   hcl,
   hsl,
+  luminance,
+  contrast,
   sequence,
   format,
   utcFormat,

--- a/packages/vega-functions/src/luminance.js
+++ b/packages/vega-functions/src/luminance.js
@@ -1,16 +1,19 @@
+import { rgb } from "d3-color";
+
 // https://www.w3.org/TR/2008/REC-WCAG20-20081211/#relativeluminancedef
 function channel_luminance_value(channelValue) {
   const val = channelValue / 255;
   if (val <= 0.03928) {
-    return val / 12.92
+    return val / 12.92;
   }
   return Math.pow((val + 0.055) / 1.055, 2.4);
 }
 
 export function luminance(color) {
-  const r = channel_luminance_value(color.r);
-  const g = channel_luminance_value(color.g);
-  const b = channel_luminance_value(color.b);
+  const c = rgb(color);
+  const r = channel_luminance_value(c.r);
+  const g = channel_luminance_value(c.g);
+  const b = channel_luminance_value(c.b);
   return 0.2126 * r + 0.7152 * g + 0.0722 * b;
 }
 

--- a/packages/vega-functions/src/luminance.js
+++ b/packages/vega-functions/src/luminance.js
@@ -1,0 +1,24 @@
+// https://www.w3.org/TR/2008/REC-WCAG20-20081211/#relativeluminancedef
+function channel_luminance_value(channelValue) {
+  const val = channelValue / 255;
+  if (val <= 0.03928) {
+    return val / 12.92
+  }
+  return Math.pow((val + 0.055) / 1.055, 2.4);
+}
+
+export function luminance(color) {
+  const r = channel_luminance_value(color.r);
+  const g = channel_luminance_value(color.g);
+  const b = channel_luminance_value(color.b);
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+// https://www.w3.org/TR/2008/REC-WCAG20-20081211/#contrast-ratiodef
+export function contrast(color1, color2) {
+  const lum1 = luminance(color1);
+  const lum2 = luminance(color2);
+  const lumL = Math.max(lum1, lum2);
+  const lumD = Math.min(lum1, lum2);
+  return (lumL + 0.05) / (lumD + 0.05);
+}

--- a/packages/vega-functions/test/luminance-test.js
+++ b/packages/vega-functions/test/luminance-test.js
@@ -1,15 +1,14 @@
 var tape = require('tape'),
-    {luminance, contrast} = require('../').functionContext,
-    {rgb} = require('d3-color');
+  { luminance, contrast } = require('../').functionContext;
 
 tape('luminance calculation extremes', function(t) {
-  t.equal(luminance(rgb("#000000")), 0);
-  t.equal(luminance(rgb("#FFFFFF")), 1);
-  t.end()
+  t.equal(luminance('#000000'), 0);
+  t.equal(luminance('#FFFFFF'), 1);
+  t.end();
 });
 
 tape('contrast calculation extremes', function(t) {
-  t.equal(contrast(rgb("black"), rgb("white")), 21);
-  t.equal(contrast(rgb("black"), rgb("black")), 1);
-  t.end()
+  t.equal(contrast('black', 'white'), 21);
+  t.equal(contrast('black', 'black'), 1);
+  t.end();
 });

--- a/packages/vega-functions/test/luminance-test.js
+++ b/packages/vega-functions/test/luminance-test.js
@@ -1,0 +1,15 @@
+var tape = require('tape'),
+    {luminance, contrast} = require('../').functionContext,
+    {rgb} = require('d3-color');
+
+tape('luminance calculation extremes', function(t) {
+  t.equal(luminance(rgb("#000000")), 0);
+  t.equal(luminance(rgb("#FFFFFF")), 1);
+  t.end()
+});
+
+tape('contrast calculation extremes', function(t) {
+  t.equal(contrast(rgb("black"), rgb("white")), 21);
+  t.equal(contrast(rgb("black"), rgb("black")), 1);
+  t.end()
+});

--- a/packages/vega-typings/tests/spec/valid/grouped-bar.ts
+++ b/packages/vega-typings/tests/spec/valid/grouped-bar.ts
@@ -108,7 +108,10 @@ export const spec: Spec = {
             "enter": {
               "x": {"field": "x2", "offset": -5},
               "y": {"field": "y", "offset": {"field": "height", "mult": 0.5}},
-              "fill": {"value": "white"},
+              "fill": [
+                {"test": "contrast('white', datum.fill) > contrast('black', datum.fill)", "value": "white"},
+                {"value": "black"}
+              ],
               "align": {"value": "right"},
               "baseline": {"value": "middle"},
               "text": {"field": "datum.value"}

--- a/packages/vega/test/scenegraphs/grouped-bar.json
+++ b/packages/vega/test/scenegraphs/grouped-bar.json
@@ -445,7 +445,7 @@
                       "y": 22.5,
                       "align": "right",
                       "baseline": "middle",
-                      "fill": "white",
+                      "fill": "black",
                       "text": 0.6,
                       "font": "sans-serif",
                       "fontSize": 11
@@ -455,7 +455,7 @@
                       "y": 37.5,
                       "align": "right",
                       "baseline": "middle",
-                      "fill": "white",
+                      "fill": "black",
                       "text": 0.9,
                       "font": "sans-serif",
                       "fontSize": 11
@@ -465,7 +465,7 @@
                       "y": 52.5,
                       "align": "right",
                       "baseline": "middle",
-                      "fill": "white",
+                      "fill": "black",
                       "text": 0.4,
                       "font": "sans-serif",
                       "fontSize": 11
@@ -541,7 +541,7 @@
                       "y": 22.5,
                       "align": "right",
                       "baseline": "middle",
-                      "fill": "white",
+                      "fill": "black",
                       "text": 0.2,
                       "font": "sans-serif",
                       "fontSize": 11
@@ -551,7 +551,7 @@
                       "y": 37.5,
                       "align": "right",
                       "baseline": "middle",
-                      "fill": "white",
+                      "fill": "black",
                       "text": 1.1,
                       "font": "sans-serif",
                       "fontSize": 11
@@ -561,7 +561,7 @@
                       "y": 52.5,
                       "align": "right",
                       "baseline": "middle",
-                      "fill": "white",
+                      "fill": "black",
                       "text": 0.8,
                       "font": "sans-serif",
                       "fontSize": 11
@@ -637,7 +637,7 @@
                       "y": 22.5,
                       "align": "right",
                       "baseline": "middle",
-                      "fill": "white",
+                      "fill": "black",
                       "text": 0.1,
                       "font": "sans-serif",
                       "fontSize": 11
@@ -647,7 +647,7 @@
                       "y": 37.5,
                       "align": "right",
                       "baseline": "middle",
-                      "fill": "white",
+                      "fill": "black",
                       "text": 0.2,
                       "font": "sans-serif",
                       "fontSize": 11
@@ -657,7 +657,7 @@
                       "y": 52.5,
                       "align": "right",
                       "baseline": "middle",
-                      "fill": "white",
+                      "fill": "black",
                       "text": 0.7,
                       "font": "sans-serif",
                       "fontSize": 11

--- a/packages/vega/test/specs-valid/grouped-bar.vg.json
+++ b/packages/vega/test/specs-valid/grouped-bar.vg.json
@@ -106,7 +106,10 @@
             "enter": {
               "x": {"field": "x2", "offset": -5},
               "y": {"field": "y", "offset": {"field": "height", "mult": 0.5}},
-              "fill": {"value": "white"},
+              "fill": [
+                {"test": "contrast('white', datum.fill) > contrast('black', datum.fill)", "value": "white"},
+                {"value": "black"}
+              ],
               "align": {"value": "right"},
               "baseline": {"value": "middle"},
               "text": {"field": "datum.value"}


### PR DESCRIPTION
# Implements luminance and contrast expression functions

This PR adds 2 new functions. It was discussed in #1860. The implementation is pretty small (20 LOC). Adding this to vega allows for more accessible charts and would help to build awareness about accessibility in my opinion.

- `luminance` returns the relative luminance according to https://www.w3.org/TR/2008/REC-WCAG20-20081211/#relativeluminancedef for a given color
- `contrast` returns the contrast ratio between two colors according to https://www.w3.org/TR/2008/REC-WCAG20-20081211/#contrast-ratiodef
- tests are added for both functions in vega-functions

This PR extends the grouped-bar example and test to use the contrast function to determine if the text mark should use black or white fill, depending on the higher contrast ratio against the rect color. The scenegraph of the grouped-bar test is changed to reflect the new text fill values.

If you don't want to add this to vega in ordner to not add more bloat to the package I would totally understand that.

Let me know if there is anything that I missed, did wrong or should change in this PR.