### PR TITLE
Use robust alternatives for isNan and isFinite.

### DIFF
--- a/docs/docs/expressions.md
+++ b/docs/docs/expressions.md
@@ -191,35 +191,35 @@ Basic mathematical functions.
 
 <a name="isNaN" href="#isNaN">#</a>
 <b>isNaN</b>(<i>value</i>)<br/>
-Returns true if _value_ is not a number. Same as JavaScript's `isNaN`.
+Returns true if _value_ is not a number. Same as JavaScript's [`Number.isNaN`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isNan).
 
 <a name="isFinite" href="#isFinite">#</a>
 <b>isFinite</b>(<i>value</i>)<br/>
-Returns true if _value_ is a finite number. Same as JavaScript's `isFinite`.
+Returns true if _value_ is a finite number. Same as JavaScript's [`Number.isFinite`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isFinite).
 
 <a name="abs" href="#abs">#</a>
 <b>abs</b>(<i>value</i>)<br/>
-Returns the absolute value of _value_. Same as JavaScript's `Math.abs`.
+Returns the absolute value of _value_. Same as JavaScript's [`Math.abs`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/abs).
 
 <a name="acos" href="#acos">#</a>
 <b>acos</b>(<i>value</i>)<br/>
-Trigonometric arccosine. Same as JavaScript's `Math.acos`.
+Trigonometric arccosine. Same as JavaScript's [`Math.acos`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/acos).
 
 <a name="asin" href="#asin">#</a>
 <b>asin</b>(<i>value</i>)<br/>
-Trigonometric arcsine. Same as JavaScript's `Math.asin`.
+Trigonometric arcsine. Same as JavaScript's [`Math.asin`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/asin).
 
 <a name="atan" href="#atan">#</a>
 <b>atan</b>(<i>value</i>)<br/>
-Trigonometric arctangent. Same as JavaScript's `Math.atan`.
+Trigonometric arctangent. Same as JavaScript's [`Math.atan`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/atan).
 
 <a name="atan2" href="#atan2">#</a>
 <b>atan2</b>(<i>dy</i>, <i>dx</i>)<br/>
-Returns the arctangent of _dy / dx_. Same as JavaScript's `Math.atan2`.
+Returns the arctangent of _dy / dx_. Same as JavaScript's [`Math.atan2`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/atan2).
 
 <a name="ceil" href="#ceil">#</a>
 <b>ceil</b>(<i>value</i>)<br/>
-Rounds _value_ to the nearest integer of equal or greater value. Same as JavaScript's `Math.ceil`.
+Rounds _value_ to the nearest integer of equal or greater value. Same as JavaScript's [`Math.ceil`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/ceil).
 
 <a name="clamp" href="#clamp">#</a>
 <b>clamp</b>(<i>value</i>, <i>min</i>, <i>max</i>)<br/>
@@ -227,51 +227,51 @@ Restricts _value_ to be between the specified _min_ and _max_.
 
 <a name="cos" href="#cos">#</a>
 <b>cos</b>(<i>value</i>)<br/>
-Trigonometric cosine. Same as JavaScript's `Math.cos`.
+Trigonometric cosine. Same as JavaScript's [`Math.cos`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/cos).
 
 <a name="exp" href="#exp">#</a>
 <b>exp</b>(<i>exponent</i>)<br/>
-Returns the value of _e_ raised to the provided _exponent_. Same as JavaScript's `Math.exp`.
+Returns the value of _e_ raised to the provided _exponent_. Same as JavaScript's [`Math.exp`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/exp).
 
 <a name="floor" href="#floor">#</a>
 <b>floor</b>(<i>value</i>)<br/>
-Rounds _value_ to the nearest integer of equal or lower value. Same as JavaScript's `Math.floor`.
+Rounds _value_ to the nearest integer of equal or lower value. Same as JavaScript's [`Math.floor`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/floor).
 
 <a name="log" href="#log">#</a>
 <b>log</b>(<i>value</i>)<br/>
-Returns the natural logarithm of _value_. Same as JavaScript's `Math.log`.
+Returns the natural logarithm of _value_. Same as JavaScript's [`Math.log`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/log).
 
 <a name="max" href="#max">#</a>
 <b>max</b>(<i>value1</i>, <i>value2</i>, ...)<br/>
-Returns the maximum argument value. Same as JavaScript's `Math.max`.
+Returns the maximum argument value. Same as JavaScript's [`Math.max`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/max).
 
 <a name="min" href="#min">#</a>
 <b>min</b>(<i>value1</i>, <i>value2</i>, ...)<br/>
