### PR TITLE
Use style for SVG radial gradient pattern fill.

### DIFF
--- a/packages/vega-scenegraph/src/SVGRenderer.js
+++ b/packages/vega-scenegraph/src/SVGRenderer.js
@@ -175,7 +175,7 @@ function updateGradient(el, grad, index) {
     pt = domChild(pt, 0, 'rect', ns);
     pt.setAttribute('width', '1');
     pt.setAttribute('height', '1');
-    pt.setAttribute('fill', 'url(' + href() + '#' + grad.id + ')');
+    pt.setAttribute('style', 'fill: url(' + href() + '#' + grad.id + ');');
 
     el = domChild(el, index++, 'radialGradient', ns);
     el.setAttribute('id', grad.id);

--- a/packages/vega-scenegraph/src/SVGStringRenderer.js
+++ b/packages/vega-scenegraph/src/SVGStringRenderer.js
@@ -117,7 +117,7 @@ prototype.buildDefs = function() {
       defs += openTag('rect', {
         width: '1',
         height: '1',
-        fill: 'url(#' + id + ')'
+        style: 'fill: url(#' + id + ');'
       }) + closeTag('rect');
 
       defs += closeTag(tag);


### PR DESCRIPTION
Fixes bug where the SVG internal stylesheet `fill: none` took precedence over attribute-based `fill` setting for radial gradient pattern.

**vega-scenegraph**

- Fix SVG radial gradient pattern fill to use style, not fill attribute.