### PR TITLE
Fix black group when strokeForeground is applied

### DIFF
--- a/packages/vega-scenegraph/src/SVGRenderer.js
+++ b/packages/vega-scenegraph/src/SVGRenderer.js
@@ -446,7 +446,7 @@ var mark_extras = {
       bg.style.removeProperty('stroke');
 
       // set style of foreground
-      if (fill) item.fill = null;
+      item.fill = null;
       values = fg.__values__;
       this.style(fg, item);
       if (fill) item.fill = fill;


### PR DESCRIPTION
**vega-scenegraph**
- Fix black group when strokeForeground is applied.

This is because the fill style is only set to null when the fill encoding is supplied, but we always need to set to null.