### PR TITLE
Allow only one of prevent/allow prop for defaults

### DIFF
--- a/packages/vega-typings/types/spec/config.d.ts
+++ b/packages/vega-typings/types/spec/config.d.ts
@@ -73,9 +73,9 @@ export interface Config
 /**
  *  The defaults object should have a single property: either "prevent" (to indicate which events should have default behavior suppressed) or "allow" (to indicate only those events whose default behavior should be allowed).
  */
-type PreventDefaultConfig = Record<'prevent', boolean | EventType[]>;
-type AllowDefaultConfig = Record<'allow', boolean | EventType[]>;
-export type DefaultsConfig = PreventDefaultConfig | AllowDefaultConfig;
+export type DefaultsConfig =
+  | Record<'prevent', boolean | EventType[]>
+  | Record<'allow', boolean | EventType[]>;
 
 export type MarkConfigKeys = 'mark' | Mark['type'];
 

--- a/packages/vega-typings/types/spec/config.d.ts
+++ b/packages/vega-typings/types/spec/config.d.ts
@@ -70,7 +70,12 @@ export interface Config
   signals?: (InitSignal | NewSignal)[];
 }
 
-export type DefaultsConfig = Record<'prevent' | 'allow', boolean | EventType[]>;
+/**
+ *  The defaults object should have a single property: either "prevent" (to indicate which events should have default behavior suppressed) or "allow" (to indicate only those events whose default behavior should be allowed).
+ */
+type PreventDefaultConfig = Record<'prevent', boolean | EventType[]>;
+type AllowDefaultConfig = Record<'allow', boolean | EventType[]>;
+export type DefaultsConfig = PreventDefaultConfig | AllowDefaultConfig;
 
 export type MarkConfigKeys = 'mark' | Mark['type'];
 


### PR DESCRIPTION
**vega-typings**

- Allow either `prevent` or `allow` in `DefaultsConfig`.


Enforcing 
> The defaults object should have a single property: either "prevent" (to indicate which events should have default behavior suppressed) or "allow" (to indicate only those events whose default behavior should be allowed).
from the [docs](https://vega.github.io/vega/docs/config/#events)

Fixes #2502