### PR TITLE
fix: don't allow value refs in legend config

### DIFF
--- a/packages/vega-typings/types/spec/config.d.ts
+++ b/packages/vega-typings/types/spec/config.d.ts
@@ -478,7 +478,7 @@ export type AxisConfig = ExcludeMappedValueRef<BaseAxis>;
 /**
  * Legend config without signals so we can use it in Vega-Lite.
  */
-export interface LegendConfig extends BaseLegend {
+export interface LegendConfig extends ExcludeMappedValueRef<BaseLegend> {
   /**
    * The default direction (`"horizontal"` or `"vertical"`) for gradient legends.
    *


### PR DESCRIPTION
Needed for https://github.com/vega/vega-lite/pull/6242