### PR TITLE
fix: Vega shouldn't fix Vega typings version

### DIFF
--- a/packages/vega/package.json
+++ b/packages/vega/package.json
@@ -49,7 +49,7 @@
     "vega-statistics": "1.7.2",
     "vega-time": "1.0.0",
     "vega-transforms": "4.6.0",
-    "vega-typings": "0.12.0",
+    "vega-typings": "~0.12.1",
     "vega-util": "1.12.2",
     "vega-view": "5.4.0",
     "vega-view-transforms": "4.5.0",


### PR DESCRIPTION
Since there might be error in the typings, we should allow the patch version to change.

The current "fixed" version means that Vega-Lite can't use a patch update in Vega-typings without a Vega release. 