### PR TITLE
Fix aria labels

### DIFF
--- a/packages/vega-scenegraph/src/util/aria.js
+++ b/packages/vega-scenegraph/src/util/aria.js
@@ -37,11 +37,11 @@ const AriaGuides = {
   'legend': {desc: 'legend', caption: legendCaption},
   'title-text': {
     desc: 'title',
-    caption: item => `Title text "${titleCaption(item)}"`
+    caption: item => `Title text '${titleCaption(item)}'`
   },
   'title-subtitle': {
     desc: 'subtitle',
-    caption: item => `Subtitle text "${titleCaption(item)}"`
+    caption: item => `Subtitle text '${titleCaption(item)}'`
   }
 };
 
@@ -125,7 +125,7 @@ function axisCaption(item) {
         xy = (orient === 'left' || orient === 'right') ? 'Y' : 'X';
 
   return `${xy}-axis`
-    + (title ? ` titled "${title}"` : '')
+    + (title ? ` titled '${title}'` : '')
     + ` for a ${isDiscrete(type) ? 'discrete' : type} scale`
     + ` with ${domainCaption(scale, item)}`;
 }
@@ -139,7 +139,7 @@ function legendCaption(item) {
         scale = item.context.scales[scales[props[0]]].value;
 
   return capitalize(type)
-    + (title ? ` titled "${title}"` : '')
+    + (title ? ` titled '${title}'` : '')
     + ` for ${channelCaption(props)} with ${domainCaption(scale, item)}`;
 }
 


### PR DESCRIPTION
The generated aria labels result in invalid svg syntax. When I output the svg string to a file and try to open it, it shows a syntax error. The reason is the usage of double quotes in the label, which generates for example the following output:

```svg
<g aria-label="X-axis titled "Some title" for a linear scale with values from 0 to 13">
```

The double quotes break the attribute, as shown in the highlighting above. 

This PR replaces the double quotes by single quotes, which should fix the svg syntax.