### PR TITLE
Improve default formatting of times for screen readers by replacing abbreviations

### DIFF
--- a/packages/vega-scale/src/caption.js
+++ b/packages/vega-scale/src/caption.js
@@ -1,10 +1,15 @@
 import {labelFormat, labelValues} from './labels';
 import {Time, UTC} from './scales/types';
 import {isDiscrete, isDiscretizing} from './scales';
-import {peek} from 'vega-util';
+import {isString, peek} from 'vega-util';
 
 function format(scale, specifier, formatType) {
   const type = formatType || scale.type;
+
+  // replace abbreviated time specifiers to improve screen reader experience
+  if (isString(specifier) && (type === Time || type === UTC)) {
+    specifier = specifier.replace(/%a/g, '%A').replace(/%b/g, '%B');
+  }
   return !specifier && type === Time  ? d => new Date(d).toLocaleString()
     : !specifier && type === UTC ? d => new Date(d).toUTCString()
     : labelFormat(scale, 5, null, specifier, formatType, true);


### PR DESCRIPTION
I noticed that VoiceOver reads `Sun` and `Mon` just like that and so I thought we could improve the default formatting of times for VoiceOver. Note that I am not supporting time unit specifiers here. 