### PR TITLE
Fix title layout spacing bug.

### DIFF
--- a/packages/vega-view-transforms/src/layout/grid.js
+++ b/packages/vega-view-transforms/src/layout/grid.js
@@ -1,6 +1,6 @@
 import {
   All, Each, Flush, Column, X, Y, Row, Middle, End,
-  Group, AxisRole, LegendRole,
+  Group, AxisRole, LegendRole, TitleRole,
   RowHeader, RowFooter, RowTitle,
   ColHeader, ColFooter, ColTitle
 } from '../constants';
@@ -31,6 +31,7 @@ function gridLayoutGroups(group) {
       switch (mark.role) {
         case AxisRole:
         case LegendRole:
+        case TitleRole:
           break;
         case RowHeader: views.rowheaders.push(...items); break;
         case RowFooter: views.rowfooters.push(...items); break;


### PR DESCRIPTION
**vega-view-transforms**
- Add TitleRole to groups to skip in grid layout.

Fixes #2058.