### PR TITLE
Change default role from figure to graphics element

### DIFF
--- a/packages/vega-view/src/aria.js
+++ b/packages/vega-view/src/aria.js
@@ -2,7 +2,7 @@
 export function initializeAria(view) {
   const el = view.container();
   if (el) {
-    el.setAttribute('role', 'figure');
+    el.setAttribute('role', 'graphics-document');
     ariaLabel(el, view.description());
   }
 }


### PR DESCRIPTION
I think we want to use `graphics-document` and later annotate axes and legends with `graphics-object` and marks with `graphics-symbol` (based on https://blog.tenon.io/accessible-charts-with-aria). 

https://www.w3.org/TR/graphics-aria-1.0/#role_other shows that a figure is for wrapping graphics.

