### PR TITLE
Document ES5 build in IE support page

### DIFF
--- a/docs/usage/internet-explorer.md
+++ b/docs/usage/internet-explorer.md
@@ -5,7 +5,8 @@ menu: usage
 permalink: /usage/internet-explorer/index.html
 ---
 
-Vega version 4.3.0 and earlier is compatible with Internet Explorer versions 10 and 11, but with some notable caveats and limitations, described below. Later versions of Vega assume [ES6](http://es6-features.org/) support. To use more recent versions of Vega with older browsers, use a JavaScript compiler such as [Babel](https://babeljs.io/) to generate ES5-compliant code.
+Vega version 4.3.0 and earlier is compatible with Internet Explorer versions 10 and 11, but with some notable caveats and limitations, described below. Later versions of Vega assume [ES6](http://es6-features.org/) support. Vega 5.9.0 and
+later provides an ES5-compliant build in the `build-es5` directory, or you can use a JavaScript compiler such as [Babel](https://babeljs.io/) to generate ES5-compliant code from the `build` directory.
 
 ## Enabling Internet Explorer Support
 


### PR DESCRIPTION
The IE support page wasn't updated after https://github.com/vega/vega/pull/2179 was merged- only the README was updated at the time.