### PR TITLE
fix(vega-typings): add blend to mark config

### DIFF
--- a/packages/vega-typings/types/spec/config.d.ts
+++ b/packages/vega-typings/types/spec/config.d.ts
@@ -15,6 +15,7 @@ import {
 import { BaseAxis } from './axis';
 import { Color } from './color';
 import {
+  Blend,
   ColorValueRef,
   Gradient,
   NumericValueRef,
@@ -131,6 +132,13 @@ export interface MarkConfig {
    * @maximum 1
    */
   strokeOpacity?: number | SignalRef;
+
+  /**
+   * The color blend mode for drawing an item on its current background. Any valid [CSS mix-blend-mode](https://developer.mozilla.org/en-US/docs/Web/CSS/mix-blend-mode) value can be used.
+   *
+   * __Default value: `"source-over"`
+   */
+  blend?: Blend;
 
   // ---------- Stroke Style ----------
   /**


### PR DESCRIPTION
It does work. See [example](https://vega.github.io/editor/#/url/vega/N4KABGBEAkDODGALApgWwIaQFxUQFzwAdYsB6UgN2QHN0A6agSz0QFcAjOxge1IRQyUa6SgFY6AK1jcAdpAA04KABNkCAE6NCeHnJyQAgmAToCydYQA23PMcTcA7oxnUw99bGSFH5sOhnKYKiMlmpghL60ltYysGAAZtzqYBTomtyscfBpsHQKSpDs6PAA1tTqGQHYUA6IzMj5EJCE6MrKztTVoopNTsos1QBMAAzDPbjIjNT4Q6PjkLB4AJ6h1ZDwyNGNKqaYOADaShCgEKdQMuioDfrSrOobAPrD22eQd5Zryruk2R6S0nJxq9EuoMHhqsBIMsImspLJIABfIGnKHqfywEGoaqHM5nE6417Q65QeIhPDmF4EqDIAAehHUa0YsAAauhLIxlAAKL54ViofYAHUgAAkkp5vA5zEKALoASjAADIFWAmQAxZz1TkAah5fMFIrFXh86hl8qVKpZbI53NMeqFAFkQmoHhF1A8AOJsmKmxXKtUa8na3X8h1O2Au8wer2yU2QI64hHxiDS+OJ5PzDDqEqwbHx-GvC5XNaZ7OUppEtawJaodjcD7IpqLFbE-bNbjOcHShskipYnCQnl7KC3e7IJ6I7uQZAyeDcVQQpMo1iEHnE-NUyDcFrwZhLCGQVKWVjE4Z0ADsSMXwJCH37B7Zx7WeDRsRa6mn4MvVJRiwqJTX95HsSkAAMQACzwGeAAc6BQROV4ojS+4mKs+hIfIJKMJsyhrKKHhGpKDJft+UB7neKHAXuGGQKS2FrI6oThq6UbRPCaZUuxZycWA7FdgUFE5gceaLpAhbAehIkVvo7IyMgaRlio3AYM4+6DpWGSjuO1G0ZYOH6Hh4rGvBBKQC+1AtmMYCQrAUwXLeNQcgMCJ8SZMiMBs1TPsek4AF7mNwnnqMeqbIuuTRiWsVGSUsMLSc4ckMpOyhKegKl3mpNwaY8zzaVhun0WGEZup6rFyMRrxmS21m2WyawoFMMxImAwwubionucSXnIL5-mBcFXFKK1kDoDSai5niIkUWsEkmUkWEyOC+i1gQSkKZA5QcgAytkqGkWtG16WAXWTjopQAMKVItVkLDV9nrJMlicn0LCkGBwyysZbXJcpegJGyniTpY6DsJsgl-ZYAMiRgNIAKI0uSC3VGMUPOHDCNXcjJmnaWODxP93UiT5ziqEhODDCFwkmVN+hRbNmgfmsoTxOCk4HdtbLiftmiHcdknuSUF2sIj5G3WsGwhJy9XTHgr3vZ9rzfalv14xDBMmUDIMQ9UKuQyZ0NowzZOTsEMgG8LzUnfzYM62rbVEwEtJIxTE1UztnOTnNhtQMteCraz3Pa-jlt4LtBr4RKFKA8DmyqkesCIH1tuvBrmwAPJUOoQOEInlvnZdyGi-o4uPc9iCyx95UovbJNO1xoWTW7kVrZ75uQEzLMiQdgeq8HocMc6zElTEa0p5Y6fmFnOd83nQtXdV1B2WLD2S5M0vl-LVfE47ZOpoN8yzjIpKdP28aQCW+7sKEVT6O08TxOY04eexiYIkAA). 