### PR TITLE
Add signal support for top-level spec properties.

### DIFF
--- a/packages/vega-parser/src/Scope.js
+++ b/packages/vega-parser/src/Scope.js
@@ -26,7 +26,6 @@ export default function Scope(config) {
   this.streams = [];
   this.updates = [];
   this.operators = [];
-  this.background = null;
   this.eventConfig = null;
 
   this._id = 0;
@@ -79,7 +78,6 @@ prototype.isSubscope = function() {
 prototype.toRuntime = function() {
   this.finish();
   return {
-    background:  this.background,
     operators:   this.operators,
     streams:     this.streams,
     updates:     this.updates,

--- a/packages/vega-parser/src/parsers/autosize.js
+++ b/packages/vega-parser/src/parsers/autosize.js
@@ -1,8 +1,5 @@
 import {isObject} from 'vega-util';
 
-export default function(spec, config) {
-  spec = spec || config.autosize;
-  return isObject(spec)
-    ? spec
-    : {type: spec || 'pad'};
+export default function(spec) {
+  return isObject(spec) ? spec : {type: spec || 'pad'};
 }

--- a/packages/vega-parser/src/parsers/padding.js
+++ b/packages/vega-parser/src/parsers/padding.js
@@ -1,21 +1,16 @@
 import {isObject} from 'vega-util';
 
-export default function(spec, config) {
-  spec = spec || config.padding;
-  return isObject(spec)
-    ? {
+const number = _ => +_ || 0;
+
+const paddingObject = _ => ({top: _, bottom: _, left: _, right: _});
+
+export default function(spec) {
+  return !isObject(spec) ? paddingObject(number(spec))
+    : spec.signal ? spec
+    : {
         top:    number(spec.top),
         bottom: number(spec.bottom),
         left:   number(spec.left),
         right:  number(spec.right)
-      }
-    : paddingObject(number(spec));
-}
-
-function number(_) {
-  return +_ || 0;
-}
-
-function paddingObject(_) {
-  return {top: _, bottom: _, left: _, right: _};
+      };
 }

--- a/packages/vega-parser/test/axis-test.js
+++ b/packages/vega-parser/test/axis-test.js
@@ -20,7 +20,7 @@ tape('Parser parses Vega specs with axes', function(t) {
 
   var dfs = parse(spec);
 
-  t.equal(dfs.operators.length, 46);
+  t.equal(dfs.operators.length, 47);
 
   t.end();
 });

--- a/packages/vega-parser/test/mark-test.js
+++ b/packages/vega-parser/test/mark-test.js
@@ -42,7 +42,7 @@ tape('Parser parses Vega specs with marks', function(t) {
 
   var dfs = parse(spec);
 
-  t.equal(dfs.operators.length, 25);
+  t.equal(dfs.operators.length, 26);
 
   t.end();
 });

--- a/packages/vega-parser/test/projection-test.js
+++ b/packages/vega-parser/test/projection-test.js
@@ -32,9 +32,9 @@ tape('Parser parses Vega specs with projection', function(t) {
 
   var dfs = parse(spec);
 
-  t.equal(dfs.operators.length, 14);
-  t.equal(dfs.operators[9].type, 'projection');
-  t.equal(dfs.operators[9].params.fit, geojson);
+  t.equal(dfs.operators.length, 15);
+  t.equal(dfs.operators[10].type, 'projection');
+  t.equal(dfs.operators[10].params.fit, geojson);
 
   t.end();
 });

--- a/packages/vega-parser/test/scale-test.js
+++ b/packages/vega-parser/test/scale-test.js
@@ -54,10 +54,10 @@ tape('Parser parses Vega specs with scales', function(t) {
 
   var dfs = parse(spec);
 
-  t.equal(dfs.operators.length, 27);
+  t.equal(dfs.operators.length, 28);
   t.deepEqual(dfs.operators.map(function(o) { return o.type; }),
     ['operator', 'operator', 'operator', 'operator', 'operator',
-     'operator', 'operator', 'operator', 'operator',
+     'operator', 'operator', 'operator', 'operator', 'operator',
      'collect', 'encode', 'sieve',
      'scale', 'scale', 'scale',
      'collect', 'sieve',
@@ -128,9 +128,10 @@ tape('Parser parses Vega specs with multi-domain scales', function(t) {
 
   var dfs = parse(spec);
 
-  t.equal(dfs.operators.length, 33);
+  t.equal(dfs.operators.length, 34);
   t.deepEqual(dfs.operators.map(function(o) { return o.type; }),
-    ['operator', 'operator', 'operator', 'operator', 'operator', 'operator',
+    ['operator', 'operator', 'operator', 'operator',
+     'operator', 'operator', 'operator',
      'collect', 'encode', 'sieve',
      'scale', 'scale', 'scale', 'scale',
      'collect', 'sieve', 'aggregate', 'collect', 'aggregate', 'collect',

--- a/packages/vega-parser/test/signal-test.js
+++ b/packages/vega-parser/test/signal-test.js
@@ -26,7 +26,20 @@ tape('Parser parses static signals', function(t) {
 });
 
 tape('Parser parses updating signals', function(t) {
-  // update: {expr: 'expr'} | {value: null} | {signal: 'name'},
+  var scope = new vega.Scope();
+
+  parseSignal({name: 'a', update: '5 * 2'}, scope);
+  parseSignal({name: 'b', update: 'a + 3'}, scope);
+
+  t.equal(Object.keys(scope.signals).length, 2);
+  t.equal(scope.signals.a.id, 0);
+  t.equal(scope.signals.a.value, undefined);
+  t.equal(scope.signals.a.update, '(5*2)');
+  t.deepEqual(scope.signals.a.params, {});
+  t.equal(scope.signals.b.id, 1);
+  t.equal(scope.signals.b.value, undefined);
+  t.equal(scope.signals.b.update, '(_["$a"]+3)');
+  t.deepEqual(scope.signals.b.params, {$a: {$ref: 0}});
   t.end();
 });
 
@@ -114,6 +127,197 @@ tape('Parser parses signals with event-driven updates', function(t) {
   t.equal(update.update.$expr, '_.value');
   t.equal(update.update.$params.value.$ref, c);
   t.equal(update.options, undefined);
+
+  t.end();
+});
+
+function testSignals(t, df, signals) {
+  df.operators.forEach(o => {
+    var s = signals[o.signal], key;
+    if (!s) return;
+    for (key in s) {
+      t.deepEqual(o[key], s[key]);
+    }
+  });
+}
+
+tape('Parser handles built-in signals', function (t) {
+  // empty spec should get default values
+  testSignals(t, vega.parse({}), {
+    background: {value: null},
+    autosize: {value: {type: 'pad'}},
+    padding: {value: {top: 0, bottom: 0, left: 0, right: 0}},
+    width: {value: 0},
+    height: {value: 0}
+  });
+
+  // config constants should be used
+  testSignals(t, vega.parse({
+    config: {
+      background: 'blue',
+      autosize: 'none',
+      padding: 7,
+      width: 400,
+      height: 300
+    }
+  }), {
+    background: {value: 'blue'},
+    autosize: {value: {type: 'none'}},
+    padding: {value: {top: 7, bottom: 7, left: 7, right: 7}},
+    width: {value: 400},
+    height: {value: 300}
+  });
+
+  // spec constants should be used
+  testSignals(t, vega.parse({
+    background: 'red',
+    autosize: 'fit',
+    padding: 5,
+    width: 200,
+    height: 100
+  }), {
+    background: {value: 'red'},
+    autosize: {value: {type: 'fit'}},
+    padding: {value: {top: 5, bottom: 5, left: 5, right: 5}},
+    width: {value: 200},
+    height: {value: 100}
+  });
+
+  // spec constants should override config constants
+  testSignals(t, vega.parse({
+    config: {
+      background: 'blue',
+      autosize: 'none',
+      padding: 7,
+      width: 400,
+      height: 300
+    },
+    background: 'red',
+    autosize: 'fit',
+    padding: 5,
+    width: 200,
+    height: 100
+  }), {
+    background: {value: 'red'},
+    autosize: {value: {type: 'fit'}},
+    padding: {value: {top: 5, bottom: 5, left: 5, right: 5}},
+    width: {value: 200},
+    height: {value: 100}
+  });
+
+  // spec constants and signals should merge
+  testSignals(t, vega.parse({
+    background: 'red',
+    autosize: 'fit',
+    padding: 5,
+    width: 200,
+    height: 100,
+    signals: [
+      {name: 'background', value: 'blue'},
+      {name: 'autosize', value: {type: 'none'}},
+      {name: 'padding', value: {top: 0, bottom: 0, left: 0, right: 0}},
+      {name: 'width', value: 400},
+      {name: 'height', value: 300}
+    ]
+  }), {
+    background: {value: 'blue'},
+    autosize: {value: {type: 'none'}},
+    padding: {value: {top: 0, bottom: 0, left: 0, right: 0}},
+    width: {value: 400},
+    height: {value: 300}
+  });
+
+  // spec properties and signals should merge
+  testSignals(t, vega.parse({
+    background: {signal: "'red'"},
+    autosize: {signal: "{type:'fit'}"},
+    padding: {signal: "5"},
+    width: {signal: "200"},
+    height: {signal: "100"},
+    signals: [
+      {name: 'background', value: 'blue'},
+      {name: 'autosize', value: {type: 'none'}},
+      {name: 'padding', value: {top: 2, bottom: 2, left: 2, right: 2}},
+      {name: 'width', value: 400},
+      {name: 'height', value: 300}
+    ]
+  }), {
+    background: {value: 'blue', update: '\'red\''},
+    autosize: {value: {type: 'none'}, update: '{type:\'fit\'}'},
+    padding: {value: {top: 2, bottom: 2, left: 2, right: 2}, update: '5'},
+    width: {value: 400, update: '200'},
+    height: {value: 300, update: '100'}
+  });
+
+  // config properties and signals should merge
+  testSignals(t, vega.parse({
+    config: {
+      background: {signal: "'red'"},
+      autosize: {signal: "{type:'fit'}"},
+      padding: {signal: "5"},
+      width: {signal: "200"},
+      height: {signal: "100"}
+    },
+    signals: [
+      {name: 'background', value: 'blue'},
+      {name: 'autosize', value: {type: 'none'}},
+      {name: 'padding', value: {top: 2, bottom: 2, left: 2, right: 2}},
+      {name: 'width', value: 400},
+      {name: 'height', value: 300}
+    ]
+  }), {
+    background: {value: 'blue', update: '\'red\''},
+    autosize: {value: {type: 'none'}, update: '{type:\'fit\'}'},
+    padding: {value: {top: 2, bottom: 2, left: 2, right: 2}, update: '5'},
+    width: {value: 400, update: '200'},
+    height: {value: 300, update: '100'}
+  });
+
+  // spec properties should be overriden by signals
+  testSignals(t, vega.parse({
+    background: {signal: "'red'"},
+    autosize: {signal: "{type:'fit'}"},
+    padding: {signal: "5"},
+    width: {signal: "200"},
+    height: {signal: "100"},
+    signals: [
+      {name: 'background', update: '\'blue\''},
+      {name: 'autosize', update: '{type:\'none\'}'},
+      {name: 'padding', update: '{top: 2, bottom: 2, left: 2, right: 2}'},
+      {name: 'width', update: '400'},
+      {name: 'height', update: '300'}
+    ]
+  }), {
+    background: {update: '\'blue\''},
+    autosize: {update: '{type:\'none\'}'},
+    padding: {update: '{top:2,bottom:2,left:2,right:2}'},
+    width: {update: '400'},
+    height: {update: '300'}
+  });
+
+  // config properties should be overriden by signals
+  testSignals(t, vega.parse({
+    config: {
+      background: {signal: "'red'"},
+      autosize: {signal: "{type:'fit'}"},
+      padding: {signal: "5"},
+      width: {signal: "200"},
+      height: {signal: "100"}
+    },
+    signals: [
+      {name: 'background', update: '\'blue\''},
+      {name: 'autosize', update: '{type:\'none\'}'},
+      {name: 'padding', update: '{top: 2, bottom: 2, left: 2, right: 2}'},
+      {name: 'width', update: '400'},
+      {name: 'height', update: '300'}
+    ]
+  }), {
+    background: {update: '\'blue\''},
+    autosize: {update: '{type:\'none\'}'},
+    padding: {update: '{top:2,bottom:2,left:2,right:2}'},
+    width: {update: '400'},
+    height: {update: '300'}
+  });
 
   t.end();
 });

--- a/packages/vega-parser/test/transform-test.js
+++ b/packages/vega-parser/test/transform-test.js
@@ -47,7 +47,7 @@ tape('Parser parses Vega specs with data transforms', function(t) {
 
   var dfs = parse(spec);
 
-  t.equal(dfs.operators.length, 32);
+  t.equal(dfs.operators.length, 33);
 
   t.end();
 });

--- a/packages/vega-schema/src/autosize.js
+++ b/packages/vega-schema/src/autosize.js
@@ -1,4 +1,4 @@
-import {enums, object, oneOf, booleanType} from './util';
+import {enums, object, oneOf, booleanType, signalRef} from './util';
 
 const autosizeEnum = [
   'pad',
@@ -21,7 +21,8 @@ const autosize = oneOf(
     _type_: autosizeType,
     resize: booleanType,
     contains: enums(containsEnum)
-  })
+  }),
+  signalRef
 );
 
 export default {

--- a/packages/vega-schema/src/background.js
+++ b/packages/vega-schema/src/background.js
@@ -1,6 +1,6 @@
-import { stringType } from './util';
+import { stringOrSignal } from './util';
 
-const background = stringType;
+const background = stringOrSignal;
 
 export default {
   defs: {

--- a/packages/vega-schema/src/padding.js
+++ b/packages/vega-schema/src/padding.js
@@ -1,4 +1,4 @@
-import { object, oneOf, numberType } from './util';
+import { object, oneOf, numberType, signalRef } from './util';
 
 const padding = oneOf(
   numberType,
@@ -7,7 +7,8 @@ const padding = oneOf(
     bottom: numberType,
     left: numberType,
     right: numberType
-  })
+  }),
+  signalRef
 );
 
 export default {

--- a/packages/vega-schema/src/schema.js
+++ b/packages/vega-schema/src/schema.js
@@ -1,4 +1,4 @@
-import {def, ref, type, numberType, objectType, stringType} from './util';
+import {def, ref, type, numberOrSignal, objectType, stringType} from './util';
 
 import autosize from './autosize';
 import axis from './axis';
@@ -48,8 +48,8 @@ export default function(definitions) {
           $schema: type('string', {format: 'uri'}),
           config: objectType,
           description: stringType,
-          width: numberType,
-          height: numberType,
+          width: numberOrSignal,
+          height: numberOrSignal,
           padding: def('padding'),
           autosize: def('autosize'),
           background: def('background'),

--- a/packages/vega-typings/tests/spec/valid/map-bind.ts
+++ b/packages/vega-typings/tests/spec/valid/map-bind.ts
@@ -8,7 +8,7 @@ export const spec: Spec = {
 
   "encode": {
     "update": {
-      "fill": {"signal": "background"}
+      "fill": {"signal": "bgcolor"}
     }
   },
 
@@ -56,7 +56,7 @@ export const spec: Spec = {
       "bind": {"input": "radio", "options": [0, 3, 5, 10]} },
     { "name": "borderWidth", "value": 1,
       "bind": {"input": "text"} },
-    { "name": "background", "value": "#ffffff",
+    { "name": "bgcolor", "value": "#ffffff",
       "bind": {"input": "color"} },
     { "name": "invert", "value": false,
       "bind": {"input": "checkbox"} }

--- a/packages/vega-typings/types/spec/background.d.ts
+++ b/packages/vega-typings/types/spec/background.d.ts
@@ -1,1 +1,0 @@
-export type Background = string;

--- a/packages/vega-typings/types/spec/config.d.ts
+++ b/packages/vega-typings/types/spec/config.d.ts
@@ -7,6 +7,7 @@ import {
   Interpolate,
   Mark,
   Orientation,
+  Padding,
   RangeScheme,
   SymbolShape,
   TextBaseline,
@@ -43,8 +44,9 @@ export type ExcludeMappedValueRef<T> = {
 export interface Config
   extends Partial<Record<MarkConfigKeys, MarkConfig>>,
     Partial<Record<AxisConfigKeys, AxisConfig>> {
-  autosize?: AutoSize;
+  autosize?: AutoSize | SignalRef;
   background?: null | Color | SignalRef;
+  padding?: Padding | SignalRef;
   group?: any; // TODO
   events?: {
     bind?: 'any' | 'container' | 'none';

--- a/packages/vega-typings/types/spec/index.d.ts
+++ b/packages/vega-typings/types/spec/index.d.ts
@@ -1,5 +1,5 @@
 import { AutoSize } from './autosize';
-import { Background } from './background';
+import { Color } from './color';
 import { Config } from './config';
 import { Encodable, EncodeEntry } from './encode';
 import { Padding } from './padding';
@@ -14,13 +14,12 @@ export interface Spec extends Scope, Encodable<EncodeEntry> {
   height?: number | SignalRef;
   padding?: Padding | SignalRef;
   autosize?: AutoSize | SignalRef;
-  background?: Background | SignalRef;
+  background?: Color | SignalRef;
   style?: string | string[];
 }
 
 export * from './autosize';
 export * from './axis';
-export * from './background';
 export * from './bind';
 export * from './color';
 export * from './config';

--- a/packages/vega-typings/types/spec/index.d.ts
+++ b/packages/vega-typings/types/spec/index.d.ts
@@ -4,16 +4,17 @@ import { Config } from './config';
 import { Encodable, EncodeEntry } from './encode';
 import { Padding } from './padding';
 import { Scope } from './scope';
+import { SignalRef } from './signal';
 
 export interface Spec extends Scope, Encodable<EncodeEntry> {
   $schema?: string;
-  width?: number;
-  height?: number;
   config?: Config;
   description?: string;
-  padding?: Padding;
-  autosize?: AutoSize;
-  background?: Background;
+  width?: number | SignalRef;
+  height?: number | SignalRef;
+  padding?: Padding | SignalRef;
+  autosize?: AutoSize | SignalRef;
+  background?: Background | SignalRef;
   style?: string | string[];
 }
 

--- a/packages/vega-view-transforms/src/ViewLayout.js
+++ b/packages/vega-view-transforms/src/ViewLayout.js
@@ -143,15 +143,14 @@ function layoutGroup(view, group, _) {
 }
 
 function viewSizeLayout(view, group, viewBounds, _) {
-  var auto = _.autosize || {},
-      type = auto.type,
-      viewWidth = view._width,
-      viewHeight = view._height,
-      padding = view.padding();
+  const auto = _.autosize || {},
+        type = auto.type;
 
   if (view._autosize < 1 || !type) return;
 
-  var width  = Math.max(0, group.width || 0),
+  let viewWidth = view._width,
+      viewHeight = view._height,
+      width  = Math.max(0, group.width || 0),
       left   = Math.max(0, Math.ceil(-viewBounds.x1)),
       right  = Math.max(0, Math.ceil(viewBounds.x2 - width)),
       height = Math.max(0, group.height || 0),
@@ -159,6 +158,7 @@ function viewSizeLayout(view, group, viewBounds, _) {
       bottom = Math.max(0, Math.ceil(viewBounds.y2 - height));
 
   if (auto.contains === Padding) {
+    const padding = view.padding();
     viewWidth -= padding.left + padding.right;
     viewHeight -= padding.top + padding.bottom;
   }

--- a/packages/vega-view/src/View.js
+++ b/packages/vega-view/src/View.js
@@ -5,6 +5,7 @@ import {initializeEventConfig, events} from './events';
 import hover from './hover';
 import finalize from './finalize';
 import initialize from './initialize';
+import padding from './padding';
 import renderToImageURL from './render-to-image-url';
 import renderToCanvas from './render-to-canvas';
 import renderToSVG from './render-to-svg';
@@ -175,7 +176,9 @@ prototype.height = function(_) {
 };
 
 prototype.padding = function(_) {
-  return arguments.length ? this.signal('padding', _) : this.signal('padding');
+  return arguments.length
+    ? this.signal('padding', padding(_))
+    : padding(this.signal('padding'));
 };
 
 prototype.autosize = function(_) {

--- a/packages/vega-view/src/View.js
+++ b/packages/vega-view/src/View.js
@@ -1,3 +1,4 @@
+import background from './background';
 import cursor from './cursor';
 import {data, dataref, change, insert, remove} from './data';
 import {initializeEventConfig, events} from './events';
@@ -80,9 +81,6 @@ export default function View(spec, options) {
     view.changeset().insert(root.items)
   );
 
-  // initialize background color
-  view._background = options.background || ctx.background || null;
-
   // initialize view size
   view._width = view.width();
   view._height = view.height();
@@ -92,6 +90,9 @@ export default function View(spec, options) {
   view._resize = 0;
   view._autosize = 1;
   initializeResize(view);
+
+  // initialize background color
+  background(view);
 
   // initialize cursor
   cursor(view);
@@ -165,16 +166,6 @@ prototype.signal = function(name, value, options) {
     : this.update(op, value, options);
 };
 
-prototype.background = function(_) {
-  if (arguments.length) {
-    this._background = _;
-    this._resize = 1;
-    return this;
-  } else {
-    return this._background;
-  }
-};
-
 prototype.width = function(_) {
   return arguments.length ? this.signal('width', _) : this.signal('width');
 };
@@ -189,6 +180,10 @@ prototype.padding = function(_) {
 
 prototype.autosize = function(_) {
   return arguments.length ? this.signal('autosize', _) : this.signal('autosize');
+};
+
+prototype.background = function(_) {
+  return arguments.length ? this.signal('background', _) : this.signal('background');
 };
 
 prototype.renderer = function(type) {

--- a/packages/vega-view/src/background.js
+++ b/packages/vega-view/src/background.js
@@ -1,0 +1,8 @@
+export default function(view) {
+  // respond to background signal
+  view.add(null, _ => {
+    view._background = _.bg;
+    view._resize = 1;
+    return _.bg;
+  }, { bg: view._signals.background });
+}

--- a/packages/vega-view/src/initialize-renderer.js
+++ b/packages/vega-view/src/initialize-renderer.js
@@ -4,5 +4,5 @@ export default function(view, r, el, constructor, scaleFactor, opt) {
   r = r || new constructor(view.loader());
   return r
     .initialize(el, width(view), height(view), offset(view), scaleFactor, opt)
-    .background(view._background);
+    .background(view.background());
 }

--- a/packages/vega-view/src/padding.js
+++ b/packages/vega-view/src/padding.js
@@ -1,0 +1,16 @@
+import {isObject} from 'vega-util';
+
+const number = _ => +_ || 0;
+
+const paddingObject = _ => ({top: _, bottom: _, left: _, right: _});
+
+export default function(_) {
+  return isObject(_)
+    ? {
+        top:    number(_.top),
+        bottom: number(_.bottom),
+        left:   number(_.left),
+        right:  number(_.right)
+      }
+    : paddingObject(number(_));
+}

--- a/packages/vega-view/src/render-size.js
+++ b/packages/vega-view/src/render-size.js
@@ -22,7 +22,7 @@ export function resizeRenderer(view) {
       w = width(view),
       h = height(view);
 
-  view._renderer.background(view._background);
+  view._renderer.background(view.background());
   view._renderer.resize(w, h, origin);
   view._handler.origin(origin);
 

--- a/packages/vega/test/specs-valid/map-bind.vg.json
+++ b/packages/vega/test/specs-valid/map-bind.vg.json
@@ -6,7 +6,7 @@
 
   "encode": {
     "update": {
-      "fill": {"signal": "background"}
+      "fill": {"signal": "bgcolor"}
     }
   },
 
@@ -54,7 +54,7 @@
       "bind": {"input": "radio", "options": [0, 3, 5, 10]} },
     { "name": "borderWidth", "value": 1,
       "bind": {"input": "text"} },
-    { "name": "background", "value": "#ffffff",
+    { "name": "bgcolor", "value": "#ffffff",
       "bind": {"input": "color"} },
     { "name": "invert", "value": false,
       "bind": {"input": "checkbox"} }


### PR DESCRIPTION
This PR does the following:

- The Vega parser now generates a built-in `background` signal which the view uses to set the background color. _While not technically a breaking change_ (specs will still parse and evaluate successfully), existing specs that use a signal named `"background"` may not render the same as before, in which case a different signal name should be used.
- The top-level properties `autosize`, `background`, `padding`, `width`, and `height` now accept signal references, such as `{"signal": "<expr>"}`, which map to a signal definition's `update` property. If a specifications top-level `signals` array contains an entry that matches one of these properties, the definitions will be merged, with precedence given to the properties defined in the `signals` array.

**vega**
- Update test specifications to avoid use of a signal named `"background"`.

**vega-parser**
- Add built-in `background` signal to drive view background.
- Add support for top-level properties to take signal-values.

**vega-schema**
- Add top-level signal-valued properties to schema.

**vega-typings**
- Add top-level signal-valued properties to view typings.
- Add top-level signal-valued properties to config typings.

**vega-view**
- Use `background` signal to control the view background color.
- Update `padding` method to handle numeric values.

**vega-view-transforms**
- Refine view layout resize code to avoid invocation of padding until needed.

Close #2394.
Close #2417.