### PR TITLE
feat: signal / numbervalue support for axis translate.

### DIFF
--- a/packages/vega-parser/src/parsers/axis.js
+++ b/packages/vega-parser/src/parsers/axis.js
@@ -33,7 +33,6 @@ export default function(spec, scope) {
     grid:   !!_('grid'),
     domain: !!_('domain'),
     title:  spec.title != null,
-    translate: _('translate')
   };
   dataRef = ref(scope.add(Collect({}, [datum])));
 
@@ -111,6 +110,7 @@ function buildAxisEncode(_, spec) {
     minExtent:    _('minExtent'),
     maxExtent:    _('maxExtent'),
     range:        {signal: `abs(span(range("${spec.scale}")))`},
+    translate:    _('translate'),
 
     // accessibility support
     format:       spec.format,

--- a/packages/vega-schema/src/axis.js
+++ b/packages/vega-schema/src/axis.js
@@ -56,7 +56,7 @@ const axis = object({
   offset: numberValue,
   position: numberValue,
   bandPosition: numberValue,
-  translate: numberType,
+  translate: numberValue,
   values: arrayOrSignal,
   zindex: numberType,
 

--- a/packages/vega-typings/types/spec/axis.d.ts
+++ b/packages/vega-typings/types/spec/axis.d.ts
@@ -146,7 +146,7 @@ export interface BaseAxis {
    *
    * __Default value:__ `0.5`
    */
-  translate?: number;
+  translate?: NumberValue;
 
   /**
    * The minimum extent in pixels that axis ticks and labels should use. This determines a minimum offset value for axis titles.

--- a/packages/vega-view-transforms/src/layout/axis.js
+++ b/packages/vega-view-transforms/src/layout/axis.js
@@ -16,11 +16,11 @@ function axisIndices(datum) {
   ];
 }
 
-export function axisLayout(view, axis, width, height) {
+export function axisLayout(view, axis, width, height) {  
   var item = axis.items[0],
       datum = item.datum,
       orient = datum.orient,
-      delta = datum.translate != null ? datum.translate : 0.5,
+      delta = item.translate != null ? item.translate : 0.5,
       indices = axisIndices(datum),
       range = item.range,
       offset = item.offset,


### PR DESCRIPTION
![translate-signal](https://user-images.githubusercontent.com/11954298/81110410-5d6d3000-8ed0-11ea-9760-44b5c7c08e07.gif)

NumberValue is also supported by moving `translate` from `datum` to `encode`

Example spec:

```
{
  "$schema": "https://vega.github.io/schema/vega/v5.json",
  "description": "A basic bar chart example, with value labels shown upon mouse hover.",
  "width": 400,
  "height": 200,
  "padding": 5,

  "data": [
    {
      "name": "table",
      "values": [
        {"category": "A", "amount": 28},
        {"category": "B", "amount": 55},
        {"category": "C", "amount": 43},
        {"category": "D", "amount": 91},
        {"category": "E", "amount": 81},
        {"category": "F", "amount": 53},
        {"category": "G", "amount": 19},
        {"category": "H", "amount": 87}
      ]
    }
  ],

  "signals": [
    {
      "name": "xAxisTranslate",
      "value": 0.5,
      "bind": {
        "input": "range",
        "min": -5,
        "max": 5
      }
    },
    {
      "name": "yAxisTranslate",
      "value": 0.5,
      "bind": {
        "input": "range",
        "min": -5,
        "max": 5
      }
    }
  ],

  "scales": [
    {
      "name": "xscale",
      "type": "band",
      "domain": {"data": "table", "field": "category"},
      "range": "width",
      "padding": 0.05,
      "round": true
    },
    {
      "name": "yscale",
      "domain": {"data": "table", "field": "amount"},
      "nice": true,
      "range": "height"
    }
  ],

  "axes": [
    { "orient": "bottom", "scale": "xscale", "translate": { "signal": "xAxisTranslate" }},
    { "orient": "left", "scale": "yscale", "translate": { "signal": "yAxisTranslate" }}
  ],

  "marks": [
    {
      "type": "rect",
      "from": {"data":"table"},
      "encode": {
        "enter": {
          "x": {"scale": "xscale", "field": "category"},
          "width": {"scale": "xscale", "band": 1},
          "y": {"scale": "yscale", "field": "amount"},
          "y2": {"scale": "yscale", "value": 0}
        },
        "update": {
          "fill": {"value": "steelblue"}
        },
        "hover": {
          "fill": {"value": "red"}
        }
      }
    }
  ]
}
```

addresses #2522