### PR TITLE
Add partial typings for event selector, expression, and scale

### DIFF
--- a/packages/vega-event-selector/index.d.ts
+++ b/packages/vega-event-selector/index.d.ts
@@ -1,0 +1,1 @@
+export function selector(selectorName: string, source: string): any[];

--- a/packages/vega-event-selector/package.json
+++ b/packages/vega-event-selector/package.json
@@ -11,6 +11,7 @@
   "author": "Arvind Satyanarayan (http://arvindsatya.com)",
   "main": "build/vega-event-selector.js",
   "module": "index",
+  "types": "index.d.ts",
   "repository": "vega/vega",
   "scripts": {
     "rollup": "rollup -f umd -n vega -o build/vega-event-selector.js -- index.js",

--- a/packages/vega-expression/index.d.ts
+++ b/packages/vega-expression/index.d.ts
@@ -1,0 +1,21 @@
+// TODO: add missing types
+
+export function parse(expression: string): any;
+
+export function codegen(params: {
+  constants?: object;
+  functions?: { [fn: string]: Function };
+  blacklist?: string[];
+  whitelist?: string[];
+  fieldvar?: string;
+  globalvar: string;
+}): (
+  ast: any
+) => {
+  /** The generated code as a string. */
+  code: string;
+  /** A hash of all properties referenced within the fieldvar scope. */
+  fields: string[];
+  /** A hash of all properties referenced outside a provided whitelist */
+  globals: string[];
+};

--- a/packages/vega-expression/package.json
+++ b/packages/vega-expression/package.json
@@ -12,6 +12,7 @@
   "license": "BSD-3-Clause",
   "main": "build/vega-expression.js",
   "module": "index",
+  "types": "index.d.ts",
   "repository": "vega/vega",
   "scripts": {
     "rollup": "rollup -f umd -g vega-util:vega -n vega -o build/vega-expression.js -- index.js",

--- a/packages/vega-scale/index.d.ts
+++ b/packages/vega-scale/index.d.ts
@@ -1,0 +1,3 @@
+// TODO: add missing types
+
+export function scheme(name: string, scheme?: any): any;

--- a/packages/vega-scale/package.json
+++ b/packages/vega-scale/package.json
@@ -12,6 +12,7 @@
   "author": "Jeffrey Heer (http://idl.cs.washington.edu)",
   "main": "build/vega-scale.js",
   "module": "index",
+  "types": "index.d.ts",
   "repository": "vega/vega",
   "scripts": {
     "rollup": "rollup -g d3-array:d3,d3-interpolate:d3,d3-scale:d3:d3,d3-time:d3,vega-util:vega -f umd -n vega -o build/vega-scale.js -- index.js",


### PR DESCRIPTION
With these, we can get rid of the typings in Vega-Lite and simplify the build process for users of Vega-Lite. 