### PR TITLE
Fix guide (re-)layout. (#2017)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,5 +11,6 @@ extends:
     "eslint:recommended"
 
 rules:
+    no-console: 2
     no-cond-assign: 0
     no-fallthrough: ["error", { "commentPattern": "break omitted" }]

--- a/packages/vega-parser/src/parsers/title.js
+++ b/packages/vega-parser/src/parsers/title.js
@@ -73,8 +73,6 @@ function groupEncode(_, userEncode) {
 }
 
 function buildTitle(spec, _, userEncode, dataRef) {
-  console.log(userEncode);
-
   var zero = {value: 0},
       text = spec.text,
       encode = {

--- a/packages/vega-view-transforms/src/Bound.js
+++ b/packages/vega-view-transforms/src/Bound.js
@@ -1,4 +1,4 @@
-import {Group, LegendRole, TitleRole} from './constants';
+import {Group, AxisRole, LegendRole, TitleRole} from './constants';
 import {Transform} from 'vega-dataflow';
 import {boundClip, Marks} from 'vega-scenegraph';
 import {inherits} from 'vega-util';
@@ -41,9 +41,13 @@ prototype.transform = function(_, pulse) {
       markBounds.union(boundItem(item, bound));
     });
 
-    // force reflow for legends/titles to propagate any layout changes
-    // suppress other types to prevent overall layout jumpiness
-    if (mark.role === LegendRole || mark.role === TitleRole) pulse.reflow();
+    // force reflow for axes/legends/titles to propagate any layout changes
+    switch (mark.role) {
+      case AxisRole:
+      case LegendRole:
+      case TitleRole:
+        pulse.reflow();
+    }
   }
 
   else {

--- a/packages/vega-view-transforms/src/layout/axis.js
+++ b/packages/vega-view-transforms/src/layout/axis.js
@@ -45,28 +45,28 @@ export function axisLayout(view, axis, width, height) {
       x = position || 0;
       y = -offset;
       s = Math.max(minExtent, Math.min(maxExtent, -bounds.y1));
-      if (title) s = axisTitleLayout(title, s, titlePadding, dl, 0, -1, bounds);
+      if (title) s = axisTitleLayout(view, title, s, titlePadding, dl, 0, -1, bounds);
       bounds.add(0, -s).add(range, 0);
       break;
     case Left:
       x = -offset;
       y = position || 0;
       s = Math.max(minExtent, Math.min(maxExtent, -bounds.x1));
-      if (title) s = axisTitleLayout(title, s, titlePadding, dl, 1, -1, bounds);
+      if (title) s = axisTitleLayout(view, title, s, titlePadding, dl, 1, -1, bounds);
       bounds.add(-s, 0).add(0, range);
       break;
     case Right:
       x = width + offset;
       y = position || 0;
       s = Math.max(minExtent, Math.min(maxExtent, bounds.x2));
-      if (title) s = axisTitleLayout(title, s, titlePadding, dl, 1, 1, bounds);
+      if (title) s = axisTitleLayout(view, title, s, titlePadding, dl, 1, 1, bounds);
       bounds.add(0, 0).add(s, range);
       break;
     case Bottom:
       x = position || 0;
       y = height + offset;
       s = Math.max(minExtent, Math.min(maxExtent, bounds.y2));
-      if (title) s = axisTitleLayout(title, s, titlePadding, 0, 0, 1, bounds);
+      if (title) s = axisTitleLayout(view, title, s, titlePadding, 0, 0, 1, bounds);
       bounds.add(0, 0).add(range, s);
       break;
     default:
@@ -87,18 +87,20 @@ export function axisLayout(view, axis, width, height) {
   return item.mark.bounds.clear().union(bounds);
 }
 
-function axisTitleLayout(title, offset, pad, dl, isYAxis, sign, bounds) {
+function axisTitleLayout(view, title, offset, pad, dl, isYAxis, sign, bounds) {
   var b = title.bounds, dx = 0, dy = 0;
 
   if (title.auto) {
+    view.dirty(title);
+
     offset += pad;
 
     isYAxis
       ? dx = (title.x || 0) - (title.x = sign * (offset + dl))
       : dy = (title.y || 0) - (title.y = sign * (offset + dl));
 
-    b.translate(-dx, -dy);
-    title.mark.bounds.clear().union(b);
+    title.mark.bounds.clear().union(b.translate(-dx, -dy));
+    view.dirty(title);
 
     if (isYAxis) {
       bounds.add(0, b.y1).add(0, b.y2);


### PR DESCRIPTION
**vega**
- Update .eslintrc.

**vega-parser**
- Fix extraneous console output.

**vega-view-transforms**
- Fix dirty call for axis title element.
- Fix view layout trigger for all guide elements.

Fix #2017.