### PR TITLE
Add blend encoding channel. 

### DIFF
--- a/packages/vega-scenegraph/schema.js
+++ b/packages/vega-scenegraph/schema.js
@@ -174,6 +174,25 @@ var MARK_BASE = {
   "required": [ "marktype" ]
 };
 
+var BLEND_MODES = [
+  null,
+  'multiply',
+  'screen',
+  'overlay',
+  'darken',
+  'lighten',
+  'color-dodge',
+  'color-burn',
+  'hard-light',
+  'soft-light',
+  'difference',
+  'exclusion',
+  'hue',
+  'saturation',
+  'color',
+  'luminosity',
+];
+
 var ITEM_BASE = {
   "type": "object",
   "properties": {
@@ -181,6 +200,7 @@ var ITEM_BASE = {
     "y": { "type": "number" },
     "width": { "type": "number" },
     "height": { "type": "number" },
+    "blend": { "enum": BLEND_MODES, "default": null },
     "opacity": { "type": "number", "default": 1 },
     "fill": { "$ref": "#/refs/paint" },
     "fillOpacity": { "type": "number", "default": 1 },

--- a/packages/vega-scenegraph/src/marks/group.js
+++ b/packages/vega-scenegraph/src/marks/group.js
@@ -2,9 +2,10 @@ import {hasCornerRadius, rectangle} from '../path/shapes';
 import boundStroke from '../bound/boundStroke';
 import {intersectRect} from '../util/intersect';
 import {visit, pickVisit} from '../util/visit';
+import blend from '../util/canvas/blend';
 import {clipGroup} from '../util/canvas/clip';
-import stroke from '../util/canvas/stroke';
 import fill from '../util/canvas/fill';
+import stroke from '../util/canvas/stroke';
 import {hitPath} from '../util/canvas/pick';
 import clip from '../util/svg/clip';
 import {translateItem} from '../util/svg/transform';
@@ -82,6 +83,7 @@ function draw(context, scene, bounds) {
     // draw group background
     if ((group.stroke || group.fill) && opacity) {
       rectanglePath(context, group, gx, gy);
+      blend(context, group);
       if (group.fill && fill(context, group, opacity)) {
         context.fill();
       }
@@ -108,6 +110,7 @@ function draw(context, scene, bounds) {
     // draw group foreground
     if (fore && group.stroke && opacity) {
       rectanglePath(context, group, gx, gy);
+      blend(context, group);
       if (stroke(context, group, opacity)) {
         context.stroke();
       }

--- a/packages/vega-scenegraph/src/marks/image.js
+++ b/packages/vega-scenegraph/src/marks/image.js
@@ -1,4 +1,5 @@
 import {visit} from '../util/visit';
+import blend from '../util/canvas/blend';
 import {pick} from '../util/canvas/pick';
 import {translate} from '../util/svg/transform';
 import {truthy} from 'vega-util';
@@ -105,6 +106,7 @@ function draw(context, scene, bounds) {
     }
 
     if (image.complete || image.toDataURL) {
+      blend(context, item);
       context.globalAlpha = (opacity = item.opacity) != null ? opacity : 1;
       context.imageSmoothingEnabled = item.smooth !== false;
       context.drawImage(image, x, y, w, h);

--- a/packages/vega-scenegraph/src/marks/rule.js
+++ b/packages/vega-scenegraph/src/marks/rule.js
@@ -1,6 +1,7 @@
 import boundStroke from '../bound/boundStroke';
 import {intersectRule} from '../util/intersect';
 import {visit} from '../util/visit';
+import blend from '../util/canvas/blend';
 import {pick} from '../util/canvas/pick';
 import stroke from '../util/canvas/stroke';
 import {translateItem} from '../util/svg/transform';
@@ -42,6 +43,7 @@ function draw(context, scene, bounds) {
     if (bounds && !bounds.intersects(item.bounds)) return; // bounds check
     var opacity = item.opacity == null ? 1 : item.opacity;
     if (opacity && path(context, item, opacity)) {
+      blend(context, item);
       context.stroke();
     }
   });

--- a/packages/vega-scenegraph/src/marks/text.js
+++ b/packages/vega-scenegraph/src/marks/text.js
@@ -3,6 +3,7 @@ import {DegToRad, HalfPi} from '../util/constants';
 import {font, lineHeight, offset, textLines, textMetrics, textValue} from '../util/text';
 import {intersectBoxLine} from '../util/intersect';
 import {visit} from '../util/visit';
+import blend from '../util/canvas/blend';
 import fill from '../util/canvas/fill';
 import {pick} from '../util/canvas/pick';
 import stroke from '../util/canvas/stroke';
@@ -118,6 +119,7 @@ function draw(context, scene, bounds) {
     y += (item.dy || 0) + offset(item);
 
     tl = textLines(item);
+    blend(context, item);
     if (isArray(tl)) {
       lh = lineHeight(item);
       for (i=0; i<tl.length; ++i) {

--- a/packages/vega-scenegraph/src/util/canvas/blend.js
+++ b/packages/vega-scenegraph/src/util/canvas/blend.js
@@ -1,0 +1,3 @@
+export default function(context, item) {
+  context.globalCompositeOperation = item.blend || 'source-over';
+}

--- a/packages/vega-scenegraph/src/util/canvas/draw.js
+++ b/packages/vega-scenegraph/src/util/canvas/draw.js
@@ -1,3 +1,4 @@
+import blend from './blend';
 import fill from './fill';
 import stroke from './stroke';
 import {visit} from '../visit';
@@ -25,6 +26,8 @@ function drawPath(path, context, item, items) {
   if (opacity === 0) return;
 
   if (path(context, items)) return;
+
+  blend(context, item);
 
   if (item.fill && fill(context, item, opacity)) {
     context.fill();

--- a/packages/vega-scenegraph/src/util/serialize.js
+++ b/packages/vega-scenegraph/src/util/serialize.js
@@ -3,7 +3,7 @@ import boundMark from '../bound/boundMark';
 var keys = [
   'marktype', 'name', 'role', 'interactive', 'clip', 'items', 'zindex',
   'x', 'y', 'width', 'height', 'align', 'baseline',             // layout
-  'fill', 'fillOpacity', 'opacity',                             // fill
+  'fill', 'fillOpacity', 'opacity', 'blend',                    // fill
   'stroke', 'strokeOpacity', 'strokeWidth', 'strokeCap',        // stroke
   'strokeDash', 'strokeDashOffset',                             // stroke dash
   'strokeForeground', 'strokeOffset',                           // group

--- a/packages/vega-scenegraph/src/util/svg/styles.js
+++ b/packages/vega-scenegraph/src/util/svg/styles.js
@@ -9,7 +9,8 @@ export var styles = {
   'strokeDash':       'stroke-dasharray',
   'strokeDashOffset': 'stroke-dashoffset',
   'strokeMiterLimit': 'stroke-miterlimit',
-  'opacity':          'opacity'
+  'opacity':          'opacity',
+  'blend':            'mix-blend-mode'
 };
 
 export var styleProperties = Object.keys(styles);


### PR DESCRIPTION
This PR adds support for different color blend modes, specified per scenegraph item. For Canvas rendering, the blend is set via the context 2D `globalCompositeOperation` property. For SVG rendering, the blend is set via the CSS `mix-blend-mode` style. The default Vega value is `null` (or `undefined`), which maps to the default values `"source-over"` (for Canvas) and `"normal"` (for SVG).

The allowed values are: `multiply`, `screen`, `overlay`, `darken`, `lighten`, `color-dodge`, `color-burn`, `hard-light`, `soft-light`, `difference`, `exclusion`, `hue`, `saturation`, `color`, `luminosity`. For more, see the [Canvas `globalCompositeOperation`](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/globalCompositeOperation) and [CSS `mix-blend-mode`](https://developer.mozilla.org/en-US/docs/Web/CSS/mix-blend-mode) documentation. (Note that the bottom of the CSS document page shows browser compatibility, and includes some notable limitations.)

**vega-scenegraph**
- Update Canvas and SVG renderers to support `blend` encoding property.

Close #2311.