### PR TITLE
fix always undefined "this" for trap(view, ...)

### DIFF
--- a/packages/vega-view/src/View.js
+++ b/packages/vega-view/src/View.js
@@ -314,7 +314,7 @@ function findOperatorHandler(op, handler) {
 function addOperatorListener(view, name, op, handler) {
   var h = findOperatorHandler(op, handler);
   if (!h) {
-    h = trap(this, function() { handler(name, op.value); });
+    h = trap(view, function() { handler(name, op.value); });
     h.handler = handler;
     view.on(op, null, h);
   }


### PR DESCRIPTION
I managed to trigger an unrelated issue, but instead of reporting the issue I saw "Cannot read property 'error' of undefined", and this PR addresses the issue