### PR TITLE
feat: allow text `baseline` to account for line-height with "line-top" and "line-bottom"

### DIFF
--- a/packages/vega-scenegraph/src/util/text.js
+++ b/packages/vega-scenegraph/src/util/text.js
@@ -129,14 +129,13 @@ export function offset(item) {
   // perform our own font baseline calculation
   // why? not all browsers support SVG 1.1 'alignment-baseline' :(
   var baseline = item.baseline,
-      h = fontSize(item),
-      lh = lineHeight(item);
+      h = fontSize(item);
 
   return Math.round(
-    baseline === 'line-top' ? 0.79.h + (lh-h) / 2.0 :
+    baseline === 'line-top' ? 0.79.h + (lineHeight(item)-h) / 2.0 :
     baseline === 'top'    ?  0.79*h :
     baseline === 'middle' ?  0.30*h :
     baseline === 'bottom' ? -0.21*h :
-    baseline === 'line-bottom' ? -0.21*h - (lh-h) / 2.0 : 0
+    baseline === 'line-bottom' ? -0.21*h - (lineHeight(item)-h) / 2.0 : 0
   );
 }

--- a/packages/vega-scenegraph/src/util/text.js
+++ b/packages/vega-scenegraph/src/util/text.js
@@ -129,10 +129,14 @@ export function offset(item) {
   // perform our own font baseline calculation
   // why? not all browsers support SVG 1.1 'alignment-baseline' :(
   var baseline = item.baseline,
-      h = fontSize(item);
+      h = fontSize(item),
+      lh = lineHeight(item);
+
   return Math.round(
+    baseline === 'line-top' ? 0.79.h + (lh-h) / 2.0 :
     baseline === 'top'    ?  0.79*h :
     baseline === 'middle' ?  0.30*h :
-    baseline === 'bottom' ? -0.21*h : 0
+    baseline === 'bottom' ? -0.21*h :
+    baseline === 'line-bottom' ? -0.21*h - (lh-h) / 2.0 : 0
   );
 }

--- a/packages/vega-schema/src/util.js
+++ b/packages/vega-schema/src/util.js
@@ -6,7 +6,7 @@ const fontWeightEnum = [
 
 const alignEnum = ['left', 'right', 'center'];
 
-const baselineEnum = ['top', 'middle', 'bottom', 'alphabetic'];
+const baselineEnum = ['top', 'middle', 'bottom', 'alphabetic', 'line-top', 'line-bottom'];
 
 const anchorEnum = [null, 'start', 'middle', 'end'];
 

--- a/packages/vega-typings/types/spec/encode.d.ts
+++ b/packages/vega-typings/types/spec/encode.d.ts
@@ -322,7 +322,7 @@ export interface SymbolEncodeEntry extends EncodeEntry {
   angle?: ProductionRule<NumericValueRef>;
 }
 export type Text = string | string[];
-export type TextBaseline = 'alphabetic' | Baseline;
+export type TextBaseline = 'alphabetic' | Baseline | 'line-top' | 'line-bottom';
 export type TextDirection = 'ltr' | 'rtl';
 export type FontWeight =
   | 'normal'


### PR DESCRIPTION
Fix https://github.com/vega/vega/issues/2395

From a quick skim, I'm not sure how you're testing for this part of code yet. 