### PR TITLE
Fix URI sanitization to accept "data:" prefix URIs

### DIFF
--- a/packages/vega-loader/src/loader.js
+++ b/packages/vega-loader/src/loader.js
@@ -5,7 +5,7 @@ import {extend, error, isFunction, stringValue} from 'vega-util';
 const protocol_re = /^([A-Za-z]+:)?\/\//;
 
 // Matches allowed URIs. From https://github.com/cure53/DOMPurify/blob/master/src/regexp.js with added file://
-const allowed_re = /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|cid|xmpp|file):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i; // eslint-disable-line no-useless-escape
+const allowed_re = /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|cid|xmpp|file|data):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i; // eslint-disable-line no-useless-escape
 const whitespace_re = /[\u0000-\u0020\u00A0\u1680\u180E\u2000-\u2029\u205f\u3000]/g; // eslint-disable-line no-control-regex
 
 

--- a/packages/vega-typings/tests/spec/valid/images-inline.ts
+++ b/packages/vega-typings/tests/spec/valid/images-inline.ts
@@ -1,0 +1,26 @@
+import { Spec } from 'vega';
+
+export const spec: Spec = {
+  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "description": "Test using inline base64-encoded image data.",
+  "background": "white",
+  "padding": 5,
+  "width": 100,
+  "height": 100,
+  "marks": [
+    {
+      "type": "image",
+      "encode": {
+        "update": {
+          "x": {"value": 0},
+          "width": {"signal": "width"},
+          "y": {"value": 0},
+          "height": {"signal": "height"},
+          "url": {
+            "value": "data:image/png;base64,iVBORw0KGgoAAA%20ANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4%20//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU%205ErkJggg=="
+          }
+        }
+      }
+    }
+  ]
+};

--- a/packages/vega/test/scenegraphs/images-inline.json
+++ b/packages/vega/test/scenegraphs/images-inline.json
@@ -1,0 +1,34 @@
+{
+  "marktype": "group",
+  "name": "root",
+  "role": "frame",
+  "interactive": true,
+  "clip": false,
+  "items": [
+    {
+      "items": [
+        {
+          "marktype": "image",
+          "role": "mark",
+          "interactive": true,
+          "clip": false,
+          "items": [
+            {
+              "x": 0,
+              "y": 0,
+              "width": 100,
+              "height": 100,
+              "url": "data:image/png;base64,iVBORw0KGgoAAA%20ANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4%20//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU%205ErkJggg=="
+            }
+          ],
+          "zindex": 0
+        }
+      ],
+      "x": 0,
+      "y": 0,
+      "width": 100,
+      "height": 100
+    }
+  ],
+  "zindex": 0
+}

--- a/packages/vega/test/specs-valid.json
+++ b/packages/vega/test/specs-valid.json
@@ -43,6 +43,7 @@
   "hops",
   "horizon",
   "images",
+  "images-inline",
   "isocontour-airports",
   "isocontour-precipitation",
   "isocontour-volcano",

--- a/packages/vega/test/specs-valid/images-inline.vg.json
+++ b/packages/vega/test/specs-valid/images-inline.vg.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "description": "Test using inline base64-encoded image data.",
+  "background": "white",
+  "padding": 5,
+  "width": 100,
+  "height": 100,
+  "marks": [
+    {
+      "type": "image",
+      "encode": {
+        "update": {
+          "x": {"value": 0},
+          "width": {"signal": "width"},
+          "y": {"value": 0},
+          "height": {"signal": "height"},
+          "url": {
+            "value": "data:image/png;base64,iVBORw0KGgoAAA%20ANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4%20//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU%205ErkJggg=="
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
**vega**
- Add `images-inline` test specification.

**vega-loader**
- Fix URI sanitization to accept `data:` prefix URIs.

Fixes #2407