### PR TITLE
Add cross-origin image handling support.

### DIFF
--- a/packages/vega-loader/src/loader.js
+++ b/packages/vega-loader/src/loader.js
@@ -125,6 +125,12 @@ async function sanitize(uri, options) {
     result.rel = options.rel + '';
   }
 
+  // provide control over cross-origin image handling (#2238)
+  // https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image
+  if (options.context === 'image' && options.crossOrigin) {
+    result.crossOrigin = options.crossOrigin + '';
+  }
+
   // return
   return result;
 }


### PR DESCRIPTION
This PR adds support for configuration of [cross-origin image handling](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image). Vega will now use `crossOrigin="anonymous"` by default for loaded images, which allows images loaded from a different host to be included in exported visualization images (and thereby avoid "tainted canvas errors"), so long as the server provides permission via proper CORS headers. This default can be overridden by providing loader options to the Vega view that include a `crossOrigin` property. If this property is defined and maps to a value of `null` or `undefined`, then a `no-cors` fetch will be performed instead.

**vega-loader**

- Add `crossOrigin` URI sanitization configuration for images.

**vega-scenegraph**

- Add `crossOrigin` image handling support.

Close #2238.