### PR TITLE
Add a vlMulti property when resolving multi selections.

### DIFF
--- a/packages/vega-selections/src/constants.js
+++ b/packages/vega-selections/src/constants.js
@@ -1,2 +1,5 @@
 export const Intersect = 'intersect';
 export const Union = 'union';
+export const VlMulti = 'vlMulti';
+export const Or = 'or';
+export const And = 'and';


### PR DESCRIPTION
This addresses vega/vega-lite#5143 to correctly expose entries in a multi selections. In particular, we list them under a `vlMulti` property using an `and`/`or` structure similar to the one used by Vega-Lite for composing filter/selection predicates. The effect is shown in the GIFs below:

In single views:

![Kapture 2019-08-14 at 10 14 48](https://user-images.githubusercontent.com/42262/63028245-73d3e700-be7c-11e9-8b10-4cfeadb7b455.gif)

In unioned repeated multi-views (entries just get appended to the `or` array, rather than nesting): 

![Kapture 2019-08-14 at 10 25 51](https://user-images.githubusercontent.com/42262/63029142-0a54d800-be7e-11e9-99b2-917b332a0b93.gif)

In intersected repeated multi-views (an `and` appears at the top level with nested `or` for each selected view):

![Kapture 2019-08-14 at 10 29 41](https://user-images.githubusercontent.com/42262/63029450-9535d280-be7e-11e9-9097-8b20714bb3d4.gif)