### PR TITLE
feat(vega-scenegraph): add resetSVGDefIds()

### DIFF
--- a/packages/vega-scenegraph/index.js
+++ b/packages/vega-scenegraph/index.js
@@ -59,6 +59,9 @@ export {
   pickVisit as scenePickVisit
 } from './src/util/visit';
 
+// deprecated, remove in next major version
+export {resetSVGClipId} from './src/util/svg/clip';
+
 export function resetSVGDefIds() {
   resetSVGClipId();
   resetSVGGradientId();

--- a/packages/vega-scenegraph/index.js
+++ b/packages/vega-scenegraph/index.js
@@ -2,7 +2,7 @@ import {resetSVGGradientId} from './src/Gradient';
 import {resetSVGClipId} from './src/util/svg/clip';
 
 export {default as Bounds} from './src/Bounds';
-export {default as Gradient, resetSVGGradientId} from './src/Gradient';
+export {default as Gradient} from './src/Gradient';
 export {default as GroupItem} from './src/GroupItem';
 export {default as ResourceLoader} from './src/ResourceLoader';
 export {default as Item} from './src/Item';
@@ -44,7 +44,6 @@ export {
   multiLineOffset,
   textMetrics
 } from './src/util/text';
-export {resetSVGClipId} from './src/util/svg/clip';
 
 export {sceneEqual, pathEqual} from './src/util/equal';
 export {sceneToJSON, sceneFromJSON} from './src/util/serialize';

--- a/packages/vega-scenegraph/index.js
+++ b/packages/vega-scenegraph/index.js
@@ -1,5 +1,8 @@
+import {resetSVGGradientId} from './src/Gradient';
+import {resetSVGClipId} from './src/util/svg/clip';
+
 export {default as Bounds} from './src/Bounds';
-export {default as Gradient} from './src/Gradient';
+export {default as Gradient, resetSVGGradientId} from './src/Gradient';
 export {default as GroupItem} from './src/GroupItem';
 export {default as ResourceLoader} from './src/ResourceLoader';
 export {default as Item} from './src/Item';
@@ -22,8 +25,6 @@ export {default as boundContext} from './src/bound/boundContext';
 export {default as boundStroke} from './src/bound/boundStroke';
 export {default as boundItem} from './src/bound/boundItem';
 export {default as boundMark} from './src/bound/boundMark';
-
-export {resetGradientId} from './src/Gradient';
 
 export {default as pathCurves} from './src/path/curves';
 export {default as pathSymbols} from './src/path/symbols';
@@ -58,3 +59,8 @@ export {
   visit as sceneVisit,
   pickVisit as scenePickVisit
 } from './src/util/visit';
+
+export function resetSVGDefIds() {
+  resetSVGClipId();
+  resetSVGGradientId();
+}

--- a/packages/vega-scenegraph/index.js
+++ b/packages/vega-scenegraph/index.js
@@ -23,6 +23,8 @@ export {default as boundStroke} from './src/bound/boundStroke';
 export {default as boundItem} from './src/bound/boundItem';
 export {default as boundMark} from './src/bound/boundMark';
 
+export {resetGradientId} from './src/Gradient';
+
 export {default as pathCurves} from './src/path/curves';
 export {default as pathSymbols} from './src/path/symbols';
 export {default as pathRectangle} from './src/path/rectangle';

--- a/packages/vega-scenegraph/src/Gradient.js
+++ b/packages/vega-scenegraph/src/Gradient.js
@@ -1,5 +1,9 @@
 var gradient_id = 0;
 
+export function resetGradientId() {
+  gradient_id = 0;
+}
+
 export const patternPrefix = 'p_';
 
 export function isGradient(value) {

--- a/packages/vega-scenegraph/src/Gradient.js
+++ b/packages/vega-scenegraph/src/Gradient.js
@@ -1,6 +1,6 @@
 var gradient_id = 0;
 
-export function resetGradientId() {
+export function resetSVGGradientId() {
   gradient_id = 0;
 }
 

--- a/packages/vega-scenegraph/test/svg-renderer-test.js
+++ b/packages/vega-scenegraph/test/svg-renderer-test.js
@@ -41,7 +41,7 @@ function render(scene, w, h) {
   }
 
   // reset clip id counter
-  vega.resetSVGClipId();
+  vega.resetSVGDefIds();
 
   // then render svg
   return compensate(new Renderer()
@@ -57,7 +57,7 @@ function renderAsync(scene, w, h, callback) {
   }
 
   // reset clip id counter
-  vega.resetSVGClipId();
+  vega.resetSVGDefIds();
 
   // then render svg
   new Renderer(loader({mode: 'http', baseURL: './test/resources/'}))
@@ -112,7 +112,7 @@ tape('SVGRenderer should support clipping and gradients', function(t) {
   var r = new Renderer()
     .initialize(doc.body, 102, 102);
 
-  vega.resetSVGClipId();
+  vega.resetSVGDefIds();
   var scene = loadScene('scenegraph-defs.json');
   var svg = compensate(r.render(scene).svg());
   var file = load('svg/scenegraph-defs.svg');
@@ -121,7 +121,7 @@ tape('SVGRenderer should support clipping and gradients', function(t) {
   svg = compensate(r.render(scene).svg());
   t.equal(svg, file);
 
-  vega.resetSVGClipId();
+  vega.resetSVGDefIds();
   scene = loadScene('scenegraph-defs.json');
   scene.items[0].clip = false;
   scene.items[0].fill = 'red';
@@ -140,7 +140,7 @@ tape('SVGRenderer should support axes, legends and sub-groups', function(t) {
 });
 
 tape('SVGRenderer should support full redraw', function(t) {
-  vega.resetSVGClipId();
+  vega.resetSVGDefIds();
 
   var scene = loadScene('scenegraph-rect.json');
   var r = new Renderer()
@@ -169,7 +169,7 @@ tape('SVGRenderer should support full redraw', function(t) {
 });
 
 tape('SVGRenderer should support enter-item redraw', function(t) {
-  vega.resetSVGClipId();
+  vega.resetSVGDefIds();
 
   var scene = loadScene('scenegraph-rect.json');
   var r = new Renderer()
@@ -195,7 +195,7 @@ tape('SVGRenderer should support enter-item redraw', function(t) {
 });
 
 tape('SVGRenderer should support exit-item redraw', function(t) {
-  vega.resetSVGClipId();
+  vega.resetSVGDefIds();
 
   var scene = loadScene('scenegraph-rect.json');
   var r = new Renderer()
@@ -217,7 +217,7 @@ tape('SVGRenderer should support exit-item redraw', function(t) {
 });
 
 tape('SVGRenderer should support single-item redraw', function(t) {
-  vega.resetSVGClipId();
+  vega.resetSVGDefIds();
 
   var scene = loadScene('scenegraph-rect.json');
   var r = new Renderer()
@@ -238,7 +238,7 @@ tape('SVGRenderer should support single-item redraw', function(t) {
 });
 
 tape('SVGRenderer should support multi-item redraw', function(t) {
-  vega.resetSVGClipId();
+  vega.resetSVGDefIds();
 
   var scene = vega.sceneFromJSON(vega.sceneToJSON(marks['line-1']));
   var r = new Renderer()
@@ -258,7 +258,7 @@ tape('SVGRenderer should support multi-item redraw', function(t) {
 });
 
 tape('SVGRenderer should support enter-group redraw', function(t) {
-  vega.resetSVGClipId();
+  vega.resetSVGDefIds();
 
   var scene = loadScene('scenegraph-barley.json');
   var r = new Renderer()

--- a/packages/vega-scenegraph/test/svg-string-renderer-test.js
+++ b/packages/vega-scenegraph/test/svg-string-renderer-test.js
@@ -24,7 +24,7 @@ function loadScene(file) {
 }
 
 function render(scene, w, h) {
-  vega.resetSVGClipId();
+  vega.resetSVGDefIds();
   return new Renderer()
     .initialize(null, w, h)
     .render(scene)
@@ -32,7 +32,7 @@ function render(scene, w, h) {
 }
 
 function renderAsync(scene, w, h, callback) {
-  vega.resetSVGClipId();
+  vega.resetSVGDefIds();
   new Renderer(loader({mode: 'http', baseURL: './test/resources/'}))
     .initialize(null, w, h)
     .renderAsync(scene)
@@ -103,7 +103,7 @@ tape('SVGStringRenderer should support axes, legends and sub-groups', function(t
 });
 
 tape('SVGStringRenderer should support full redraw', function(t) {
-  vega.resetSVGClipId();
+  vega.resetSVGDefIds();
 
   var scene = loadScene('scenegraph-rect.json');
   var r = new Renderer()
@@ -135,7 +135,7 @@ tape('SVGStringRenderer should support full redraw', function(t) {
 });
 
 tape('SVGStringRenderer should support enter-item redraw', function(t) {
-  vega.resetSVGClipId();
+  vega.resetSVGDefIds();
 
   var scene = loadScene('scenegraph-rect.json');
   var r = new Renderer()
@@ -164,7 +164,7 @@ tape('SVGStringRenderer should support enter-item redraw', function(t) {
 });
 
 tape('SVGStringRenderer should support exit-item redraw', function(t) {
-  vega.resetSVGClipId();
+  vega.resetSVGDefIds();
 
   var scene = loadScene('scenegraph-rect.json');
   var r = new Renderer()
@@ -185,7 +185,7 @@ tape('SVGStringRenderer should support exit-item redraw', function(t) {
 });
 
 tape('SVGStringRenderer should support single-item redraw', function(t) {
-  vega.resetSVGClipId();
+  vega.resetSVGDefIds();
 
   var scene = loadScene('scenegraph-rect.json');
   var r = new Renderer()
@@ -207,7 +207,7 @@ tape('SVGStringRenderer should support single-item redraw', function(t) {
 });
 
 tape('SVGStringRenderer should support multi-item redraw', function(t) {
-  vega.resetSVGClipId();
+  vega.resetSVGDefIds();
 
   var scene = vega.sceneFromJSON(vega.sceneToJSON(marks['line-1']));
   var r = new Renderer()
@@ -229,7 +229,7 @@ tape('SVGStringRenderer should support multi-item redraw', function(t) {
 });
 
 tape('SVGStringRenderer should support enter-group redraw', function(t) {
-  vega.resetSVGClipId();
+  vega.resetSVGDefIds();
 
   var scene = loadScene('scenegraph-barley.json');
   var r = new Renderer()


### PR DESCRIPTION
Fix https://github.com/vega/vega/issues/2573

With this new `resetGradientId()`, we can address https://github.com/vega/vega/issues/2573 by calling both `resetGradientId()` and `resetSVGClipId()`.  