### PR TITLE
Prevent prototype pollution.

### DIFF
--- a/packages/vega-util/src/mergeConfig.js
+++ b/packages/vega-util/src/mergeConfig.js
@@ -1,6 +1,8 @@
 import isArray from './isArray';
 import isObject from './isObject';
 
+const isLegalKey = key => key !== '__proto__';
+
 export function mergeConfig(...configs) {
   return configs.reduce((out, source) => {
     for (var key in source) {
@@ -14,7 +16,7 @@ export function mergeConfig(...configs) {
         // for legend block, recurse for the layout entry only
         // for style block, recurse for all properties
         // otherwise, no recursion: objects overwrite, no merging
-        var r = key === 'legend' ? {'layout': 1}
+        var r = key === 'legend' ? {layout: 1}
           : key === 'style' ? true
           : null;
         writeConfig(out, key, source[key], r);
@@ -25,13 +27,15 @@ export function mergeConfig(...configs) {
 }
 
 export function writeConfig(output, key, value, recurse) {
+  if (!isLegalKey(key)) return;
+
   var k, o;
   if (isObject(value) && !isArray(value)) {
     o = isObject(output[key]) ? output[key] : (output[key] = {});
     for (k in value) {
       if (recurse && (recurse === true || recurse[k])) {
         writeConfig(o, k, value[k]);
-      } else {
+      } else if (isLegalKey(k)) {
         o[k] = value[k];
       }
     }

--- a/packages/vega-util/test/mergeConfig-test.js
+++ b/packages/vega-util/test/mergeConfig-test.js
@@ -78,3 +78,15 @@ tape('mergeConfig handles empty arguments', function(t) {
   t.deepEqual(vega.mergeConfig(null, undefined, c), c);
   t.end();
 });
+
+tape('mergeConfig must not allow prototype pollution', function(t) {
+  const config = {symbol: {shape: 'triangle-right'}},
+        payload = JSON.parse('{"__proto__": {"vulnerable": "Polluted"}}'),
+        merged = vega.mergeConfig(config, payload, {symbol: payload});
+
+  t.equal(merged.__proto__.vulnerable, undefined);
+  t.equal(merged.symbol.__proto__.vulnerable, undefined);
+  t.equal(Object.prototype.vulnerable, undefined);
+
+  t.end();
+});


### PR DESCRIPTION
**vega-util**
- Fix prototype pollution vulnerability in `mergeConfig`.