### PR TITLE
fix: add default size and color to trail marks

### DIFF
--- a/packages/vega-parser/src/config.js
+++ b/packages/vega-parser/src/config.js
@@ -61,6 +61,10 @@ export default function() {
       font: defaultFont,
       fontSize: 11
     },
+    trail: {
+      fill: defaultColor,
+      size: defaultStrokeWidth
+    },
 
     // style definitions
     style: {


### PR DESCRIPTION
(I'm choosing values that are consistent with lines.)