### PR TITLE
Fix KDE bandwidth heuristic.

### DIFF
--- a/packages/vega-statistics/package.json
+++ b/packages/vega-statistics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vega-statistics",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Statistical routines and probability distributions.",
   "keywords": [
     "vega",
@@ -24,6 +24,6 @@
     "postpublish": "git push && git push --tags"
   },
   "dependencies": {
-    "d3-array": "^2.3.1"
+    "d3-array": "^2.3.2"
   }
 }

--- a/packages/vega-statistics/src/kde.js
+++ b/packages/vega-statistics/src/kde.js
@@ -1,7 +1,7 @@
 import gaussian from './normal';
 import quartiles from './quartiles';
 import {random} from './random';
-import {variance} from 'd3-array';
+import {deviation} from 'd3-array';
 
 // TODO: support for additional kernels?
 export default function(support, bandwidth) {
@@ -56,6 +56,7 @@ export default function(support, bandwidth) {
 function estimateBandwidth(array) {
   var n = array.length,
       q = quartiles(array),
-      h = (q[2] - q[0]) / 1.34;
-  return 1.06 * Math.min(Math.sqrt(variance(array)), h) * Math.pow(n, -0.2);
+      h = ((q[2] - q[0]) / 1.34),
+      v = h ? Math.min(deviation(array), h) : (v || Math.abs(array[0]) || 1);
+  return 1.06 * v * Math.pow(n, -0.2);
 }

--- a/packages/vega-statistics/test/kde-test.js
+++ b/packages/vega-statistics/test/kde-test.js
@@ -66,3 +66,13 @@ tape('kde does not support the inverse cdf', function(t) {
   t.throws(function() { stats.randomKDE([1,1,1]).icdf(0.5); });
   t.end();
 });
+
+tape('kde auto-selects positive bandwidth values', function(t) {
+  var a = [377, 347, 347, 347, 347, 347];
+  t.ok(stats.randomKDE(a).bandwidth() > 0);
+  t.ok(stats.randomKDE(a.slice(1)).bandwidth() > 0);
+  t.ok(stats.randomKDE([-1, -1, -1]).bandwidth() > 0);
+  t.ok(stats.randomKDE([0, 0, 0]).bandwidth() > 0);
+  t.ok(stats.randomKDE([]).bandwidth() > 0);
+  t.end();
+});


### PR DESCRIPTION
**vega-statistics**
- Fix KDE bandwidth heuristic to handle degenerate cases. (#2085)

Fixes #2085.