### PR TITLE
Update group mark stroke offset.

### DIFF
--- a/packages/vega-scenegraph/schema.js
+++ b/packages/vega-scenegraph/schema.js
@@ -240,7 +240,8 @@ var MARKS = {
       "cornerRadiusTopRight": { "type": "number" },
       "cornerRadiusBottomRight": { "type": "number" },
       "cornerRadiusBottomLeft": { "type": "number" },
-      "items": { "type": "array", "items": { "$ref": "#/refs/mark" } }
+      "items": { "type": "array", "items": { "$ref": "#/refs/mark" } },
+      "strokeOffset": { "type": "number" }
     }
   },
   "arc": {

--- a/packages/vega-scenegraph/src/marks/group.js
+++ b/packages/vega-scenegraph/src/marks/group.js
@@ -9,16 +9,21 @@ import {hitPath} from '../util/canvas/pick';
 import clip from '../util/svg/clip';
 import {translateItem} from '../util/svg/transform';
 
-var StrokeOffset = 0.5;
+function offset(item) {
+  var sw = (sw = item.strokeWidth) != null ? sw : 1;
+  return item.strokeOffset != null ? item.strokeOffset
+    : item.stroke && sw > 0.5 && sw < 1.5 ? 0.5 - Math.abs(sw - 1)
+    : 0;
+}
 
 function attr(emit, item) {
   emit('transform', translateItem(item));
 }
 
 function background(emit, item) {
-  var offset = item.stroke ? StrokeOffset : 0;
+  var off = offset(item);
   emit('class', 'background');
-  emit('d', rectangle(null, item, offset, offset));
+  emit('d', rectangle(null, item, off, off));
 }
 
 function foreground(emit, item, renderer) {
@@ -44,9 +49,9 @@ function bound(bounds, group) {
 }
 
 function backgroundPath(context, group) {
-  var offset = group.stroke ? StrokeOffset : 0;
+  var off = offset(group);
   context.beginPath();
-  rectangle(context, group, offset, offset);
+  rectangle(context, group, off, off);
 }
 
 var hitBackground = hitPath(backgroundPath);

--- a/packages/vega-scenegraph/src/util/serialize.js
+++ b/packages/vega-scenegraph/src/util/serialize.js
@@ -6,6 +6,7 @@ var keys = [
   'fill', 'fillOpacity', 'opacity',                             // fill
   'stroke', 'strokeOpacity', 'strokeWidth', 'strokeCap',        // stroke
   'strokeDash', 'strokeDashOffset',                             // stroke dash
+  'strokeOffset',                                               // group
   'startAngle', 'endAngle', 'innerRadius', 'outerRadius',       // arc
   'cornerRadius', 'padAngle',                                   // arc, rect
   'cornerRadiusTopLeft', 'cornerRadiusTopRight',                // rect, group

--- a/packages/vega-schema/src/encode.js
+++ b/packages/vega-schema/src/encode.js
@@ -198,6 +198,7 @@ const encodeEntry = object({
 
   // Group-mark properties
   clip: booleanValueRef,
+  strokeOffset: numberValueRef,
 
   // Rect-mark properties
   cornerRadius: numberValueRef,

--- a/packages/vega-typings/types/spec/config.d.ts
+++ b/packages/vega-typings/types/spec/config.d.ts
@@ -131,7 +131,7 @@ export interface MarkConfig {
   strokeDashOffset?: number;
 
   /**
-   * The distance between the stroke and the mark boundary.
+   * The amount to offset background rendering for stroked group marks.
    */
   strokeOffset?: number;
 

--- a/packages/vega-typings/types/spec/config.d.ts
+++ b/packages/vega-typings/types/spec/config.d.ts
@@ -131,6 +131,11 @@ export interface MarkConfig {
   strokeDashOffset?: number;
 
   /**
+   * The distance between the stroke and the mark boundary.
+   */
+  strokeOffset?: number;
+
+  /**
    * The stroke cap for line ending style.
    *
    * __Default value:__ `butt`

--- a/packages/vega-typings/types/spec/encode.d.ts
+++ b/packages/vega-typings/types/spec/encode.d.ts
@@ -245,6 +245,7 @@ export interface AreaEncodeEntry extends LineEncodeEntry {
 }
 export interface GroupEncodeEntry extends RectEncodeEntry {
   clip?: ProductionRule<BooleanValueRef>;
+  strokeOffset?: ProductionRule<NumericValueRef>;
 }
 export type Baseline = 'top' | 'middle' | 'bottom';
 export interface ImageEncodeEntry extends EncodeEntry, AlignProperty {


### PR DESCRIPTION
**vega-scenegraph**
- Add group mark `strokeOffset` property.
- Fix group offset adjustment to interpolate smoothly.

**vega-schema**
- Add group mark `strokeOffset` to schema.

**vega-typings**
- Add group mark `strokeOffset` typings.

Close #2186.