### PR TITLE
Add labels property for radio/select bindings.

### DIFF
--- a/packages/vega-schema/src/bind.js
+++ b/packages/vega-schema/src/bind.js
@@ -1,5 +1,5 @@
 import {
-  enums, not, object, oneOf, ref,
+  array, enums, not, object, oneOf, ref,
   arrayType, numberType, stringType
 } from './util';
 
@@ -22,6 +22,7 @@ const bind = oneOf(
     _input_: enums([Radio, Select]),
     element: elementRef,
     _options_: arrayType,
+    labels: array(stringType),
     debounce: numberType,
     name: stringType
   }),

--- a/packages/vega-typings/tests/spec/valid/density.ts
+++ b/packages/vega-typings/tests/spec/valid/density.ts
@@ -12,7 +12,11 @@ export const spec: Spec = {
     { "name": "steps", "value": 0,
       "bind": {"input": "range", "min": 0, "max": 500, "step": 1} },
     { "name": "method", "value": "pdf",
-      "bind": {"input": "radio", "options": ["pdf", "cdf"]} },
+      "bind": {
+        "input": "radio", "options": ["pdf", "cdf"],
+        "labels": ["Probability Density", "Cumulative Distribution"]
+      }
+    },
     { "name": "summary",
       "update": "data('summary')[0] || {mean: 0, stdev: 0}" }
   ],

--- a/packages/vega-typings/types/spec/bind.d.ts
+++ b/packages/vega-typings/types/spec/bind.d.ts
@@ -16,6 +16,7 @@ export interface BindCheckbox extends BaseBinding {
 export interface BindRadioSelect extends BaseBinding {
   input: 'radio' | 'select';
   options: any[];
+  labels?: string[];
 }
 export interface BindRange extends BaseBinding {
   input: 'range';

--- a/packages/vega-view/src/bind.js
+++ b/packages/vega-view/src/bind.js
@@ -130,12 +130,13 @@ function checkbox(bind, el, param, value) {
  * Generates a selection list input element.
  */
 function select(bind, el, param, value) {
-  var node = element('select', {name: param.signal});
+  var node = element('select', {name: param.signal}),
+      label = param.labels || [];
 
-  param.options.forEach(function(option) {
+  param.options.forEach(function(option, i) {
     var attr = {value: option};
     if (valuesEqual(option, value)) attr.selected = true;
-    node.appendChild(element('option', attr, option+''));
+    node.appendChild(element('option', attr, (label[i] || option)+''));
   });
 
   el.appendChild(node);
@@ -158,11 +159,12 @@ function select(bind, el, param, value) {
  * Generates a radio button group.
  */
 function radio(bind, el, param, value) {
-  var group = element('span', {'class': RadioClass});
+  var group = element('span', {'class': RadioClass}),
+      label = param.labels || [];
 
   el.appendChild(group);
 
-  bind.elements = param.options.map(function(option) {
+  bind.elements = param.options.map(function(option, i) {
     var id = OptionClass + param.signal + '-' + option;
 
     var attr = {
@@ -180,7 +182,7 @@ function radio(bind, el, param, value) {
     });
 
     group.appendChild(input);
-    group.appendChild(element('label', {'for': id}, option+''));
+    group.appendChild(element('label', {'for': id}, (label[i] || option)+''));
 
     return input;
   });

--- a/packages/vega/test/specs-valid/density.vg.json
+++ b/packages/vega/test/specs-valid/density.vg.json
@@ -10,7 +10,11 @@
     { "name": "steps", "value": 0,
       "bind": {"input": "range", "min": 0, "max": 500, "step": 1} },
     { "name": "method", "value": "pdf",
-      "bind": {"input": "radio", "options": ["pdf", "cdf"]} },
+      "bind": {
+        "input": "radio", "options": ["pdf", "cdf"],
+        "labels": ["Probability Density", "Cumulative Distribution"]
+      }
+    },
     { "name": "summary",
       "update": "data('summary')[0] || {mean: 0, stdev: 0}" }
   ],


### PR DESCRIPTION
**vega-schema**
- Add signal bind `labels` to schema.

**vega-typings**
- Add signal bind `labels` typings.

**vega-view**
- Add `labels` property for radio/select bindings.

Close #2152