-Returns the minimum argument value. Same as JavaScript's `Math.min`.
+Returns the minimum argument value. Same as JavaScript's [`Math.min`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/min).
 
 <a name="pow" href="#pow">#</a>
 <b>pow</b>(<i>value</i>, <i>exponent</i>)<br/>
-Returns _value_ raised to the given _exponent_. Same as JavaScript's `Math.pow`.
+Returns _value_ raised to the given _exponent_. Same as JavaScript's [`Math.pow`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/pow).
 
 <a name="random" href="#random">#</a>
 <b>random</b>()<br/>
-Returns a pseudo-random number in the range [0,1). Same as JavaScript's `Math.random`.
+Returns a pseudo-random number in the range [0,1). Same as JavaScript's [`Math.random`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/random).
 
 <a name="round" href="#round">#</a>
 <b>round</b>(<i>value</i>)<br/>
-Rounds _value_ to the nearest integer. Same as JavaScript's `Math.round`.
+Rounds _value_ to the nearest integer. Same as JavaScript's [`Math.round`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/round).
 
 <a name="sin" href="#sin">#</a>
 <b>sin</b>(<i>value</i>)<br/>
-Trigonometric sine. Same as JavaScript's `Math.sin`.
+Trigonometric sine. Same as JavaScript's [`Math.sin`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sin).
 
 <a name="sqrt" href="#sqrt">#</a>
 <b>sqrt</b>(<i>value</i>)<br/>
-Square root function. Same as JavaScript's `Math.sqrt`.
+Square root function. Same as JavaScript's [`Math.sqrt`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sqrt).
 
 <a name="tan" href="#tan">#</a>
 <b>tan</b>(<i>value</i>)<br/>
