### PR TITLE
Restore Travis CI for node 13.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
   - "10"
   - "12"
-  - "13.8"
+  - "13"
 before_install:
   - sudo apt-get install -y libcairo2-dev libpango1.0-dev
 script:


### PR DESCRIPTION
**monorepo**

- Restore Travis CI to latest version of Node.js v13.