### PR TITLE
Align to base pixel grid in case of non-integer scaling.

### DIFF
--- a/packages/vega-scenegraph/src/Bounds.js
+++ b/packages/vega-scenegraph/src/Bounds.js
@@ -77,6 +77,14 @@ prototype.round = function() {
   return this;
 };
 
+prototype.scale = function(s) {
+  this.x1 *= s;
+  this.y1 *= s;
+  this.x2 *= s;
+  this.y2 *= s;
+  return this;
+};
+
 prototype.translate = function(dx, dy) {
   this.x1 += dx;
   this.x2 += dx;

--- a/packages/vega-scenegraph/src/CanvasRenderer.js
+++ b/packages/vega-scenegraph/src/CanvasRenderer.js
@@ -55,10 +55,15 @@ function clipToBounds(g, b, origin) {
   // expand bounds by 1 pixel, then round to pixel boundaries
   b.expand(1).round();
 
+  // align to base pixel grid in case of non-integer scaling (#2425)
+  if (g.pixelRatio % 1) {
+    b.scale(g.pixelRatio).round().scale(1 / g.pixelRatio);
+  }
+
   // to avoid artifacts translate if origin has fractional pixels
   b.translate(-(origin[0] % 1), -(origin[1] % 1));
 
-  // set clipping path
+  // set clip path
   g.beginPath();
   g.rect(b.x1, b.y1, b.width(), b.height());
   g.clip();

--- a/packages/vega-scenegraph/src/util/canvas/resize.js
+++ b/packages/vega-scenegraph/src/util/canvas/resize.js
@@ -5,18 +5,16 @@ function devicePixelRatio() {
 var pixelRatio = devicePixelRatio();
 
 export default function(canvas, width, height, origin, scaleFactor, opt) {
-  var inDOM = typeof HTMLElement !== 'undefined'
-    && canvas instanceof HTMLElement
-    && canvas.parentNode != null;
-
-  var context = canvas.getContext('2d'),
-      ratio = inDOM ? pixelRatio : scaleFactor,
-      key;
+  const inDOM = typeof HTMLElement !== 'undefined'
+              && canvas instanceof HTMLElement
+              && canvas.parentNode != null,
+        context = canvas.getContext('2d'),
+        ratio = inDOM ? pixelRatio : scaleFactor;
 
   canvas.width = width * ratio;
   canvas.height = height * ratio;
 
-  for (key in opt) {
+  for (const key in opt) {
     context[key] = opt[key];
   }
 


### PR DESCRIPTION
**vega-scenegraph**
- Fix canvas damage/redraw: Align to base pixel grid in case of non-integer scaling.

Fixes #2425.