### PR TITLE
Use Math.floor to avoid overflow with large domain and small tickMinStep

### DIFF
--- a/packages/vega-encode/src/ticks.js
+++ b/packages/vega-encode/src/ticks.js
@@ -22,7 +22,7 @@ export function tickCount(scale, count, minStep) {
       count = Math.max(count, scale.bins.length);
     }
     if (minStep != null) {
-      count = Math.min(count, ~~(span(scale.domain()) / minStep) || 1);
+      count = Math.min(count, Math.floor(span(scale.domain()) / minStep) || 1);
     }
   }
 


### PR DESCRIPTION
If you render the attached spec with a tickMinStep of `0.01` the axis labels disappear.  Setting a tickMinStep of `0.1` works fine.  The issue appears to be the `~~` operator forces a 32-bit conversion.
[vega-overflow.zip](https://github.com/vega/vega/files/4513100/vega-overflow.zip)
