### PR TITLE
Fix splitAccessPath escape handling.

### DIFF
--- a/packages/vega-util/src/splitAccessPath.js
+++ b/packages/vega-util/src/splitAccessPath.js
@@ -20,7 +20,8 @@ export default function(p) {
     c = p[j];
     if (c === '\\') {
       s += p.substring(i, j);
-      i = ++j;
+      s += p.substring(++j, ++j);
+      i = j;
     } else if (c === q) {
       push();
       q = null;

--- a/packages/vega-util/test/splitAccessPath-test.js
+++ b/packages/vega-util/test/splitAccessPath-test.js
@@ -1,0 +1,23 @@
+var tape = require('tape'),
+    vega = require('../');
+
+tape('splitAccessPath parses field accessor paths', function(t) {
+  t.deepEqual(vega.splitAccessPath('x'), ['x']);
+  t.deepEqual(vega.splitAccessPath('x\\'), ['x']);
+  t.deepEqual(vega.splitAccessPath('\\x'), ['x']);
+  t.deepEqual(vega.splitAccessPath('x\\.y'), ['x.y']);
+  t.deepEqual(vega.splitAccessPath('[x.y]'), ['x.y']);
+  t.deepEqual(vega.splitAccessPath("['x.y']"), ['x.y']);
+  t.deepEqual(vega.splitAccessPath('[1].x'), ['1', 'x']);
+  t.deepEqual(vega.splitAccessPath('x["y"].z'), ['x', 'y', 'z']);
+  t.deepEqual(vega.splitAccessPath('x[y].z'), ['x', 'y', 'z']);
+  t.deepEqual(vega.splitAccessPath('x["a.b"].z'), ['x', 'a.b', 'z']);
+  t.deepEqual(vega.splitAccessPath('x[a.b].z'), ['x', 'a.b', 'z']);
+  t.deepEqual(vega.splitAccessPath('x[a b].z'), ['x', 'a b', 'z']);
+  t.deepEqual(vega.splitAccessPath('x.a b.z'), ['x', 'a b', 'z']);
+  t.deepEqual(vega.splitAccessPath('y\\[foo\\]'), ['y[foo]']);
+  t.deepEqual(vega.splitAccessPath('y\\[foo'), ['y[foo']);
+  t.deepEqual(vega.splitAccessPath('yfoo\\]'), ['yfoo]']);
+  t.end();
+});
+


### PR DESCRIPTION
**vega-util**

- Fix `splitAccessPath` escape handling, add tests.

Fix #2287.