### PR TITLE
Add zindex encoding to typings.

### DIFF
--- a/packages/vega-typings/types/spec/encode.d.ts
+++ b/packages/vega-typings/types/spec/encode.d.ts
@@ -220,6 +220,7 @@ export interface EncodeEntry {
   strokeMiterLimit?: ProductionRule<NumericValueRef>;
   cursor?: ProductionRule<StringValueRef>;
   tooltip?: ProductionRule<StringValueRef>;
+  zindex?: ProductionRule<NumericValueRef>;
   [k: string]: ProductionRule<ArbitraryValueRef> | undefined;
 }
 export type Align = 'left' | 'center' | 'right';


### PR DESCRIPTION
**vega-typings**

- Add `zindex` mark encoding typing.

Fixes #2341.