### PR TITLE
Add top-level lineBreak config option.

### DIFF
--- a/packages/vega-parser/src/parsers/encode/encode-util.js
+++ b/packages/vega-parser/src/parsers/encode/encode-util.js
@@ -53,7 +53,13 @@ export function encoders(encode, type, role, style, scope, params) {
 function applyDefaults(encode, type, role, style, config) {
   var defaults = {}, enter = {}, update, key, skip, props;
 
-  // ignore legend and axis
+  // if text mark, apply global lineBreak settings (#2370)
+  key = 'lineBreak';
+  if (type === 'text' && config[key] != null && !has(key, encode)) {
+    applyDefault(defaults, key, config[key]);
+  }
+
+  // ignore legend and axis roles
   if (role == 'legend' || String(role).indexOf('axis') === 0) {
     role = null;
   }

--- a/packages/vega-typings/types/spec/config.d.ts
+++ b/packages/vega-typings/types/spec/config.d.ts
@@ -54,6 +54,7 @@ export interface Config
     view?: boolean | string[];
     window?: boolean | string[];
   };
+  lineBreak?: string | SignalRef;
   style?: {
     [style: string]: MarkConfig;
   };


### PR DESCRIPTION
**vega-parser**
- Apply top-level `lineBreak` config option to text marks.

**vega-typings**
- Add `lineBreak` config typing.

Close #2370.