### PR TITLE
Fix bug in svg renderer

### DIFF
--- a/packages/vega-scenegraph/src/SVGRenderer.js
+++ b/packages/vega-scenegraph/src/SVGRenderer.js
@@ -390,14 +390,18 @@ function bind(item, el, sibling, tag, svg) {
   }
 
   // (re-)insert if (a) not contained in SVG or (b) sibling order has changed
-  if (node.ownerSVGElement !== svg || hasSiblings(item) && node.previousSibling !== sibling) {
+  if (node.ownerSVGElement !== svg || hasSiblings(node, item) && node.previousSibling !== sibling) {
     el.insertBefore(node, sibling ? sibling.nextSibling : el.firstChild);
   }
 
   return node;
 }
 
-function hasSiblings(item) {
+function hasSiblings(node, item) {
+  if (node && node.parentNode) {
+    return node.parentNode.childNodes.length > 1;
+  }
+
   var parent = item.mark || item.group;
   return parent && parent.items.length > 1;
 }


### PR DESCRIPTION
This fixes a bug I've discovered with axis labels. Here's the situation:

* I have a bar chart with 20 bars (let's say the labels are A, B, C, etc for simplicity).
* External to my Vega chart, my UI allows the user to filter the data that is sent to Vega. These filtering operations are handled by rebuilding the data table via querying a backend database, and then feeding the updated data to Vega via `view.data("tableName", obj)`. Let's say the user sets a filter to only show the data for label C.
* The renderer runs until `item` is the scenegraph node corresponding to the label C SVG node. Since all of the other labels have been removed, the intention is to move this label's SVG node to be the first child of its parent so that `domClear()` can remove the other children. However, `hasSiblings` returns false because `item.mark.items` has a length of 1, so the node is never moved to the front.
* When `domClear()` runs, it removes all but the first axis label which almost certainly is not the one we wanted.

My solution is to check the actual DOM to see if there are siblings. I'm not completely sure under what conditions the code enters here, so I made my additions rather defensive, falling back to the old code path. Please let me know if there are any updates I could make!