### PR TITLE
Minify es5 build of vega

### DIFF
--- a/packages/vega/package.json
+++ b/packages/vega/package.json
@@ -23,7 +23,7 @@
     "rollup": "node rollup-node && node rollup && node schema-copy",
     "prebuild": "rimraf build && mkdirp build",
     "build": "yarn rollup && node rollup -e && node rollup -m && babel build --out-dir build-es5 --config-file ../../babel.config.js",
-    "postbuild": "terser build/vega.js -c -m -o build/vega.min.js && terser build/vega-core.js -c -m -o build/vega-core.min.js",
+    "postbuild": "terser build/vega.js -c -m -o build/vega.min.js && terser build/vega-core.js -c -m -o build/vega-core.min.js && terser build-es5/vega.js -c -m -o build-es5/vega.min.js && terser build-es5/vega-core.js -c -m -o build-es5/vega-core.min.js",
     "pretest": "yarn prebuild && yarn rollup",
     "test": "TZ=America/Los_Angeles tape 'test/**/*-test.js' && eslint index.js test",
     "prepublishOnly": "yarn test && yarn build",


### PR DESCRIPTION
I found that the directory structure of the `build` directory was not the same as the `build-es5` directory, due to missing `.min.js` files.

Before:

```
build-es5/vega-core.js
build-es5/vega-module.js
build-es5/vega-node.js
build-es5/vega.js
```

After:

```
build-es5/vega-core.js
build-es5/vega-core.min.js
build-es5/vega-module.js
build-es5/vega-node.js
build-es5/vega.js
build-es5/vega.min.js
```