### PR TITLE
Fix grid layout with empty grid.

### DIFF
--- a/packages/vega-view-transforms/src/layout/grid.js
+++ b/packages/vega-view-transforms/src/layout/grid.js
@@ -80,7 +80,7 @@ export function gridLayout(view, groups, opt) {
       padCol = get(opt.padding, Column),
       padRow = get(opt.padding, Row),
       ncols = opt.columns || groups.length,
-      nrows = ncols < 0 ? 1 : Math.ceil(groups.length / ncols),
+      nrows = ncols <= 0 ? 1 : Math.ceil(groups.length / ncols),
       n = groups.length,
       xOffset = Array(n), xExtent = Array(ncols), xMax = 0,
       yOffset = Array(n), yExtent = Array(nrows), yMax = 0,
@@ -234,12 +234,13 @@ export function trellisLayout(view, group, opt) {
       bbox = opt.bounds === Flush ? boundFlush : boundFull,
       off = opt.offset,
       ncols = opt.columns || groups.length,
-      nrows = ncols < 0 ? 1 : Math.ceil(groups.length / ncols),
+      nrows = ncols <= 0 ? 1 : Math.ceil(groups.length / ncols),
       cells = nrows * ncols,
       x, y, x2, y2, anchor, band, offset;
 
   // -- initial grid layout
   const bounds = gridLayout(view, groups, opt);
+  if (bounds.empty()) bounds.set(0, 0, 0, 0); // empty grid
 
   // -- layout grid headers and footers --
 


### PR DESCRIPTION
**vega-view-transforms**

- Fix grid layout calculations with empty grid input.

Fixes #2541.