### PR TITLE
fix(vega-typings,vega-schema): fix schema for axis/legend properties

### DIFF
--- a/packages/vega-typings/types/spec/axis.d.ts
+++ b/packages/vega-typings/types/spec/axis.d.ts
@@ -182,7 +182,7 @@ export interface BaseAxis {
   /**
    * Horizontal text alignment of axis titles.
    */
-  titleAlign?: AlignValue;
+  titleAlign?: AlignValue | SignalRef;
 
   /**
    * Text anchor position for placing axis titles.
@@ -192,7 +192,7 @@ export interface BaseAxis {
   /**
    * Angle in degrees of axis titles.
    */
-  titleAngle?: NumberValue;
+  titleAngle?: NumberValue | SignalRef;
 
   /**
    * X-coordinate of the axis title relative to the axis group.
@@ -207,52 +207,52 @@ export interface BaseAxis {
   /**
    * Vertical text baseline for axis titles.
    */
-  titleBaseline?: TextBaselineValue;
+  titleBaseline?: TextBaselineValue | SignalRef;
 
   /**
    * Color of the title, can be in hex color code or regular color name.
    */
-  titleColor?: ColorValue;
+  titleColor?: ColorValue | SignalRef;
 
   /**
    * Font of the title. (e.g., `"Helvetica Neue"`).
    */
-  titleFont?: StringValue;
+  titleFont?: StringValue | SignalRef;
 
   /**
    * Font size of the title.
    *
    * @minimum 0
    */
-  titleFontSize?: NumberValue;
+  titleFontSize?: NumberValue | SignalRef;
 
   /**
    * Font style of the title.
    */
-  titleFontStyle?: FontStyleValue;
+  titleFontStyle?: FontStyleValue | SignalRef;
 
   /**
    * Font weight of the title.
    * This can be either a string (e.g `"bold"`, `"normal"`) or a number (`100`, `200`, `300`, ..., `900` where `"normal"` = `400` and `"bold"` = `700`).
    */
-  titleFontWeight?: FontWeightValue;
+  titleFontWeight?: FontWeightValue | SignalRef;
 
   /**
    * Maximum allowed pixel width of axis titles.
    *
    * @minimum 0
    */
-  titleLimit?: NumberValue;
+  titleLimit?: NumberValue | SignalRef;
 
   /**
    * Line height in pixels for multi-line title text.
    */
-  titleLineHeight?: NumberValue;
+  titleLineHeight?: NumberValue | SignalRef;
 
   /**
    * Opacity of the axis title.
    */
-  titleOpacity?: NumberValue;
+  titleOpacity?: NumberValue | SignalRef;
 
   // ---------- Domain ----------
   /**
@@ -265,31 +265,31 @@ export interface BaseAxis {
   /**
    * An array of alternating [stroke, space] lengths for dashed domain lines.
    */
-  domainDash?: DashArrayValue;
+  domainDash?: DashArrayValue | SignalRef;
 
   /**
    * The pixel offset at which to start drawing with the domain dash array.
    */
-  domainDashOffset?: NumberValue;
+  domainDashOffset?: NumberValue | SignalRef;
 
   /**
    * Color of axis domain line.
    *
    * __Default value:__ `"gray"`.
    */
-  domainColor?: ColorValue;
+  domainColor?: ColorValue | SignalRef;
 
   /**
    * Opacity of the axis domain line.
    */
-  domainOpacity?: NumberValue;
+  domainOpacity?: NumberValue | SignalRef;
 
   /**
    * Stroke width of axis domain line
    *
    * __Default value:__ `1`
    */
-  domainWidth?: NumberValue;
+  domainWidth?: NumberValue | SignalRef;
 
   // ---------- Ticks ----------
   /**
@@ -309,17 +309,17 @@ export interface BaseAxis {
    *
    * __Default value:__ `"gray"`
    */
-  tickColor?: ColorValue;
+  tickColor?: ColorValue | SignalRef;
 
   /**
    * An array of alternating [stroke, space] lengths for dashed tick mark lines.
    */
-  tickDash?: DashArrayValue;
+  tickDash?: DashArrayValue | SignalRef;
 
   /**
    * The pixel offset at which to start drawing with the tick mark dash array.
    */
-  tickDashOffset?: NumberValue;
+  tickDashOffset?: NumberValue | SignalRef;
 
   /**
    * Boolean flag indicating if an extra axis tick should be added for the initial position of the axis. This flag is useful for styling axes for `band` scales such that ticks are placed on band boundaries rather in the middle of a band. Use in conjunction with `"bandPosition": 1` and an axis `"padding"` value of `0`.
@@ -334,7 +334,7 @@ export interface BaseAxis {
   /**
    * Opacity of the ticks.
    */
-  tickOpacity?: NumberValue;
+  tickOpacity?: NumberValue | SignalRef;
 
   /**
    * Boolean flag indicating if pixel position values should be rounded to the nearest integer.
@@ -357,7 +357,7 @@ export interface BaseAxis {
    * __Default value:__ `1`
    * @minimum 0
    */
-  tickWidth?: NumberValue;
+  tickWidth?: NumberValue | SignalRef;
 
   // ---------- Grid ----------
   /**
@@ -370,17 +370,17 @@ export interface BaseAxis {
    *
    * __Default value:__ `"lightGray"`.
    */
-  gridColor?: ColorValue;
+  gridColor?: ColorValue | SignalRef;
 
   /**
    * An array of alternating [stroke, space] lengths for dashed grid lines.
    */
-  gridDash?: DashArrayValue;
+  gridDash?: DashArrayValue | SignalRef;
 
   /**
    * The pixel offset at which to start drawing with the grid dash array.
    */
-  gridDashOffset?: NumberValue;
+  gridDashOffset?: NumberValue | SignalRef;
 
   /**
    * The stroke opacity of grid (value between [0,1])
@@ -389,7 +389,7 @@ export interface BaseAxis {
    * @minimum 0
    * @maximum 1
    */
-  gridOpacity?: NumberValue;
+  gridOpacity?: NumberValue | SignalRef;
 
   /**
    * The grid width, in pixels.
@@ -397,7 +397,7 @@ export interface BaseAxis {
    * __Default value:__ `1`
    * @minimum 0
    */
-  gridWidth?: NumberValue;
+  gridWidth?: NumberValue | SignalRef;
 
   // ---------- Labels ----------
   /**
@@ -439,7 +439,7 @@ export interface BaseAxis {
   /**
    * Line height in pixels for multi-line label text.
    */
-  labelLineHeight?: NumberValue;
+  labelLineHeight?: NumberValue | SignalRef;
 
   /**
    * The strategy to use for resolving overlap of axis labels. If `false` (the default), no overlap reduction is attempted. If set to `true` or `"parity"`, a strategy of removing every other label is used (this works well for standard linear axes). If set to `"greedy"`, a linear scan of the labels is performed, removing any labels that overlaps with the last visible label (this often works better for log-scaled axes).
@@ -459,53 +459,53 @@ export interface BaseAxis {
    * @minimum -360
    * @maximum 360
    */
-  labelAngle?: NumberValue;
+  labelAngle?: NumberValue | SignalRef;
 
   /**
    * The color of the tick label, can be in hex color code or regular color name.
    */
-  labelColor?: ColorValue;
+  labelColor?: ColorValue | SignalRef;
 
   /**
    * The font of the tick label.
    */
-  labelFont?: StringValue;
+  labelFont?: StringValue | SignalRef;
 
   /**
    * The font size of the label, in pixels.
    *
    * @minimum 0
    */
-  labelFontSize?: NumberValue;
+  labelFontSize?: NumberValue | SignalRef;
 
   /**
    * Font style of the title.
    */
-  labelFontStyle?: FontStyleValue;
+  labelFontStyle?: FontStyleValue | SignalRef;
 
   /**
    * Font weight of axis tick labels.
    */
-  labelFontWeight?: FontWeightValue;
+  labelFontWeight?: FontWeightValue | SignalRef;
 
   /**
    * Maximum allowed pixel width of axis tick labels.
    *
    * __Default value:__ `180`
    */
-  labelLimit?: NumberValue;
+  labelLimit?: NumberValue | SignalRef;
 
   /**
    * The opacity of the labels.
    */
-  labelOpacity?: NumberValue;
+  labelOpacity?: NumberValue | SignalRef;
 
   /**
    * Position offset in pixels to apply to labels, in addition to tickOffset.
    *
    * __Default value:__ `0`
    */
-  labelOffset?: NumberValue;
+  labelOffset?: NumberValue | SignalRef;
 
   /**
    * The padding in pixels between labels and ticks.

--- a/packages/vega-typings/types/spec/legend.d.ts
+++ b/packages/vega-typings/types/spec/legend.d.ts
@@ -206,28 +206,28 @@ export interface BaseLegend {
   /**
    * The color of the legend title, can be in hex color code or regular color name.
    */
-  titleColor?: ColorValue;
+  titleColor?: ColorValue | SignalRef;
 
   /**
    * The font of the legend title.
    */
-  titleFont?: StringValue;
+  titleFont?: StringValue | SignalRef;
 
   /**
    * The font size of the legend title.
    */
-  titleFontSize?: NumberValue;
+  titleFontSize?: NumberValue | SignalRef;
 
   /**
    * The font style of the legend title.
    */
-  titleFontStyle?: FontStyleValue;
+  titleFontStyle?: FontStyleValue | SignalRef;
 
   /**
    * The font weight of the legend title.
    * This can be either a string (e.g `"bold"`, `"normal"`) or a number (`100`, `200`, `300`, ..., `900` where `"normal"` = `400` and `"bold"` = `700`).
    */
-  titleFontWeight?: FontWeightValue;
+  titleFontWeight?: FontWeightValue | SignalRef;
 
   /**
    * Maximum allowed pixel width of legend titles.
@@ -235,22 +235,22 @@ export interface BaseLegend {
    * __Default value:__ `180`.
    * @minimum 0
    */
-  titleLimit?: NumberValue;
+  titleLimit?: NumberValue | SignalRef;
 
   /**
    * Line height in pixels for multi-line title text.
    */
-  titleLineHeight?: NumberValue;
+  titleLineHeight?: NumberValue | SignalRef;
 
   /**
    * Opacity of the legend title.
    */
-  titleOpacity?: NumberValue;
+  titleOpacity?: NumberValue | SignalRef;
 
   /**
    * Orientation of the legend title.
    */
-  titleOrient?: OrientValue;
+  titleOrient?: OrientValue | SignalRef;
 
   /**
    * The padding, in pixels, between title and legend.
@@ -272,7 +272,7 @@ export interface BaseLegend {
   /**
    * Opacity of the color gradient.
    */
-  gradientOpacity?: NumberValue;
+  gradientOpacity?: NumberValue | SignalRef;
 
   /**
    * The thickness in pixels of the color gradient. This value corresponds to the width of a vertical gradient or the height of a horizontal gradient.
@@ -333,17 +333,17 @@ export interface BaseLegend {
   /**
    * An array of alternating [stroke, space] lengths for dashed symbol strokes.
    */
-  symbolDash?: DashArrayValue;
+  symbolDash?: DashArrayValue | SignalRef;
 
   /**
    * The pixel offset at which to start drawing with the symbol stroke dash array.
    */
-  symbolDashOffset?: NumberValue;
+  symbolDashOffset?: NumberValue | SignalRef;
 
   /**
    * The color of the legend symbol,
    */
-  symbolFillColor?: ColorValue;
+  symbolFillColor?: ColorValue | SignalRef;
 
   /**
    * Horizontal pixel offset for legend symbols.
@@ -355,7 +355,7 @@ export interface BaseLegend {
   /**
    * Opacity of the legend symbols.
    */
-  symbolOpacity?: NumberValue;
+  symbolOpacity?: NumberValue | SignalRef;
 
   /**
    * The size of the legend symbol, in pixels.
@@ -363,12 +363,12 @@ export interface BaseLegend {
    * __Default value:__ `100`.
    * @minimum 0
    */
-  symbolSize?: NumberValue;
+  symbolSize?: NumberValue | SignalRef;
 
   /**
    * Stroke color for legend symbols.
    */
-  symbolStrokeColor?: ColorValue;
+  symbolStrokeColor?: ColorValue | SignalRef;
 
   /**
    * The width of the symbol's stroke.
@@ -376,7 +376,7 @@ export interface BaseLegend {
    * __Default value:__ `1.5`.
    * @minimum 0
    */
-  symbolStrokeWidth?: NumberValue;
+  symbolStrokeWidth?: NumberValue | SignalRef;
 
   /**
    * The symbol shape. One of the plotting shapes `circle` (default), `square`, `cross`, `diamond`, `triangle-up`, `triangle-down`, `triangle-right`, or `triangle-left`, the line symbol `stroke`, or one of the centered directional shapes `arrow`, `wedge`, or `triangle`. Alternatively, a custom [SVG path string](https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths) can be provided. For correct sizing, custom shape paths should be defined within a square bounding box with coordinates ranging from -1 to 1 along both the x and y dimensions.
@@ -401,12 +401,12 @@ export interface BaseLegend {
   /**
    * The color of the legend label, can be in hex color code or regular color name.
    */
-  labelColor?: ColorValue;
+  labelColor?: ColorValue | SignalRef;
 
   /**
    * The font of the legend label.
    */
-  labelFont?: StringValue;
+  labelFont?: StringValue | SignalRef;
 
   /**
    * The font size of legend label.
@@ -415,29 +415,29 @@ export interface BaseLegend {
    *
    * @minimum 0
    */
-  labelFontSize?: NumberValue;
+  labelFontSize?: NumberValue | SignalRef;
 
   /**
    * The font style of legend label.
    */
-  labelFontStyle?: FontStyleValue;
+  labelFontStyle?: FontStyleValue | SignalRef;
 
   /**
    * The font weight of legend label.
    */
-  labelFontWeight?: FontWeightValue;
+  labelFontWeight?: FontWeightValue | SignalRef;
 
   /**
    * Maximum allowed pixel width of legend tick labels.
    *
    * __Default value:__ `160`.
    */
-  labelLimit?: NumberValue;
+  labelLimit?: NumberValue | SignalRef;
 
   /**
    * Opacity of labels.
    */
-  labelOpacity?: NumberValue;
+  labelOpacity?: NumberValue | SignalRef;
 
   /**
    * Padding in pixels between the legend and legend labels.


### PR DESCRIPTION
According to Slack conversation, all axis/legend properties that are transpiled via `addEncoders` do support signals. Thus, the typings we have are probably wrong. 


I haven't updated vega-schema/docs yet, wanna make sure that this should be officially supported.

In any case, it seems a bit painful that we have to update these in 3 places (vega-typings/schema/docs)

