### PR TITLE
Refine multi-line text.

### DIFF
--- a/packages/vega-scenegraph/index.js
+++ b/packages/vega-scenegraph/index.js
@@ -38,7 +38,7 @@ export {
   fontFamily,
   fontSize,
   lineHeight,
-  multilineOffset,
+  multiLineOffset,
   textMetrics
 } from './src/util/text';
 export {resetSVGClipId} from './src/util/svg/clip';

--- a/packages/vega-scenegraph/src/SVGRenderer.js
+++ b/packages/vega-scenegraph/src/SVGRenderer.js
@@ -3,7 +3,7 @@ import {gradientRef, isGradient, patternPrefix} from './Gradient';
 import marks from './marks/index';
 import {domChild, domClear, domCreate, cssClass} from './util/dom';
 import {openTag, closeTag} from './util/tags';
-import {fontFamily, fontSize, lineHeight, textValue} from './util/text';
+import {fontFamily, fontSize, lineHeight, textLines, textValue} from './util/text';
 import {visit} from './util/visit';
 import clip from './util/svg/clip';
 import metadata from './util/svg/metadata';
@@ -426,11 +426,12 @@ var mark_extras = {
     }
   },
   text: function(mdef, el, item) {
-    var key, value, doc, lh;
+    var tl = textLines(item),
+        key, value, doc, lh;
 
-    if (isArray(item.text)) {
+    if (isArray(tl)) {
       // multi-line text
-      value = item.text.map(_ => textValue(item, _));
+      value = tl.map(_ => textValue(item, _));
       key = value.join('\n'); // content cache key
 
       if (key !== values.text) {
@@ -451,7 +452,7 @@ var mark_extras = {
       }
     } else {
       // single-line text
-      value = textValue(item);
+      value = textValue(item, tl);
       if (value !== values.text) {
         el.textContent = value;
         values.text = value;

--- a/packages/vega-scenegraph/src/SVGStringRenderer.js
+++ b/packages/vega-scenegraph/src/SVGStringRenderer.js
@@ -3,13 +3,12 @@ import {gradientRef, isGradient, patternPrefix} from './Gradient';
 import marks from './marks/index';
 import {cssClass} from './util/dom';
 import {openTag, closeTag} from './util/tags';
-import {fontFamily, fontSize, lineHeight, textValue} from './util/text';
+import {fontFamily, fontSize, lineHeight, textLines, textValue} from './util/text';
 import {visit} from './util/visit';
 import clip from './util/svg/clip';
 import metadata from './util/svg/metadata';
 import {styles, styleProperties} from './util/svg/styles';
-import {inherits} from 'vega-util';
-import { isArray } from 'vega-util';
+import {inherits, isArray} from 'vega-util';
 
 export default function SVGStringRenderer(loader) {
   Renderer.call(this, loader);
@@ -234,18 +233,18 @@ prototype.mark = function(scene) {
     str += openTag(tag, renderer.attributes(mdef.attr, item), style);
 
     if (tag === 'text') {
-      if (isArray(item.text)) {
+      const tl = textLines(item);
+      if (isArray(tl)) {
         // multi-line text
-        const attrs = {x: 0, dy: lineHeight(item)},
-              lines = item.text;
-        for (let i=0; i<lines.length; ++i) {
+        const attrs = {x: 0, dy: lineHeight(item)};
+        for (let i=0; i<tl.length; ++i) {
           str += openTag('tspan', i ? attrs: null)
-            + escape_text(textValue(item, lines[i]))
+            + escape_text(textValue(item, tl[i]))
             + closeTag('tspan');
         }
       } else {
         // single-line text
-        str += escape_text(textValue(item));
+        str += escape_text(textValue(item, tl));
       }
     } else if (tag === 'g') {
       str += openTag('path', renderer.attributes(mdef.background, item),

--- a/packages/vega-scenegraph/src/util/text.js
+++ b/packages/vega-scenegraph/src/util/text.js
@@ -45,20 +45,32 @@ export function lineHeight(item) {
   return item.lineHeight != null ? item.lineHeight : (fontSize(item) + 2);
 }
 
-export function multilineOffset(item) {
-  return isArray(item.text)
-    ? (item.text.length - 1) * lineHeight(item)
-    : 0;
+function lineArray(_) {
+  return isArray(_) ? _.length > 1 ? _ : _[0] : _;
 }
 
-export function textValue(item, text) {
-  var s = text || item.text;
-  return s == null ? '' : (item.limit > 0 ? truncate(item, s) : s + '');
+export function textLines(item) {
+  return lineArray(
+    item.lineBreak && item.text && !isArray(item.text)
+      ? item.text.split(item.lineBreak)
+      : item.text
+  );
 }
 
-export function truncate(item, line) {
+export function multiLineOffset(item) {
+  const tl = textLines(item);
+  return (isArray(tl) ? (tl.length - 1) : 0) * lineHeight(item);
+}
+
+export function textValue(item, line) {
+  return line == null ? ''
+    : item.limit > 0 ? truncate(item, line)
+    : line + '';
+}
+
+function truncate(item, line) {
   var limit = +item.limit,
-      text = (line || item.text) + '',
+      text = line + '',
       width;
 
   if (textMetrics.width === measureWidth) {

--- a/packages/vega-view-transforms/src/layout/axis.js
+++ b/packages/vega-view-transforms/src/layout/axis.js
@@ -1,6 +1,6 @@
 import {Top, Bottom, Left, Right} from '../constants';
 import {set, tempBounds} from './util';
-import {boundStroke, multilineOffset} from 'vega-scenegraph';
+import {boundStroke, multiLineOffset} from 'vega-scenegraph';
 
 const AxisOffset = 0.5;
 
@@ -31,7 +31,7 @@ export function axisLayout(view, axis, width, height) {
       title = datum.title && item.items[indices[2]].items[0],
       titlePadding = item.titlePadding,
       bounds = item.bounds,
-      dl = title && multilineOffset(title),
+      dl = title && multiLineOffset(title),
       x = 0, y = 0, i, s;
 
   tempBounds.clear().union(bounds);

--- a/packages/vega-view-transforms/src/layout/legend.js
+++ b/packages/vega-view-transforms/src/layout/legend.js
@@ -3,7 +3,7 @@ import {
   TopLeft, TopRight, BottomLeft, BottomRight, None,
   Each, Flush
 } from '../constants';
-import {boundStroke, multilineOffset} from 'vega-scenegraph';
+import {boundStroke, multiLineOffset} from 'vega-scenegraph';
 
 // utility for looking up legend layout configuration
 function lookup(config, orient) {
@@ -189,7 +189,7 @@ function legendTitleOffset(item, entry, title, anchor, y, lr, noBar) {
         s = e.bounds[y ? 'y2' : 'x2'] - item.padding,
         u = vgrad && lr ? s : 0,
         v = vgrad && lr ? 0 : s,
-        o = y <= 0 ? 0 : multilineOffset(title);
+        o = y <= 0 ? 0 : multiLineOffset(title);
 
   return Math.round(anchor === Start ? u
     : anchor === End ? (v - o)


### PR DESCRIPTION
**vega-scenegraph**
- Refactor and encapsulate multi-line text handling.
- Add initial text item lineBreak support.

**vega-view-transforms**
- Use updated `multiLineOffset` method from scenegraph.