### PR TITLE
BUG: fix issue with day & month formats

### DIFF
--- a/packages/vega-functions/src/format.js
+++ b/packages/vega-functions/src/format.js
@@ -44,6 +44,7 @@ var dateObj = new Date(2000, 0, 1);
 
 function time(month, day, specifier) {
   if (!Number.isInteger(month) || !Number.isInteger(day)) return '';
+  dateObj.setYear(2000);
   dateObj.setMonth(month);
   dateObj.setDate(day);
   return timeFormat(dateObj, specifier);


### PR DESCRIPTION
Currently, if you pass a negative day or month value to ``dayFormat``, ``monthFormat``, or related functions, subsequent calls to the function return the wrong result. An example of this: [vega editor](https://vega.github.io/editor/#/url/vega-lite/N4KABGBEAmCGAutIC4yghSA3WAbArgKYDOKYA2uBhMDLAJ5kAMAvgDRXW1yOoCM7Thm4MyAWgBMg6jTq8wrDjLRyyAoQF0q0qPABOsAHbEAZgHs9AWzKUukAMZ57+XAkJk5AMQuWEACjh4fEsAOh4ASkg2KFhSVC8fBEgWKg0lKF89AGsPAAczAEtDeCiqSEJDezNoIoBzMnQMSAAPBsgTAsJcaA8eKN16XPd4gEd8I3gCxEmsdx1MeVoOrp74nm8rJOjIeEHhqEMzSyK8ZO0QFKA).

The issue is that setting a negative day or month changes the year value, which is then used in subsequent calls. A remedy is to re-set the year each time the function is called.