### PR TITLE
docs: change default renderer for examples to SVG to make charts more accessible

### DIFF
--- a/docs/_includes/embed
+++ b/docs/_includes/embed
@@ -24,7 +24,7 @@ function image(view, type) {
 var view = new vega.View(vega.parse(spec), {
   loader: vega.loader({baseURL: '{{ site.baseurl }}/'}),
   logLevel: vega.Warn,
-  renderer: '{{ include.renderer | default: "canvas" }}'
+  renderer: '{{ include.renderer | default: "svg" }}'
 }).initialize('#{{id}}').hover().run();
 
 document.querySelector('#{{id}}-png').addEventListener('click', image(view, 'png'));

--- a/docs/examples/flight-passengers.md
+++ b/docs/examples/flight-passengers.md
@@ -8,4 +8,4 @@ image: /examples/img/flight-passengers.png
 
 Monthly [total passengers at Seattle-Tacoma International Airport](https://www.portseattle.org/page/airport-statistics) (October 2019 to March 2020) relative to the previous year. This specification uses both automatically-generated and user-customized [ARIA accessibility attributes](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA). The `aria` and `description` properties are used to customize the elements and content provided to screen readers. In addition, custom `zindex` values are used to ensure a legible ordering of marks and guides within the output SVG. This example will update over time as Vega's accessibility support improves.
 
-{% include example spec=page.spec renderer="svg" %}
+{% include example spec=page.spec %}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "lerna run build && yarn docsbuild",
     "clean": "lerna clean --yes && lerna exec -- rimraf build && lerna exec -- rimraf LICENSE && rimraf node_modules yarn.lock",
     "data": "rsync -r node_modules/vega-datasets/data/* docs/data",
-    "docs": "cd docs && bundle exec jekyll serve",
+    "docs": "cd docs && bundle exec jekyll serve -I -l",
     "docsbuild": "cd packages/vega/build && cp vega.js vega.min.js vega-core.js vega-core.min.js vega-schema.json ../../../docs/",
     "license": "lerna exec -- cp ../../LICENSE .",
     "release": "yarn license && lerna publish from-package",


### PR DESCRIPTION
Also add live reload for jekyll

I tried a few large chart examples and didn't notice any performance issues. 