### PR TITLE
Make groups navigatable with screenreaders

### DIFF
--- a/packages/vega-scenegraph/src/util/aria.js
+++ b/packages/vega-scenegraph/src/util/aria.js
@@ -82,7 +82,11 @@ export function ariaItemAttributes(emit, item) {
     }
   } else {
     emit(ARIA_LABEL, item.description);
-    emit(ARIA_ROLE, item.ariaRole || GRAPHICS_SYMBOL);
+    emit(
+      ARIA_ROLE,
+      item.ariaRole ||
+        (item.mark.marktype === 'group' ? GRAPHICS_OBJECT : GRAPHICS_SYMBOL)
+    );
     emit(
       ARIA_ROLEDESCRIPTION,
       item.ariaRoleDescription || `${item.mark.marktype} mark`


### PR DESCRIPTION
Without this change, I wasn't able to go into group marks defined in a Vega spec. 