### PR TITLE
Fix window operator init state.

### DIFF
--- a/packages/vega-transforms/src/util/WindowOps.js
+++ b/packages/vega-transforms/src/util/WindowOps.js
@@ -113,8 +113,9 @@ export const WindowOps = {
   },
 
   prev_value: function(field) {
-    let prev = null;
+    let prev;
     return {
+      init: () => prev = null,
       next: w => {
         let v = field(w.data[w.index]);
         return v != null ? (prev = v) : prev;
@@ -122,9 +123,9 @@ export const WindowOps = {
     }
   },
   next_value: function(field) {
-    let v = null,
-        i = -1;
+    let v, i;
     return {
+      init: () => (v = null, i = -1),
       next: w => {
         let d = w.data;
         return w.index <= i ? v

--- a/packages/vega-transforms/test/window-test.js
+++ b/packages/vega-transforms/test/window-test.js
@@ -525,3 +525,42 @@ tape('Window handles prev_value with overwrite', function(t) {
 
   t.end();
 });
+
+tape('Window fill operations handle partition state', function(t) {
+  var data = [
+    {u: 'a',  v: null, key:0, idx:0},
+    {u: null, v: 'b',  key:1, idx:0},
+  ];
+
+  var u = util.field('u'),
+      v = util.field('v'),
+      df = new vega.Dataflow(),
+      col = df.add(Collect),
+      win = df.add(Window, {
+        groupby: [util.field('key')],
+        sort: util.compare('idx'),
+        fields: [u, u, v, v],
+        ops: [
+          'next_value', 'prev_value',
+          'next_value', 'prev_value',
+        ],
+        as: ['un', 'up', 'vn', 'vp'],
+        pulse: col
+      }),
+      out = df.add(Collect, {pulse: win});
+
+  // -- test add
+  df.pulse(col, changeset().insert(data)).run();
+  var d = out.value;
+  t.equal(d.length, data.length);
+  match(t, d[0], {
+    u: 'a', v: null, key: 0, idx: 0,
+    un: 'a', up: 'a', vn: null, vp: null
+  });
+  match(t, d[1], {
+    u: null, v: 'b', key: 1, idx: 0,
+    un: null, up: null, vn: 'b', vp: 'b'
+  });
+
+  t.end();
+});


### PR DESCRIPTION
**vega-transforms**

- Fix `window` operator init state for `prev_value` and `next_value`.

Fix #2475.