### PR TITLE
Adjust clipping region for stroked group elements

### DIFF
--- a/packages/vega-scenegraph/src/SVGRenderer.js
+++ b/packages/vega-scenegraph/src/SVGRenderer.js
@@ -201,10 +201,14 @@ function updateClipping(el, clip, index) {
     mask.setAttribute('d', clip.path);
   } else {
     mask = domChild(el, 0, 'rect', ns);
-    mask.setAttribute('x', 0);
-    mask.setAttribute('y', 0);
+    mask.setAttribute('x', clip.x || 0);
+    mask.setAttribute('y', clip.y || 0);
     mask.setAttribute('width', clip.width);
     mask.setAttribute('height', clip.height);
+  }
+
+  if(el.childNodes.length > 1) {
+    el.removeChild(el.childNodes[1]);
   }
 
   return index + 1;

--- a/packages/vega-scenegraph/src/marks/group.js
+++ b/packages/vega-scenegraph/src/marks/group.js
@@ -22,7 +22,8 @@ function background(emit, item) {
 }
 
 function foreground(emit, item, renderer) {
-  var url = item.clip ? clip(renderer, item, item) : null;
+  var offset = item.stroke ? StrokeOffset : 0;
+  var url = item.clip ? clip(renderer, item, item, offset) : null;
   emit('clip-path', url);
 }
 
@@ -78,7 +79,10 @@ function draw(context, scene, bounds) {
     }
 
     // set clip and bounds
-    if (group.clip) clipGroup(context, group);
+    if (group.clip) {
+      var offset = group.stroke ? StrokeOffset : 0;
+      clipGroup(context, group, offset);
+    }
     if (bounds) bounds.translate(-gx, -gy);
 
     // draw group contents

--- a/packages/vega-scenegraph/src/path/shapes.js
+++ b/packages/vega-scenegraph/src/path/shapes.js
@@ -77,6 +77,24 @@ export function rectangle(context, item, x, y) {
   return rectShape.context(context)(item, x, y);
 }
 
+export function rectangleWithContract(context, item, x, y, contract) {
+  if(contract) {
+    let rs = {
+      width: Math.max(0, item.width - contract),
+      height: Math.max(0, item.height - contract)
+    };
+    // Modify cornerRadius properties appropriately
+    if(item.cornerRadius) rs.cornerRadius = Math.max(0, item.cornerRadius - contract / 2);
+    if(item.cornerRadiusTopLeft) rs.cornerRadiusTopLeft = Math.max(0, item.cornerRadiusTopLeft - contract / 2);
+    if(item.cornerRadiusTopRight) rs.cornerRadiusTopRight = Math.max(0, item.cornerRadiusTopRight - contract / 2);
+    if(item.cornerRadiusBottomLeft) rs.cornerRadiusBottomLeft = Math.max(0, item.cornerRadiusBottomLeft - contract / 2);
+    if(item.cornerRadiusBottomRight) rs.cornerRadiusBottomRight = Math.max(0, item.cornerRadiusBottomRight - contract / 2);
+    return rectangle(context, rs, x + contract / 2 , y + contract / 2);
+  } else {
+    return rectangle(context, item, x, y);
+  }
+}
+
 export function shape(context, item) {
   return (item.mark.shape || item.shape)
     .context(context)(item);

--- a/packages/vega-scenegraph/src/util/canvas/clip.js
+++ b/packages/vega-scenegraph/src/util/canvas/clip.js
@@ -1,4 +1,4 @@
-import {hasCornerRadius, rectangle} from '../../path/shapes';
+import {hasCornerRadius, rectangleWithContract} from '../../path/shapes';
 import {isFunction} from 'vega-util';
 
 export default function(context, scene) {
@@ -15,10 +15,14 @@ export default function(context, scene) {
   }
 }
 
-export function clipGroup(context, group) {
+export function clipGroup(context, group, offset) {
+  var sw = group.stroke ? (group.strokeWidth || 1) : 0;
   context.beginPath();
   hasCornerRadius(group)
-    ? rectangle(context, group, 0, 0)
-    : context.rect(0, 0, group.width || 0, group.height || 0);
+    ? rectangleWithContract(context, group, offset, offset, sw)
+    : context.rect(
+        sw / 2 + offset, sw / 2 + offset,
+        Math.max(0, (group.width || 0) - sw), Math.max(0, (group.height || 0) - sw)
+      );
   context.clip();
 }

--- a/packages/vega-scenegraph/src/util/svg/clip.js
+++ b/packages/vega-scenegraph/src/util/svg/clip.js
@@ -1,4 +1,4 @@
-import {hasCornerRadius, rectangle} from '../../path/shapes';
+import {hasCornerRadius, rectangleWithContract} from '../../path/shapes';
 import {isFunction} from 'vega-util';
 
 var clip_id = 1;
@@ -7,8 +7,9 @@ export function resetSVGClipId() {
   clip_id = 1;
 }
 
-export default function(renderer, item, size) {
+export default function(renderer, item, size, offset) {
   var clip = item.clip,
+      sw = item.stroke ? (item.strokeWidth || 1) : 0,
       defs = renderer._defs,
       id = item.clip_id || (item.clip_id = 'clip' + clip_id++),
       c = defs.clipping[id] || (defs.clipping[id] = {id: id});
@@ -16,10 +17,13 @@ export default function(renderer, item, size) {
   if (isFunction(clip)) {
     c.path = clip(null);
   } else if (hasCornerRadius(size)) {
-    c.path = rectangle(null, size, 0, 0);
+    c.path = rectangleWithContract(null, size, 0, 0, sw);
   } else {
-    c.width = size.width || 0;
-    c.height = size.height || 0;
+    c.x = sw / 2 + offset;
+    c.y = sw / 2 + offset;
+    c.width = Math.max(0, (size.width || 0) - sw);
+    c.height = Math.max(0, (size.height || 0) - sw);
+    delete c.path;
   }
 
   return 'url(#' + id + ')';


### PR DESCRIPTION
* Adjust the clipping region for group elements when a stroke is used.
* Fixes an SVG renderer issue that the clip region doesn't update when `cornerRadius` is changed from zero to non-zero and vice-versa.

Fixes #2197