### PR TITLE
feat: add axis `labelLineHeight`

### DIFF
--- a/docs/docs/axes.md
+++ b/docs/docs/axes.md
@@ -44,6 +44,7 @@ Properties for specifying a coordinate axis.
 | labelFontStyle  | {% include type t="String" %} | Font style of axis tick labels (e.g., `normal` or `italic`). {% include tag ver="5.0" %} |
 | labelFontWeight | {% include type t="String|Number" %} | Font weight of axis tick labels. |
 | labelLimit    | {% include type t="Number" %}  | The maximum allowed length in pixels of axis tick labels. |
+| labelLineHeight | {% include type t="Number" %} | Line height in pixels for multi-line label text. {% include tag ver="5.10" %} |
 | labelOffset  | {% include type t="Number" %}  | Position offset in pixels to apply to labels, in addition to *tickOffset*. {% include tag ver="5.10" %} |
 | labelOpacity  | {% include type t="Number" %}  | Opacity of axis tick labels. {% include tag ver="4.1" %} |
 | labelOverlap  | {% include type t="Boolean|String" %} | The strategy to use for resolving overlap of axis labels. If `false` (the default), no overlap reduction is attempted. If set to `true` or `"parity"`, a strategy of removing every other label is used (this works well for standard linear axes). If set to `"greedy"`, a linear scan of the labels is performed, removing any label that overlaps with the last visible label (this often works better for log-scaled axes).|

--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -221,6 +221,7 @@ Additional property blocks can target more specific axis types based on the orie
 | labelFontStyle  | {% include type t="String" %} | Font style of axis tick labels (e.g., `normal` or `italic`). {% include tag ver="5.0" %} |
 | labelFontWeight | {% include type t="String|Number" %}   | Font weight of axis tick labels. |
 | labelLimit      | {% include type t="Number" %}   | The maximum allowed length in pixels of axis tick labels. |
+| labelLineHeight | {% include type t="Number" %}   | Line height in pixels for multi-line label text. {% include tag ver="5.10" %} |
 | labelOffset     | {% include type t="Number" %}   | Position offset in pixels to apply to labels, in addition to *tickOffset*. {% include tag ver="5.10" %} |
 | labelOpacity    | {% include type t="Number" %}   | Opacity of axis tick labels. {% include tag ver="4.1" %} |
 | labelOverlap    | {% include type t="Boolean|String" %} | The strategy to use for resolving overlap of axis labels. If `false`, no overlap reduction is attempted. If `true` or `"parity"`, a strategy of removing every other label is used (this works well for standard linear axes). If `"greedy"`, a linear scan of the labels is performed, removing any labels that overlaps with the last visible label (this often works better for log-scaled axes).|

--- a/packages/vega-parser/src/parsers/guides/axis-labels.js
+++ b/packages/vega-parser/src/parsers/guides/axis-labels.js
@@ -88,7 +88,8 @@ export default function(spec, config, userEncode, dataRef, size, band) {
     fontSize:    _('labelFontSize'),
     fontWeight:  _('labelFontWeight'),
     fontStyle:   _('labelFontStyle'),
-    limit:       _('labelLimit')
+    limit:       _('labelLimit'),
+    lineHeight:  _('labelLineHeight')
   });
 
   bound   = _('labelBound');

