### PR TITLE
Remove object spread syntax, not supported in MS Edge

### DIFF
--- a/packages/vega-parser/src/parsers/guides/guide-util.js
+++ b/packages/vega-parser/src/parsers/guides/guide-util.js
@@ -84,5 +84,5 @@ export function extendOffset(value, offset) {
   return !offset ? value
     : !value ? offset
     : !isObject(value) ? { value, offset }
-    : { ...value, offset: extendOffset(value.offset, offset) };
+    : Object.assign({}, value, { offset: extendOffset(value.offset, offset) });
 }


### PR DESCRIPTION
Object spread syntax is not yet natively supported in MS Edge. I see that your ES5 build supports down to IE11, but I'd rather not have to alias `vega: 'vega/build-es5/vega'` in webpack just to get this to work in MS Edge, which the site I'm working on does support. We want ES6 imports and tree shaking from webpack for vega. So if you would kindly use this older syntax, it would be much appreciated.