### PR TITLE
Fix hanging extent function

### DIFF
--- a/packages/vega-util/src/extent.js
+++ b/packages/vega-util/src/extent.js
@@ -8,7 +8,7 @@ export default function(array, f) {
   if (array && (n = array.length)) {
     if (f == null) {
       // find first valid value
-      for (v = array[i]; v == null || v !== v; v = array[++i]);
+      for (v = array[i]; i < n && (v == null || v !== v); v = array[++i]);
       min = max = v;
 
       // visit all other values
@@ -22,7 +22,7 @@ export default function(array, f) {
       }
     } else {
       // find first valid value
-      for (v = f(array[i]); v == null || v !== v; v = f(array[++i]));
+      for (v = f(array[i]); i < n && (v == null || v !== v); v = f(array[++i]));
       min = max = v;
 
       // visit all other values


### PR DESCRIPTION
Hi!

This patch fixes an infinite loop in vega-util's extent function. The bug appeared with input that is all undefined.

Vega editor froze as I was playing with density transform. I had to clear local storages, cookies, etc. to get it back up and running. Somewhat inconvenient...

To reproduce the problem, just try the following spec:

```json
{
  "data": {"url": "data/cars.json"},
  "transform": [
    { "density": "Missing_Field_Causes_a_Hang" }
  ],
  "mark": "area",
  "encoding": {
    "x": {"field": "value", "type": "quantitative"},
    "y": {"field": "density", "type": "quantitative"}
  }
}
```