### PR TITLE
Fix legend columns handling.

### DIFF
--- a/packages/vega-parser/src/parsers/guides/legend-symbol-groups.js
+++ b/packages/vega-parser/src/parsers/guides/legend-symbol-groups.js
@@ -19,7 +19,7 @@ export default function(spec, config, userEncode, dataRef, columns) {
       symbolOffset = _('symbolOffset'),
       valueRef = {data: 'value'},
       encode = {},
-      xSignal = `${columns} ? datum.${Offset} : datum.${Size}`,
+      xSignal = `(${columns}) ? datum.${Offset} : datum.${Size}`,
       yEncode = height ? encoder(height) : {field: Size},
       index = `datum.${Index}`,
       ncols = `max(1, ${columns})`,
@@ -141,7 +141,7 @@ export default function(spec, config, userEncode, dataRef, columns) {
     sort = {field: index};
   }
   // handle zero column case (implies infinite columns)
-  update.column.signal = `${columns}?${update.column.signal}:${index}`;
+  update.column.signal = `(${columns})?${update.column.signal}:${index}`;
 
   // facet legend entries into sub-groups
   dataRef = {facet: {data: dataRef, name: 'value', groupby: Index}};


### PR DESCRIPTION
**vega-parser**
- Fix legend `columns` value handling.

Fixes #2268.