### PR TITLE
Update guide configuration.

### DIFF
--- a/packages/vega-parser/src/parsers/guides/guide-util.js
+++ b/packages/vega-parser/src/parsers/guides/guide-util.js
@@ -3,7 +3,7 @@ import {value} from '../../util';
 import {stringValue} from 'vega-util';
 
 export function lookup(spec, config) {
-  const _ = name => value(spec[name], config[name]);
+  const _ = (name, dflt) => value(spec[name], value(config[name], dflt));
 
   _.isVertical = s => Vertical === value(
     spec.direction,

--- a/packages/vega-parser/src/parsers/guides/legend-symbol-groups.js
+++ b/packages/vega-parser/src/parsers/guides/legend-symbol-groups.js
@@ -44,18 +44,18 @@ export default function(spec, config, userEncode, dataRef, columns) {
     }
   };
 
+  var baseFill = null,
+      baseStroke = null;
   if (!spec.fill) {
-    addEncoders(encode, {
-      fill:   config.symbolBaseFillColor,
-      stroke: config.symbolBaseStrokeColor
-    });
+    baseFill = config.symbolBaseFillColor;
+    baseStroke = config.symbolBaseStrokeColor;
   }
 
   addEncoders(encode, {
-    fill:             _('symbolFillColor'),
+    fill:             _('symbolFillColor', baseFill),
     shape:            _('symbolType'),
     size:             _('symbolSize'),
-    stroke:           _('symbolStrokeColor'),
+    stroke:           _('symbolStrokeColor', baseStroke),
     strokeDash:       _('symbolDash'),
     strokeDashOffset: _('symbolDashOffset'),
     strokeWidth:      _('symbolStrokeWidth')

--- a/packages/vega-typings/tests/spec/valid/budget-forecasts.ts
+++ b/packages/vega-typings/tests/spec/valid/budget-forecasts.ts
@@ -134,13 +134,9 @@ export const spec: Spec = {
       "grid": true, "domain": false,
       "values": [1982, 1986, 1990, 1994, 1998, 2002, 2006, 2010, 2014, 2018],
       "tickSize": 0,
+      "gridColor": "white",
+      "gridOpacity": 0.75,
       "encode": {
-        "grid": {
-          "enter": {
-            "stroke": {"value": "white"},
-            "strokeOpacity": {"value": 0.75}
-          }
-        },
         "labels": {
           "update": {
             "x": {"scale": "x", "field": "value"}
@@ -153,13 +149,9 @@ export const spec: Spec = {
       "grid": true, "domain": false,
       "values": [0, -0.5, -1, -1.5],
       "tickSize": 0,
+      "gridColor": "white",
+      "gridOpacity": 0.75,
       "encode": {
-        "grid": {
-          "enter": {
-            "stroke": {"value": "white"},
-            "strokeOpacity": {"value": 0.75}
-          }
-        },
         "labels": {
           "enter": {
             "text": {"signal": "format(datum.value, '$.1f') + ' trillion'"}

--- a/packages/vega-typings/tests/spec/valid/jobs.ts
+++ b/packages/vega-typings/tests/spec/valid/jobs.ts
@@ -116,10 +116,8 @@ export const spec: Spec = {
     {
       "orient": "right", "scale": "y", "format": "%",
       "grid": true, "domain": false, "tickSize": 12,
-      "encode": {
-        "grid": {"enter": {"stroke": {"value": "#ccc"}}},
-        "ticks": {"enter": {"stroke": {"value": "#ccc"}}}
-      }
+      "gridColor": "#ccc",
+      "tickColor": "#ccc"
     }
   ],
 

--- a/packages/vega-typings/tests/spec/valid/weather.ts
+++ b/packages/vega-typings/tests/spec/valid/weather.ts
@@ -52,9 +52,7 @@ export const spec: Spec = {
       "grid": true,
       "domain": false,
       "zindex": 1,
-      "encode": {
-        "grid": {"enter": {"stroke": {"value": "white"}}}
-      }
+      "gridColor": "white"
     }
   ],
 

--- a/packages/vega/test/specs-valid/budget-forecasts.vg.json
+++ b/packages/vega/test/specs-valid/budget-forecasts.vg.json
@@ -132,13 +132,9 @@
       "grid": true, "domain": false,
       "values": [1982, 1986, 1990, 1994, 1998, 2002, 2006, 2010, 2014, 2018],
       "tickSize": 0,
+      "gridColor": "white",
+      "gridOpacity": 0.75,
       "encode": {
-        "grid": {
-          "enter": {
-            "stroke": {"value": "white"},
-            "strokeOpacity": {"value": 0.75}
-          }
-        },
         "labels": {
           "update": {
             "x": {"scale": "x", "field": "value"}
@@ -151,13 +147,9 @@
       "grid": true, "domain": false,
       "values": [0, -0.5, -1, -1.5],
       "tickSize": 0,
+      "gridColor": "white",
+      "gridOpacity": 0.75,
       "encode": {
-        "grid": {
-          "enter": {
-            "stroke": {"value": "white"},
-            "strokeOpacity": {"value": 0.75}
-          }
-        },
         "labels": {
           "enter": {
             "text": {"signal": "format(datum.value, '$.1f') + ' trillion'"}

--- a/packages/vega/test/specs-valid/jobs.vg.json
+++ b/packages/vega/test/specs-valid/jobs.vg.json
@@ -114,10 +114,8 @@
     {
       "orient": "right", "scale": "y", "format": "%",
       "grid": true, "domain": false, "tickSize": 12,
-      "encode": {
-        "grid": {"enter": {"stroke": {"value": "#ccc"}}},
-        "ticks": {"enter": {"stroke": {"value": "#ccc"}}}
-      }
+      "gridColor": "#ccc",
+      "tickColor": "#ccc"
     }
   ],
 

--- a/packages/vega/test/specs-valid/weather.vg.json
+++ b/packages/vega/test/specs-valid/weather.vg.json
@@ -50,9 +50,7 @@
       "grid": true,
       "domain": false,
       "zindex": 1,
-      "encode": {
-        "grid": {"enter": {"stroke": {"value": "white"}}}
-      }
+      "gridColor": "white"
     }
   ],
 


### PR DESCRIPTION
**vega**
- Update test specifications to use top-level guide configuration properties.

**vega-parser**
- Fix symbol color configuration to consider all values in parallel, not sequentially.

Closes #2101.