### PR TITLE
Handle empty item set in Overlap transform.

### DIFF
--- a/packages/vega-view-transforms/src/Overlap.js
+++ b/packages/vega-view-transforms/src/Overlap.js
@@ -114,15 +114,19 @@ prototype.transform = function(_, pulse) {
     return pulse;
   }
 
+  // skip labels with no content
+  source = source.filter(hasBounds);
+
   if (_.sort) {
     source = source.slice().sort(_.sort);
   }
 
-  // skip labels with no content
-  source = source.filter(hasBounds);
-
   items = reset(source);
   pulse = reflow(pulse, _);
+
+  if (items.length === 0) {
+    return pulse; // early exit, nothing to do
+  }
 
   if (items.length >= 3 && hasOverlap(items, sep)) {
     do {

--- a/packages/vega-view-transforms/src/Overlap.js
+++ b/packages/vega-view-transforms/src/Overlap.js
@@ -117,16 +117,15 @@ prototype.transform = function(_, pulse) {
   // skip labels with no content
   source = source.filter(hasBounds);
 
+  // early exit, nothing to do
+  if (!source.length) return;
+
   if (_.sort) {
     source = source.slice().sort(_.sort);
   }
 
   items = reset(source);
   pulse = reflow(pulse, _);
-
-  if (items.length === 0) {
-    return pulse; // early exit, nothing to do
-  }
 
   if (items.length >= 3 && hasOverlap(items, sep)) {
     do {


### PR DESCRIPTION
**vega-view-transforms**

- Fix `Overlap` transform to early exit when there are no items.

Fix #2449.