--- a/packages/vega-schema/src/axis.js
+++ b/packages/vega-schema/src/axis.js
@@ -125,6 +125,7 @@ const axis = object({
   labelFontWeight: fontWeightValue,
   labelFontStyle: stringValue,
   labelLimit: numberValue,
+  labelLineHeight: numberValue,
   labelOpacity: numberValue,
   labelOffset: numberValue,
   labelPadding: numberValue,

--- a/packages/vega-typings/types/spec/axis.d.ts
+++ b/packages/vega-typings/types/spec/axis.d.ts
@@ -7,7 +7,6 @@ import {
   TimeInterval,
 } from '.';
 import { Text } from './encode';
-import { LayoutAlign } from './layout';
 import {
   AlignValue,
   AnchorValue,
@@ -436,6 +435,11 @@ export interface BaseAxis {
    * __Default value:__ `0`.
    */
   labelFlushOffset?: number | SignalRef;
+
+  /**
+   * Line height in pixels for multi-line label text.
+   */
+  labelLineHeight?: NumberValue;
 
   /**
    * The strategy to use for resolving overlap of axis labels. If `false` (the default), no overlap reduction is attempted. If set to `true` or `"parity"`, a strategy of removing every other label is used (this works well for standard linear axes). If set to `"greedy"`, a linear scan of the labels is performed, removing any labels that overlaps with the last visible label (this often works better for log-scaled axes).


### PR DESCRIPTION
I've tested this [spec](https://vega.github.io/editor/#/url/vega/N4KABGBEAkDODGALApgWwIaQFxUQFzwAdYsB6UgN2QHN0A6agSz0QFcAjOxge1IRQyUa6SgFY6AK1jcAdpAA04KABNkCAE6NCeHnJyQAgmAToCydYQA23PMcTcA7oxnUw99bGSFH5sOhnKYKiMlmpghL60ltYysHQKSpDs6PAA1tTq3KwB2FAOiMzICRCQhOjKys7UuaKKJU7KLLkATAAMrXW4yIzU+C3tnZCweACeobmQ8MjRxSqmmDgA2koQoBDrUDLoqEX60qzqUwD6rbMbkAeWE8rzpPDoHpLScp3nAGbc6hh4ucCQoxEJlJZJAAL6vdb-dT+WAfL65ZYbDZrJHnAG7KBvEJ4cxnVFQZAAD0I6gmjFgADV0JZGMoABQ3PCsVCLAA6kAAEp9PN4HOZ2QBdACUYAAZKKwOSAGLOQp0gDUjOZbM53K8PnUgpF4sllOptIZpmV7IAsiE1EcIuojgBxakxLViiXS2U4hVKlmm82wS3mW322RayArJGgkMQAUhsMRwYYdSpWAIkMo85bHYTOMJvEldETWAjVDsbhXCElYZjDGLUrcZw-AWlzGZVC-SCMhZQfaHZAnMENyDIGTwbiqX7hyGsQiMjEp-GQbhleDMEYtijU1gY1p0ADs4LH7xCVxwf1XlnXEzw0NiZXUA5+u-xkOGmVS06G93G+iH1lJ8kxjGmygTAA8poTByPeD5QISLYmB+UEKH+AETFyHjqnypIQQ+kDLkeb7Uhi2EIZAWJIfoZqhD6Vr+tEIKYbOsCIOggK4bBBEMUxRS-sR-6WIB+ggT0zhgnuYDRqGUZKPWiSsYmSzJmOkBpgR0F9rm+g0jIyAPNmKjcBgQm4W2eZZF2PZcSRvHIWqvK4nRJSXtQlYdGAfywD0WyHnktJNKCUmoopjBTLkF7rn2ABe5jcMF6jrlGEIziUSkTMuqkjMxUAaVpP4KcoenoAZLmtvMxkHMcpzmTxfFQORFpUXaNHgX2DmVq57nUhMKA9H04JgK0flIgFQU4CFyDhZF0WxRsdEJZs2wEV+nw6f8aUEZ8lQeUtuX6XohVGXsJllURFlVZAAlgUR0jqD8w0xcgdlQM1Ez3Di1CfMucXyf5SV7IxgKpelc7qOt7V9lt+U7X8e0dgd3blYhln8aBQlcZd11gCN92QI9ewFkWVwSTGiToISahJsiCmsRMKkKZ8-4yGjSQ2HgelLRktIAMrvgRKUKWzVUjapgWpAAwlk9MwW1nmTN0lh0g0LCkAALK0Qq9jleUFW81KeH2ljoOw0yyWAWuWDrCkYISACihI4uLOAdObzjW7baMO-5OhpEbJtm-5YXOKo0H2x95P+ZT+g8-5tO3hMoRvD8fZ85z+FU6zmj87dgtpKL2Ro611AbZ+Mt0p1vR4ErKtq-5YOa9ro0KXrBum7k3t1-5FvO9H9t9sEMgd3bvWZ1mOAt+F-tErkrTB+sM14XBkDU5Hmid1ARYECzCdp83teC3gc8oTyGpLQ30xSqeDETaNED1-r0xAVQ6h64QF+-tfjcAELoJ4mUx84yAALTMyfrrG+lgAAyv8OTdFLv0Qe2d+55wLlAKYIQ5beUQOXVWmM-YBHHkHKa8UKZc2SktKO-dICx3jrzTew9t4KR0LvAiNVKJ+nqjEI+IC77mEfs-OhQs4G5yGJLJ6RcS74AwZXAa2CA4TwJmAfq5CaADmUEbRE08KYXm4C+J6xZFp9nzIWYsAAVFaT1GCHHGDvOeZ1kYKQHEOEcR4RJDFxsWI2M1zgTinKOSCkIsQzFwieM8+gLwwmvNHe6kcFxLhXGuDc24xIPgSeJVEmN2IAzSUUWRkZQRAA), which doesn't work in the online version, works in my local build. 

![image](https://user-images.githubusercontent.com/111269/76036709-b41eb380-5ef9-11ea-91d7-651be41a257a.png)


Why? This line height positioning is particularly useful for this axis style ([spec](https://vega.github.io/editor/#/url/vega/N4KABGBEAkDODGALApgWwIaQFxUQFzwAdYsB6UgN2QHN0A6agSz0QFcAjOxge1IRQyUa6SgFY6AK1jcAdpAA04KABNkCAE6NCeHnJyQAgmAToCydYQA23PMcTcA7oxnUw99bGSFH5sOhnKYKiMlmpghL60ltYysHQKSpDs6PAA1tTq3KwB2FAOiMzICRCQhOjKys7UuaKKJU7KLLkATAAMrXW4yIzU+C3tnZCweACeobmQ8MjRxSqmmDgA2koQoBDrUDLoqEX60qzqUwD6rbMbkAeWE8rzpPDoHpLScp3nAGbc6hh4ucCQoxEJlJZJAAL6vdb-dT+WAfL65ZYbDZrJHnAG7KBvEJ4cxnVFQZAAD0I6gmjFgADV0JZGMoABQ3PCsVCLAA6kAAEp9PN4HOZ2QBdACUYAAZKKwOSAGLOQp0gDUjOZbM53K8PnUgpF4sllOptIZpmV7IAsiE1EcIuojgBxakxLViiXS2U4hVKlmm82wS3mW322RayArJGgkMQAUhsMRwYYdSpWAIkMo85bHYTOMJvEldETWAjVDsbhXCElYZjDGLUrcZw-AWlzGZVC-SCMhZQfaHZAnMENyDIGTwbiqX7hyGsQiMjEp-GQbhleDMEYtijU1gY1p0ADs4LH7xCVxwf1XlnXEzw0NiZXUA5+u-xkOGmVS06G93G+iH1lJ8kxjGmygTAA8poTByPeD5QISLYmB+UEKH+AETFyHjqnypIQQ+kDLkeb7Uhi2EIZAWJIfoZqhD6Vr+tEIKYbOsCIOggK4bBBEMUxRS-sR-6WIB+ggT0zhgnuYDRqGUZKPWiSsYmSzJmOkBpgR0F9rm+g0jIyAPNmKjcBgQm4W2eZZF2PZcSRvHIWqvK4nRJSXtQlYdGAfywD0WyHnktJNKCUmoopjBTLkF7rn2ABe5jcMF6jrlGEIziUSkTMuqkjMxUAaVpP4KcoenoAZLmtvMxkHMcpzmTxfFQORFpUXaNHgX2DmVq57nUhMKA9H04JgK0flIgFQU4CFyDhZF0WxRsdEJZs2wEV+nw6f8aUEZ8lQeUtuX6XohVGXsJllURFlVZAAlgUR0jqD8w0xcgdlQM1Ez3Di1CfMucXyf5SV7IxgKpelc7qOt7V9lt+U7X8e0dgd3blYhln8aBQlcZd11gCN92QI9ewFkWVwSTGiToISahJsiCmsRMKkKZ8-4yGjSQ2HgelLRktIAMrvgRKUKWzVUjapgWpAAwlk9MwW1nmTN0lh0g0LCkAALK0Qq9jleUFW81KeH2ljoOw0yyWAWuWDrCkYISACihI4uLOAdObzjW7baMO-5OhpEbJtm-5YXOKo0H2x95P+ZT+g8-5tO3hMoRvD8fZ85z+FU6zmj87dgtpKL2Ro611AbZ+Mt0p1vR4ErKtq-5YOa9ro0KXrBum7k3t1-5FvO9H9t9sEMgd3bvWZ1mOAt+F-tErkrTB+sM14XBkDU5Hmid1ARYECzCdp83teD+zjARbkACMABsgt4HPKE8hqS0N9MUqngxE2jWA9f69MQFvG8nho80v4v43QFUHUHrQgj9f7+RvpYAwNJ84x2QHHa+r9LAACF0CeEyjHZwyAAC0zMQG60QQAGUwRybopdD4nz-tMAACuUda1QcBYOPoPGhFQqgT0HtnfuecC5QCmCEOW3lEDl1VpjP2ARx5BymvFCmXNkpLSjv3SAsd46803sPbeCkdBnwIjVSifp6oxAQf-QBwDQGaKFpw3OQxJZPSLiXfAwjK4DTEQHCeBMwD9SUTQAcygjaImnhTC83AXxPWLItPs+ZCzFgACorSeowQ44xT5zzOsjBSA4hwjiPCJIYuNixGxmucCcU5RyQUhFiGYuETxnn0BeGE15o73UjguJcK41wbm3GJB8XTxKokxuxAGAyijuMjKCIAA) -- only works in a local branch):

![image](https://user-images.githubusercontent.com/111269/76036864-327b5580-5efa-11ea-8b73-2029dba90f4c.png)


Note: 

For legends, `labelLineHeight` currently doesn't seem particularly useful from my experiment. 
  - symbol legend seems to expect a "middle" baseline for the layout to work well
  - gradient totally ignores `labelBaseline` according to `legend-gradient-labels.js`

Thus I'm not adding its support in this PR, but if you want to add it for consistency (legend also has `labelBaseline` even though it might not be the most useful), I've also made `kw/legend.labelLineHeight` as a follow-up branch.