### PR TITLE
Create more semantic bindings to improve accessibility

### DIFF
--- a/docs/assets/main.css
+++ b/docs/assets/main.css
@@ -462,12 +462,10 @@ ul.column-set, .column-set ul {
 .view .vega-bind input[type="range"] {
   padding: 0;
   width: 100px;
+  margin-right: 4px;
 }
 .view .vega-bind select {
   max-width: 200px;
-}
-.view .vega-bind label {
-  margin-left: 4px;
 }
 .view .vega-bind-radio label {
   margin-left: 0;

--- a/packages/vega-view/src/bind.js
+++ b/packages/vega-view/src/bind.js
@@ -3,8 +3,8 @@ import {debounce} from 'vega-util';
 import {tickStep} from 'd3-array';
 
 const BindClass = 'vega-bind',
-    NameClass = 'vega-bind-name',
-    RadioClass = 'vega-bind-radio';
+      NameClass = 'vega-bind-name',
+      RadioClass = 'vega-bind-radio';
 
 /**
  * Bind a signal to an external HTML input element. The resulting two-way
@@ -30,7 +30,7 @@ export default function(view, el, binding) {
       elements: null,
       active: false,
       set: null,
-      update: function(value) {
+      update: value => {
         if (value !== view.signal(param.signal)) {
           view.runAsync(null, function() {
             bind.source = true;
@@ -47,7 +47,7 @@ export default function(view, el, binding) {
   generate(bind, el, param, view.signal(param.signal));
 
   if (!bind.active) {
-    view.on(view._signals[param.signal], null, function() {
+    view.on(view._signals[param.signal], null, () => {
       bind.source
         ? (bind.source = false)
         : bind.set(view.signal(param.signal));
@@ -64,8 +64,9 @@ export default function(view, el, binding) {
 function generate(bind, el, param, value) {
   const div = element('div', {'class': BindClass});
 
-  const wrapper =
-    param.input === 'radio' ? div : div.appendChild(element('label'));
+  const wrapper = param.input === 'radio'
+    ? div
+    : div.appendChild(element('label'));
 
   wrapper.appendChild(element('span',
     {'class': NameClass},
@@ -101,13 +102,10 @@ function form(bind, el, param, value) {
   node.value = value;
 
   el.appendChild(node);
-
-  node.addEventListener('input', function() {
-    bind.update(node.value);
-  });
+  node.addEventListener('input', () => bind.update(node.value));
 
   bind.elements = [node];
-  bind.set = function(value) { node.value = value; };
+  bind.set = value => node.value = value;
 }
 
 /**
@@ -119,13 +117,10 @@ function checkbox(bind, el, param, value) {
   const node = element('input', attr);
 
   el.appendChild(node);
-
-  node.addEventListener('change', function() {
-    bind.update(node.checked);
-  });
+  node.addEventListener('change', () => bind.update(node.checked));
 
   bind.elements = [node];
-  bind.set = function(value) { node.checked = !!value || null; };
+  bind.set = value => node.checked = !!value || null;
 }
 
 /**
@@ -133,9 +128,9 @@ function checkbox(bind, el, param, value) {
  */
 function select(bind, el, param, value) {
   const node = element('select', {name: param.signal}),
-      labels = param.labels || [];
+        labels = param.labels || [];
 
-  param.options.forEach(function(option, i) {
+  param.options.forEach((option, i) => {
     const attr = {value: option};
     if (valuesEqual(option, value)) attr.selected = true;
     node.appendChild(element('option', attr, (labels[i] || option)+''));
@@ -143,13 +138,13 @@ function select(bind, el, param, value) {
 
   el.appendChild(node);
 
-  node.addEventListener('change', function() {
+  node.addEventListener('change', () => {
     bind.update(param.options[node.selectedIndex]);
   });
 
   bind.elements = [node];
-  bind.set = function(value) {
-    for (let i=0, n=param.options.length; i<n; ++i) {
+  bind.set = value => {
+    for (let i = 0, n = param.options.length; i < n; ++i) {
       if (valuesEqual(param.options[i], value)) {
         node.selectedIndex = i; return;
       }
@@ -162,11 +157,11 @@ function select(bind, el, param, value) {
  */
 function radio(bind, el, param, value) {
   const group = element('span', {'class': RadioClass}),
-      labels = param.labels || [];
+        labels = param.labels || [];
 
   el.appendChild(group);
 
-  bind.elements = param.options.map(function(option, i) {
+  bind.elements = param.options.map((option, i) => {
     const attr = {
       type:  'radio',
       name:  param.signal,
@@ -175,23 +170,19 @@ function radio(bind, el, param, value) {
     if (valuesEqual(option, value)) attr.checked = true;
 
     const input = element('input', attr);
-
-    input.addEventListener('change', function() {
-      bind.update(option);
-    });
+    input.addEventListener('change', () => bind.update(option));
 
     const label = element('label', {}, (labels[i] || option)+'');
-
     label.prepend(input);
     group.appendChild(label);
 
     return input;
   });
 
-  bind.set = function(value) {
+  bind.set = value => {
     const nodes = bind.elements,
-        n = nodes.length;
-    for (let i = 0; i<n; ++i) {
+          n = nodes.length;
+    for (let i = 0; i < n; ++i) {
       if (valuesEqual(nodes[i].value, value)) nodes[i].checked = true;
     }
   };
@@ -204,8 +195,8 @@ function range(bind, el, param, value) {
   value = value !== undefined ? value : ((+param.max) + (+param.min)) / 2;
 
   const max = param.max != null ? param.max : Math.max(100, +value) || 100,
-      min = param.min || Math.min(0, max, +value) || 0,
-      step = param.step || tickStep(min, max, 100);
+        min = param.min || Math.min(0, max, +value) || 0,
+        step = param.step || tickStep(min, max, 100);
 
   const node = element('input', {
     type:  'range',
@@ -221,17 +212,17 @@ function range(bind, el, param, value) {
   el.appendChild(node);
   el.appendChild(span);
 
-  function update() {
+  const update = () => {
     span.textContent = node.value;
     bind.update(+node.value);
-  }
+  };
 
   // subscribe to both input and change
   node.addEventListener('input', update);
   node.addEventListener('change', update);
 
   bind.elements = [node];
-  bind.set = function(value) {
+  bind.set = value => {
     node.value = value;
     span.textContent = value;
   };

--- a/packages/vega-view/src/initialize.js
+++ b/packages/vega-view/src/initialize.js
@@ -31,7 +31,7 @@ export default function(el, elBind) {
   // initialize signal bindings
   if (el && config !== 'none') {
     elBind = elBind ? (view._elBind = lookup(view, elBind))
-      : el.appendChild(element('div', {'class': 'vega-bindings'}));
+      : el.appendChild(element('form', {'class': 'vega-bindings'}));
 
     view._bind.forEach(function(_) {
       if (_.param.element && config !== 'container') {

--- a/packages/vega/test/index.html
+++ b/packages/vega/test/index.html
@@ -22,7 +22,9 @@
       .vega-bind { line-height: 18px; margin-bottom: 2px; }
       .vega-bind-name { display: inline-block; width: 100px; }
       .vega-bind input[type="range"] { width: 400px; }
-      .vega-bind-radio label { margin: 0 0.5em 0 2px; }
+      .vega-bind input[type="radio"] { margin-right: 0.5em; }
+      .vega-bind input[type="range"] { margin-right: 0.5em; }
+      .vega-bind-radio label { margin-right: 1em; }
     </style>
   </head>
   <body>

--- a/packages/vega/test/index.html
+++ b/packages/vega/test/index.html
@@ -21,10 +21,9 @@
       canvas, svg { border: 1px dashed #ccc; }
       .vega-bind { line-height: 18px; margin-bottom: 2px; }
       .vega-bind-name { display: inline-block; width: 100px; }
-      .vega-bind input[type="range"] { width: 400px; }
-      .vega-bind input[type="radio"] { margin-right: 0.5em; }
-      .vega-bind input[type="range"] { margin-right: 0.5em; }
-      .vega-bind-radio label { margin-right: 1em; }
+      .vega-bind input[type="range"] { width: 400px; margin-right: 0.5em; }
+      .vega-bind input[type="radio"] { margin-right: 4px; }
+      .vega-bind-radio label { margin-right: 0.5em; }
     </style>
   </head>
   <body>

--- a/packages/vega/test/index.html
+++ b/packages/vega/test/index.html
@@ -22,7 +22,7 @@
       .vega-bind { line-height: 18px; margin-bottom: 2px; }
       .vega-bind-name { display: inline-block; width: 100px; }
       .vega-bind input[type="range"] { width: 400px; }
-      .vega-bind label { margin: 0 0.5em 0 2px; }
+      .vega-bind-radio label { margin: 0 0.5em 0 2px; }
     </style>
   </head>
   <body>


### PR DESCRIPTION
Fixes #2490

The example spec I tried

```json
{
  "$schema": "https://vega.github.io/schema/vega/v5.json",
  "signals": [
    {
      "name": "palette",
      "value": "Viridis",
      "bind": {"input": "select", "options": ["Viridis"]}
    },
    {
      "name": "offset",
      "value": "zero",
      "bind": {"input": "radio", "options": ["zero", "center"]}
    },
    {"name": "reverse", "value": false, "bind": {"input": "checkbox"}},
    {"name": "value", "value": 10, "bind": {"input": "range"}},
    {"name": "name", "value": "Hello", "bind": {"input": "text"}}
  ]
}
```

Before

![2020-04-24 14-53-43 2020-04-24 14_54_07](https://user-images.githubusercontent.com/589034/80260072-ee741980-863b-11ea-9688-72000db93d84.gif)

After

![2020-04-24 14-54-15 2020-04-24 14_54_34](https://user-images.githubusercontent.com/589034/80260075-f0d67380-863b-11ea-96d1-598ec34b5604.gif)
