### PR TITLE
Fix title encode schema.

### DIFF
--- a/docs/docs/title.md
+++ b/docs/docs/title.md
@@ -47,7 +47,7 @@ To create themes, new default values for many title properties can be set using 
 
 ## <a name="custom"></a>Custom Title Encodings
 
-Custom mark properties can be set for all title elements using the _encode_ parameter. The addressable elements are:
+In addition to the customization parameters above, mark properties can be set for all title elements using the _encode_ parameter. The addressable elements are:
 
 - `group` for the title [group](../marks/group) mark,
 - `title` for the title [text](../marks/text) mark, and
@@ -56,3 +56,31 @@ Custom mark properties can be set for all title elements using the _encode_ para
 Each element accepts a set of visual encoding directives grouped into `enter`, `update`, `exit`, _etc._ objects as described in the [Marks](../marks) documentation. Mark properties can be styled using standard [value references](../types/#Value).
 
 In addition, each encode block may include a string-valued `name` property to assign a unique name to the mark set, a boolean-valued `interactive` property to enable input event handling, and a string-valued (or array-valued) `style` property to apply default property values. Unless otherwise specified, title elements use a default style of `"group-title"` and subtitle elements use a default style of `"group-subtitle"`.
+
+The following example shows how to set custom color and font properties for title and subtitle text marks, and enable interactivity for the subtitle text:
+
+{: .suppress-error}
+```json
+"title": [
+  {
+    "text": "Title Text",
+    "subtitle": "Subtitle Text",
+    "encode": {
+      "title": {
+        "enter": {
+          "fill": {"value": "purple"}
+        }
+      },
+      "subtitle": {
+        "interactive": true,
+        "update": {
+          "fontStyle": {"value": "italic"}
+        },
+        "hover": {
+          "fontStyle": {"value": "normal"}
+        }
+      }
+    }
+  }
+]
+```

--- a/packages/vega-schema/package.json
+++ b/packages/vega-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vega-schema",
-  "version": "5.7.1",
+  "version": "5.7.2",
   "description": "Generate the Vega JSON schema.",
   "keywords": [
     "vega",

--- a/packages/vega-schema/src/title.js
+++ b/packages/vega-schema/src/title.js
@@ -1,7 +1,7 @@
 import {
   numberValue, stringValue, textOrSignal, anchorValue,
   alignValue, baselineValue, colorValue, fontWeightValue,
-  def, enums, object, oneOf, pattern, ref,
+  def, enums, object, anyOf, oneOf, pattern, ref,
   booleanType, numberType, stringType, orSignal, numberOrSignal
 } from './util';
 
@@ -49,7 +49,7 @@ const title = oneOf(
     subtitlePadding: numberOrSignal,
 
     // custom encoders
-    encode: oneOf(
+    encode: anyOf(
       titleEncode, // deprecated! (v5.7.0)
       object({
         group: guideEncodeRef,

--- a/packages/vega-typings/tests/spec/valid/titles.ts
+++ b/packages/vega-typings/tests/spec/valid/titles.ts
@@ -163,7 +163,12 @@ export const spec: Spec = {
         "anchor": {"signal": "titleAnchor"},
         "offset": {"signal": "titleOffset"},
         "subtitle": {"signal": "subtitleText"},
-        "subtitlePadding": {"signal": "subtitlePadding"}
+        "subtitlePadding": {"signal": "subtitlePadding"},
+        "encode": {
+          "enter": {
+            "fill": {"value": "purple"}
+          }
+        }
       },
 
       "marks": [
@@ -213,7 +218,14 @@ export const spec: Spec = {
         "anchor": {"signal": "titleAnchor"},
         "offset": {"signal": "titleOffset"},
         "subtitle": {"signal": "subtitleText"},
-        "subtitlePadding": {"signal": "subtitlePadding"}
+        "subtitlePadding": {"signal": "subtitlePadding"},
+        "encode": {
+          "title": {
+            "enter": {
+              "fontStyle": {"value": "italic"}
+            }
+          }
+        }
       },
 
       "marks": [
@@ -263,7 +275,18 @@ export const spec: Spec = {
         "anchor": {"signal": "titleAnchor"},
         "offset": {"signal": "titleOffset"},
         "subtitle": {"signal": "subtitleText"},
-        "subtitlePadding": {"signal": "subtitlePadding"}
+        "subtitlePadding": {"signal": "subtitlePadding"},
+        "encode": {
+          "subtitle": {
+            "interactive": true,
+            "update": {
+              "fontStyle": {"value": "italic"}
+            },
+            "hover": {
+              "fontStyle": {"value": "normal"}
+            }
+          }
+        }
       },
 
       "marks": [

--- a/packages/vega/test/scenegraphs/titles.json
+++ b/packages/vega/test/scenegraphs/titles.json
@@ -2039,7 +2039,7 @@
                             {
                               "align": "center",
                               "baseline": "top",
-                              "fill": "#000",
+                              "fill": "purple",
                               "opacity": 1,
                               "text": "Bar Chart, Such a Great Bar Chart, Only the Best Bar Chart, A Truly Magnificent Bar Chart",
                               "angle": -90,
@@ -3089,7 +3089,8 @@
                               "limit": 100,
                               "font": "sans-serif",
                               "fontSize": 13,
-                              "fontWeight": "bold"
+                              "fontWeight": "bold",
+                              "fontStyle": "italic"
                             }
                           ],
                           "zindex": 0
@@ -4140,7 +4141,7 @@
                         {
                           "marktype": "text",
                           "role": "title-subtitle",
-                          "interactive": false,
+                          "interactive": true,
                           "clip": false,
                           "items": [
                             {
@@ -4154,7 +4155,8 @@
                               "angle": 0,
                               "limit": 400,
                               "font": "sans-serif",
-                              "fontSize": 12
+                              "fontSize": 12,
+                              "fontStyle": "italic"
                             }
                           ],
                           "zindex": 0

--- a/packages/vega/test/specs-valid/titles.vg.json
+++ b/packages/vega/test/specs-valid/titles.vg.json
@@ -161,7 +161,12 @@
         "anchor": {"signal": "titleAnchor"},
         "offset": {"signal": "titleOffset"},
         "subtitle": {"signal": "subtitleText"},
-        "subtitlePadding": {"signal": "subtitlePadding"}
+        "subtitlePadding": {"signal": "subtitlePadding"},
+        "encode": {
+          "enter": {
+            "fill": {"value": "purple"}
+          }
+        }
       },
 
       "marks": [
@@ -211,7 +216,14 @@
         "anchor": {"signal": "titleAnchor"},
         "offset": {"signal": "titleOffset"},
         "subtitle": {"signal": "subtitleText"},
-        "subtitlePadding": {"signal": "subtitlePadding"}
+        "subtitlePadding": {"signal": "subtitlePadding"},
+        "encode": {
+          "title": {
+            "enter": {
+              "fontStyle": {"value": "italic"}
+            }
+          }
+        }
       },
 
       "marks": [
@@ -261,7 +273,18 @@
         "anchor": {"signal": "titleAnchor"},
         "offset": {"signal": "titleOffset"},
         "subtitle": {"signal": "subtitleText"},
-        "subtitlePadding": {"signal": "subtitlePadding"}
+        "subtitlePadding": {"signal": "subtitlePadding"},
+        "encode": {
+          "subtitle": {
+            "interactive": true,
+            "update": {
+              "fontStyle": {"value": "italic"}
+            },
+            "hover": {
+              "fontStyle": {"value": "normal"}
+            }
+          }
+        }
       },
 
       "marks": [


### PR DESCRIPTION
**docs**
- Add usage example of title `encode` parameter.

**vega**
- Update `titles` test specification and output scenegraph.

**vega-schema**
- Fix title encode schema definition.

Fix #2071.