### PR TITLE
Fixing Area Labeler does not always check for label-to-label collisions

### DIFF
--- a/packages/vega-label/src/util/placeAreaLabel/placeFloodFill.js
+++ b/packages/vega-label/src/util/placeAreaLabel/placeFloodFill.js
@@ -60,7 +60,8 @@ export default function($, bitmaps, avoidBaseMark, markIndex) {
 
         if (
           !outOfBounds(x, y, textWidth, textHeight, width, height) &&
-          !collision($, x, y, textHeight, textWidth, lo, bm0, bm1)
+          !collision($, x, y, textHeight, textWidth, lo, bm0, bm1) &&
+          !collision($, x, y, textHeight, textWidth, textHeight, bm0, null)
         ) {
           // if the label fits at the current sample point,
           // perform binary search to find the largest font size that fits

--- a/packages/vega-label/src/util/placeAreaLabel/placeFloodFill.js
+++ b/packages/vega-label/src/util/placeAreaLabel/placeFloodFill.js
@@ -17,7 +17,7 @@ export default function($, bitmaps, avoidBaseMark, markIndex) {
     const items = d.datum.datum.items[markIndex].items, // area points
           n = items.length, // number of points
           textHeight = d.datum.fontSize, // label width
-          textWidth = textMetrics.width(d.datum), // label height
+          textWidth = textMetrics.width(d.datum, d.datum.text), // label height
           stack = []; // flood fill stack
 
     let maxSize = avoidBaseMark ? textHeight : 0,

--- a/packages/vega-label/src/util/placeAreaLabel/placeNaive.js
+++ b/packages/vega-label/src/util/placeAreaLabel/placeNaive.js
@@ -9,7 +9,7 @@ export default function($, bitmaps, avoidBaseMark, markIndex) {
     const items = d.datum.datum.items[markIndex].items, // area points
           n = items.length, // number of points
           textHeight = d.datum.fontSize, // label width
-          textWidth = textMetrics.width(d.datum); // label height
+          textWidth = textMetrics.width(d.datum, d.datum.text); // label height
 
     let maxAreaWidth = 0,
         x1, x2, y1, y2, x, y, areaWidth;

--- a/packages/vega-label/src/util/placeAreaLabel/placeReducedSearch.js
+++ b/packages/vega-label/src/util/placeAreaLabel/placeReducedSearch.js
@@ -15,7 +15,8 @@ export default function($, bitmaps, avoidBaseMark, markIndex) {
         mid;
     if (
       !outOfBounds(x, y, textWidth, textHeight, width, height) &&
-      !collision($, x, y, textHeight, textWidth, lo, bm0, bm1)
+      !collision($, x, y, textHeight, textWidth, lo, bm0, bm1) &&
+      !collision($, x, y, textHeight, textWidth, textHeight, bm0, null)
     ) {
       // if the label fits at the current sample point,
       // perform binary search to find the largest font size that fits
@@ -79,9 +80,6 @@ export default function($, bitmaps, avoidBaseMark, markIndex) {
           result = tryLabel(_x, _y, maxSize, textWidth, textHeight);
           if (result) {
             [d.x, d.y, maxSize, labelPlaced] = result;
-          } else {
-            _x = _x1 - 1;
-            break;
           }
         }
       }
@@ -92,9 +90,6 @@ export default function($, bitmaps, avoidBaseMark, markIndex) {
           result = tryLabel(_x, _y, maxSize, textWidth, textHeight);
           if (result) {
             [d.x, d.y, maxSize, labelPlaced] = result;
-          } else {
-            _x = _x2 + 1;
-            break;
           }
         }
       }

--- a/packages/vega-label/src/util/placeAreaLabel/placeReducedSearch.js
+++ b/packages/vega-label/src/util/placeAreaLabel/placeReducedSearch.js
@@ -40,7 +40,7 @@ export default function($, bitmaps, avoidBaseMark, markIndex) {
     const items = d.datum.datum.items[markIndex].items, // area points
           n = items.length, // number of points
           textHeight = d.datum.fontSize, // label width
-          textWidth = textMetrics.width(d.datum); // label height
+          textWidth = textMetrics.width(d.datum, d.datum.text); // label height
 
     let maxSize = avoidBaseMark ? textHeight : 0,
         labelPlaced = false,


### PR DESCRIPTION
In `floodfill` and `reduced-search` method, the the algorithm does not check for label-to-label collision. It only checks when doing binary search for finding the largest space, not the actual text.

I also find that `textMetrics.width` takes 2 parameters, so I add data point's text to the second parameter.