### PR TITLE
Use infinite bin values outside extent bounds.

### DIFF
--- a/packages/vega-transforms/src/Bin.js
+++ b/packages/vega-transforms/src/Bin.js
@@ -64,6 +64,7 @@ prototype.transform = function(_, pulse) {
         // maximum bin value (exclusive)
         // use convoluted math for better floating point agreement
         // see https://github.com/vega/vega/issues/830
+        // infinite values propagate through this formula! #2227
         t[b1] = v == null ? null : start + step * (1 + (v - start) / step);
       }
     : function(t) { t[b0] = bins(t); }
@@ -92,12 +93,13 @@ prototype._bins = function(_) {
 
   var f = function(t) {
     var v = field(t);
-    if (v == null) {
-      return null;
-    } else {
-      v = Math.max(start, Math.min(+v, stop - step));
-      return start + step * Math.floor(EPSILON + (v - start) / step);
-    }
+    return v == null ? null
+      : v < start ? -Infinity
+      : v > stop ? +Infinity
+      : (
+          v = Math.max(start, Math.min(+v, stop - step)),
+          start + step * Math.floor(EPSILON + (v - start) / step)
+        );
   };
 
   f.start = start;

--- a/packages/vega-transforms/test/bin-test.js
+++ b/packages/vega-transforms/test/bin-test.js
@@ -65,10 +65,13 @@ function testBin(t, b, extent, step) {
   }
 
   // test bins that precede extent
-  t.equal(b({v: f(-1)}), f(0));
+  t.equal(b({v: f(-1)}), -Infinity);
 
   // test very last, inclusive bin
   t.equal(b({v: f(steps)}), f(steps - 1));
+
+  // test bins that exceed extent
+  t.equal(b({v: f(steps+1)}), Infinity);
 }
 
 tape('Bin handles tail aggregation for last bin', function(t) {
@@ -87,7 +90,7 @@ tape('Bin handles tail aggregation for last bin', function(t) {
   t.equal(bin.value({v:28}), 25);
   t.equal(bin.value({v:29}), 25);
   t.equal(bin.value({v:30}), 25);
-  t.equal(bin.value({v:35}), 25);
+  t.equal(bin.value({v:31}), Infinity);
 
   t.end();
 });


### PR DESCRIPTION
**vega-transforms**
- Use infinite bin values outside extent bounds.

This PR changes the `bin` transform output such that values outside the bin `extent` (modulo the step size) are given infinite bin values. If the value is less than the lower extent, the bin boundaries are given as `[-Infinity, -Infinity]`; if greater than the upper extent, `[+Infinity, +Infinity]` is returned.

An alternative scheme would be to return `[-Infinity, start]` and `[stop, +Infinity]`, which is a more mathematically accurate representation. However, the scheme above has several advantages: it allows quick testing of out-of-range bins (check one value, not two), it still results in infinite values when requesting bin point values (`interval: false`), and involves significantly simpler code paths. Moreover, one can easily recover "true" ranges by checking the sign of the Infinity and consulting the computed `bin.start` and `bin.stop` values.

Fixes #2227.