-Trigonometric tangent. Same as JavaScript's `Math.tan`.
+Trigonometric tangent. Same as JavaScript's [`Math.tan`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/tan).
 
 [Back to Top](#reference)
 

--- a/packages/vega-cli/src/render.js
+++ b/packages/vega-cli/src/render.js
@@ -32,7 +32,7 @@ module.exports = function(type, callback, opt) {
 
   // use a seeded random number generator, if specified
   if (typeof arg.seed !== 'undefined') {
-    if (isNaN(arg.seed)) throw 'Illegal seed value: must be a valid number.';
+    if (Number.isNaN(arg.seed)) throw 'Illegal seed value: must be a valid number.';
     vega.setRandom(vega.randomLCG(arg.seed));
   }
 

--- a/packages/vega-encode/src/labels.js
+++ b/packages/vega-encode/src/labels.js
@@ -90,7 +90,7 @@ function formatPoint(format) {
 }
 
 function formatValue(value, format) {
-  return isFinite(value) ? format(value) : null;
+  return Number.isFinite(value) ? format(value) : null;
 }
 
 export function labelFraction(scale) {

--- a/packages/vega-expression/src/functions.js
+++ b/packages/vega-expression/src/functions.js
@@ -25,8 +25,8 @@ export default function(codegen) {
 
   return {
     // MATH functions
-    isNaN:    'isNaN',
-    isFinite: 'isFinite',
+    isNaN:    'Number.isNaN',
+    isFinite: 'Number.isFinite',
     abs:      'Math.abs',
     acos:     'Math.acos',
     asin:     'Math.asin',

--- a/packages/vega-expression/test/codegen-test.js
+++ b/packages/vega-expression/test/codegen-test.js
@@ -166,9 +166,12 @@ tape('Evaluate expressions with white list', function(t) {
 
   // Function evaluation
   // should eval math functions', function() {
-  t.equal(evaluate('isNaN(1/0)'), isNaN(1/0));
-  t.equal(evaluate('isFinite(1)'), isFinite(1));
-  t.equal(evaluate('isFinite(1/0)'), isFinite(1/0));
+  t.equal(evaluate('isNaN(1/0)'), Number.isNaN(1/0));
+  t.equal(evaluate('isNaN("1")'), Number.isNaN('1'));
+  t.equal(evaluate('isFinite(1)'), Number.isFinite(1));
+  t.equal(evaluate('isFinite(1/0)'), Number.isFinite(1/0));
+  t.equal(evaluate('isFinite(null)'), Number.isFinite(null));
+  t.equal(evaluate('isFinite("0")'), Number.isFinite('0'));
   t.equal(evaluate('abs(-3)'), Math.abs(-3));
   t.equal(evaluate('acos(1)'), Math.acos(1));
   t.equal(evaluate('asin(1)'), Math.asin(1));

--- a/packages/vega-force/test/force-test.js
+++ b/packages/vega-force/test/force-test.js
@@ -28,8 +28,8 @@ tape('Force places points', function(t) {
   t.equal(c0.value.length, data.length);
 
   for (var i=0, n=data.length; i<n; ++i) {
-    t.ok(data[i].x != null && !isNaN(data[i].x));
-    t.ok(data[i].y != null && !isNaN(data[i].y));
+    t.ok(data[i].x != null && !Number.isNaN(data[i].x));
+    t.ok(data[i].y != null && !Number.isNaN(data[i].y));
   }
 
   t.end();

--- a/packages/vega-loader/src/type.js
+++ b/packages/vega-loader/src/type.js
@@ -64,11 +64,11 @@ function isBoolean(_) {
 }
 
 function isDate(_) {
-  return !isNaN(Date.parse(_));
+  return !Number.isNaN(Date.parse(_));
 }
 
 function isNumber(_) {
-  return !isNaN(+_) && !(_ instanceof Date);
+  return !Number.isNaN(+_) && !(_ instanceof Date);
 }
 
 function isInteger(_) {

--- a/packages/vega-scale/src/interpolate.js
+++ b/packages/vega-scale/src/interpolate.js
@@ -31,7 +31,7 @@ export function scaleCopy(scale) {
 export function scaleFraction(scale, min, max) {
   var delta = max - min, i, t, s;
 
-  if (!delta || !isFinite(delta)) {
+  if (!delta || !Number.isFinite(delta)) {
     return constant(0.5);
   } else {
     i = (t = scale.type).indexOf('-');

--- a/packages/vega-statistics/test/integer-test.js
+++ b/packages/vega-statistics/test/integer-test.js
@@ -40,8 +40,8 @@ tape('integer evaluates the cdf', function(t) {
 tape('integer evaluates the inverse cdf', function(t) {
   var n1 = integer(0, 5);
   // extreme values
-  t.ok(isNaN(n1.icdf(-1)));
-  t.ok(isNaN(n1.icdf(2)));
+  t.ok(Number.isNaN(n1.icdf(-1)));
+  t.ok(Number.isNaN(n1.icdf(2)));
   // in range values
   t.equal(n1.icdf(0), -1);
   t.equal(n1.icdf(0.2), 0);

--- a/packages/vega-statistics/test/normal-test.js
+++ b/packages/vega-statistics/test/normal-test.js
@@ -56,8 +56,8 @@ tape('normal approximates the cdf', function(t) {
 tape('normal approximates the inverse cdf', function(t) {
   var n1 = normal();
   // out of domain inputs
-  t.ok(isNaN(n1.icdf(-1)));
-  t.ok(isNaN(n1.icdf(2)));
+  t.ok(Number.isNaN(n1.icdf(-1)));
+  t.ok(Number.isNaN(n1.icdf(2)));
   t.equal(n1.icdf(0), -Infinity);
   t.equal(n1.icdf(1), Infinity);
   // regular values

--- a/packages/vega-statistics/test/uniform-test.js
+++ b/packages/vega-statistics/test/uniform-test.js
@@ -39,8 +39,8 @@ tape('uniform evaluates the cdf', function(t) {
 tape('uniform evaluates the inverse cdf', function(t) {
   var n1 = uniform(-1, 1);
   // extreme values
-  t.ok(isNaN(n1.icdf(-2)));
-  t.ok(isNaN(n1.icdf(2)));
+  t.ok(Number.isNaN(n1.icdf(-2)));
+  t.ok(Number.isNaN(n1.icdf(2)));
   t.equal(n1.icdf(0), -1);
   t.equal(n1.icdf(1), 1);
   // in range values

--- a/packages/vega-transforms/src/Impute.js
+++ b/packages/vega-transforms/src/Impute.js
@@ -95,7 +95,7 @@ prototype.transform = function(_, pulse) {
       t = {_impute: true};
       for (i=0, n=gVals.length; i<n; ++i) t[gNames[i]] = gVals[i];
       t[kName] = kVal;
-      t[fName] = isNaN(value) ? (value = impute(group, field)) : value;
+      t[fName] = Number.isNaN(value) ? (value = impute(group, field)) : value;
 
       curr.push(ingest(t));
     }

--- a/packages/vega-transforms/src/util/AggregateOps.js
+++ b/packages/vega-transforms/src/util/AggregateOps.js
@@ -124,7 +124,7 @@ export var AggregateOps = {
     init: 'this.min = undefined;',
     add:  'if (v < this.min || this.min === undefined) this.min = v;',
     rem:  'if (v <= this.min) this.min = NaN;',
-    set:  'this.min = (isNaN(this.min) ? cell.data.min(this.get) : this.min)',
+    set:  'this.min = (Number.isNaN(this.min) ? cell.data.min(this.get) : this.min)',
     str:  ['values'], idx: 4
   }),
   'max': measure({
@@ -132,7 +132,7 @@ export var AggregateOps = {
     init: 'this.max = undefined;',
     add:  'if (v > this.max || this.max === undefined) this.max = v;',
     rem:  'if (v >= this.max) this.max = NaN;',
-    set:  'this.max = (isNaN(this.max) ? cell.data.max(this.get) : this.max)',
+    set:  'this.max = (Number.isNaN(this.max) ? cell.data.max(this.get) : this.max)',
     str:  ['values'], idx: 4
   })
 };

--- a/packages/vega-util/test/type-parse-test.js
+++ b/packages/vega-util/test/type-parse-test.js
@@ -25,13 +25,13 @@ tape('toDate parses dates', function(t) {
   t.equal(vega.toDate(undefined), null);
   t.equal(vega.toDate(''), null);
   t.equal(vega.toDate('1/1/2000'), Date.parse('1/1/2000'));
-  t.ok(isNaN(vega.toDate('foo')));
+  t.ok(Number.isNaN(vega.toDate('foo')));
   t.equal(vega.toDate(0), 0);
   t.equal(vega.toDate(1), 1);
   t.equal(vega.toDate(now), now);
   t.equal(vega.toDate(d), d);
-  t.ok(isNaN(vega.toDate(true)));
-  t.ok(isNaN(vega.toDate(false)));
+  t.ok(Number.isNaN(vega.toDate(true)));
+  t.ok(Number.isNaN(vega.toDate(false)));
   t.end();
 });
 
@@ -43,10 +43,10 @@ tape('toDate parses dates with custom parser', function(t) {
   t.equal(vega.toDate(null, parser), null);
   t.equal(vega.toDate(undefined, parser), null);
   t.equal(vega.toDate('', parser), null);
-  t.ok(isNaN(vega.toDate('1/1/2000', parser)));
-  t.ok(isNaN(vega.toDate('foo', parser)));
-  t.ok(isNaN(vega.toDate(Date.now(), parser)));
-  t.ok(isNaN(vega.toDate(new Date(), parser)));
+  t.ok(Number.isNaN(vega.toDate('1/1/2000', parser)));
+  t.ok(Number.isNaN(vega.toDate('foo', parser)));
+  t.ok(Number.isNaN(vega.toDate(Date.now(), parser)));
+  t.ok(Number.isNaN(vega.toDate(new Date(), parser)));
   t.equal(vega.toDate('epoch', parser), 0);
   t.end();
 });
@@ -58,7 +58,7 @@ tape('toNumber parses numbers', function(t) {
   t.equal(vega.toNumber('0'), 0);
   t.equal(vega.toNumber('1'), 1);
   t.equal(vega.toNumber('1e5'), 1e5);
-  t.ok(isNaN(vega.toNumber('foo')));
+  t.ok(Number.isNaN(vega.toNumber('foo')));
   t.equal(vega.toNumber(0), 0);
   t.equal(vega.toNumber(1), 1);
   t.equal(vega.toNumber(1e5), 1e5);

--- a/packages/vega-wordcloud/test/wordcloud-test.js
+++ b/packages/vega-wordcloud/test/wordcloud-test.js
@@ -34,8 +34,8 @@ tape('Wordcloud generates wordcloud layout', function(t) {
   t.equal(wc.stamp, df.stamp());
 
   for (var i=0, n=data.length; i<n; ++i) {
-    t.ok(data[i].x != null && !isNaN(data[i].x));
-    t.ok(data[i].y != null && !isNaN(data[i].y));
+    t.ok(data[i].x != null && !Number.isNaN(data[i].x));
+    t.ok(data[i].y != null && !Number.isNaN(data[i].y));
     t.equal(data[i].font, 'sans-serif');
     t.equal(data[i].fontSize, Math.sqrt(data[i].size));
     t.equal(data[i].fontStyle, 'normal');


### PR DESCRIPTION
As MDN says ["Note: coercion inside the `isNaN` function has interesting rules"](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/isNaN). Let's use more robust alternatives for isNan and isFinite. 

**vega**
- Use `Number.isFinite` instead of `isFinite` and `Number.isNan` instead of `isNaN`.

cc @donghaoren