### PR TITLE
Trim text to make rendering consistent

### DIFF
--- a/packages/vega-scenegraph/src/util/text.js
+++ b/packages/vega-scenegraph/src/util/text.js
@@ -71,8 +71,8 @@ export function multiLineOffset(item) {
 
 export function textValue(item, line) {
   return line == null ? ''
-    : item.limit > 0 ? truncate(item, line)
-    : line + '';
+    : item.limit > 0 ? truncate(item, line).trim()
+    : (line + '').trim();
 }
 
 function widthGetter(item) {


### PR DESCRIPTION
**vega-scenegraph**
- Trim text to make rendering between SVG and Canvas consistent.

Fixes https://github.com/vega/vega/issues/2418