### PR TITLE
Bound canvas rendering to view.

### DIFF
--- a/packages/vega-scenegraph/package.json
+++ b/packages/vega-scenegraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vega-scenegraph",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "description": "Vega scenegraph and renderers.",
   "license": "BSD-3-Clause",
   "author": "Jeffrey Heer (http://idl.cs.washington.edu)",
@@ -23,6 +23,6 @@
     "d3-shape": "^1.3.5",
     "vega-canvas": "^1.2.1",
     "vega-loader": "^4.1.2",
-    "vega-util": "^1.11.2"
+    "vega-util": "^1.12.0"
   }
 }

--- a/packages/vega-scenegraph/src/CanvasRenderer.js
+++ b/packages/vega-scenegraph/src/CanvasRenderer.js
@@ -66,6 +66,12 @@ function clipToBounds(g, b, origin) {
   return b;
 }
 
+function viewBounds(origin, width, height) {
+  return tempBounds
+    .set(0, 0, width, height)
+    .translate(-origin[0], -origin[1]);
+}
+
 function translate(bounds, group) {
   if (group == null) return bounds;
   var b = tempBounds.clear().union(bounds);
@@ -86,9 +92,9 @@ prototype._render = function(scene) {
   g.save();
   if (this._redraw || b.empty()) {
     this._redraw = false;
-    b = null;
+    b = viewBounds(o, w, h).expand(1);
   } else {
-    b = clipToBounds(g, b, o);
+    b = clipToBounds(g, b.intersect(viewBounds(o, w, h)), o, w, h);
   }
 
   this.clear(-o[0], -o[1], w, h);

--- a/packages/vega-scenegraph/test/canvas-renderer-test.js
+++ b/packages/vega-scenegraph/test/canvas-renderer-test.js
@@ -109,7 +109,8 @@ tape('CanvasRenderer should support full redraw', function(t) {
   var mark = scene.items[0].items[0].items;
   var rect = mark[1]; rect.fill = 'red'; rect.width *= 2;
   mark.push({
-    mark:mark, x:0, y:0, width:10, height:10, fill:'purple'
+    mark: mark, x: 0, y: 0, width: 10, height: 10, fill: 'purple',
+    bounds: new Bounds().set(0, 0, 10, 10)
   });
   r.render(scene);
 


### PR DESCRIPTION
**vega-scenegraph**
- Fix canvas renderer to always bound to visible view.

Fixes #2109