### PR TITLE
BUG: fix r-squared computation for poly and quad regression

### DIFF
--- a/packages/vega-statistics/src/regression/poly.js
+++ b/packages/vega-statistics/src/regression/poly.js
@@ -49,7 +49,7 @@ export default function(data, x, y, order) {
   return {
     coef: uncenter(k, coef, -ux, uy),
     predict: predict,
-    rSquared: rSquared(data, x, y, 0, predict)
+    rSquared: rSquared(data, x, y, uy, predict)
   };
 }
 

--- a/packages/vega-statistics/src/regression/quad.js
+++ b/packages/vega-statistics/src/regression/quad.js
@@ -38,6 +38,6 @@ export default function(data, x, y) {
       a
     ],
     predict: predict,
-    rSquared: rSquared(data, x, y, 0, predict)
+    rSquared: rSquared(data, x, y, uy, predict)
   };
 }


### PR DESCRIPTION
I discovered in the course of implementing regression transforms in [altair-transform](https://github.com/altair-viz/altair-transform) that in vega's ``poly`` and ``quad`` regression, the r-squared values are being computed with respect to zero, rather than with respect to the mean.

This fixes the issue in the source files... I suspect there's some sort of build step I need to complete this pull request, but I don't have my local dev environment set up for building vega.