### PR TITLE
fix: correct string to number conversion in sum op

### DIFF
--- a/packages/vega-transforms/src/util/AggregateOps.js
+++ b/packages/vega-transforms/src/util/AggregateOps.js
@@ -34,7 +34,7 @@ export const AggregateOps = {
   sum: {
     init:  m => m.sum = 0,
     value: m => m.sum,
-    add:  (m, v) => m.sum += v,
+    add:  (m, v) => m.sum += +v,
     rem:  (m, v) => m.sum -= v,
   },
   product: {


### PR DESCRIPTION
A missing `+` conversion operator in the `sum` op results in broken aggregation on specs that source from a csv (concatenation of strings instead of sum of the number values). Looks like #2598 left this out.

Here's an [example spec](http://localhost:8080/#/url/vega/N4KABGBEAkDODGALApgWwIaQFxUQFzwAdYsB6UgN2QHN0A6agSz0QFcAjOxge1IRQyUa6SgFY6AK1jcAdpAA04KABNkCAE6NCeHnJyQAgmHbpYjeMfTqwSK3jDIAHulSEANsnlgA7s0RgKdDdWZDA3dHZkN1gwWERubxkwVkJZMFRuVlhQ+Kp1OgUlSF9lFmwwABYABirFCEgURmp8coAmGrqoQnRlZUYZanLRRSLldDxMHABtJQhQCAWoGRdkcshpVnV4Vc7FyE23NbGJ0j7YUzxkdVg6eFgKQsX6gDNudQw8cuBIPABPQlW+juDwAvrMwCDdmB5k9IMtUICoBN2B5HrCNltEetMpi0Xs8Op0DJYK93uUZk8FjDKfU-gC1uhqNR1MJLniaZBmZlCOxfuTIABRGQ6P6QAC6UMpkG4xH5sFYqHFkthz0YUWUsH5ABFkONEJqJeCpaY5QqAPrwTLC8VGhZgyli8H2sCG+oIIJqcng6kLOErNa-d2o5U-f5YkwyZTs+rKbgYfpfSDHSZIiLBqCq9VrIUivmQ22QQkDLGNZqfEPdXr9QY4Kp0KrDAvqK1RnAEkJOqE++rwrGOIM7Aux+N6aFJ8Ypn5pnYZtVuVtQeWoC1Wz75qUycyI9ueJtE6hYkplJ1KQ1FdCOT3Tb1QN5q636djcAhxhSL+Aetb9j+oiFd2+aMgD5QB4zzlu+n76IGP6rBCp4jPUGDqAA1pq16LN2SJhmsLLwOWBbPM2io4N8ybYFOKKrOusJAZaqhfLa9RAZc6gMTSvqOK0iYDl+PFeJAmbzmsS4rqw1rUexkCONxMG8bJ-GBMEiJVBJHJ8iR6yyVBfGzlm+g5swebKnspYtBpPHafJUARguACMzqUqpewpMciKYXsqpuIcGmKSEwmXFEKJ+Q5TxOb6uRXGx7Gzl5ia+ViLJRiFizJXBKWniAYJAA)

```
{
  "$schema": "https://vega.github.io/schema/vega/v5.json",
  "description": "A basic bar chart example, with value labels shown upon mouse hover.",
  "width": 400,
  "height": 200,
  "padding": 5,

  "data": [
    {
      "name": "source",
      "url": "data/disasters.csv",
      "format": {"type": "csv"}
    },
    {
      "name": "table",
      "source": "source",
      "transform": [
        {
          "type": "aggregate",
          "groupby": ["Entity"],
          "ops": ["sum"],
          "fields": ["Deaths"],
          "as": ["sum_count"]
        }
      ]
    }
  ],
  "scales": [
    {
      "name": "yscale",
      "type": "band",
      "domain": {"data": "table", "field": "Entity"},
      "range": "height",
      "padding": 0.05,
      "round": true
    },
    {
      "name": "xscale",
      "domain": {"data": "table", "field": "sum_count"},
      "nice": true,
      "range": "width"
    }
  ],

  "axes": [
    { "orient": "bottom", "scale": "xscale" },
    { "orient": "left", "scale": "yscale" }
  ],

  "marks": [
    {
      "type": "rect",
      "from": {"data":"table"},
      "encode": {
        "enter": {
          "x2": {"scale": "xscale", "field": "sum_count"},
          "x": {"scale": "xscale", "value": 0},
          "y": {"scale": "yscale", "field": "Entity"},
          "height": {"scale": "yscale", "band": 1}
        },
        "update": {
          "fill": {"value": "steelblue"}
        },
        "hover": {
          "fill": {"value": "red"}
        }
      }
    }
  ]
}
```

Current:

![image](https://user-images.githubusercontent.com/11954298/82247934-23525400-98fc-11ea-9311-a48f7cf81c0f.png)

Intended (with fix):

<img width="551" alt="image" src="https://user-images.githubusercontent.com/11954298/82247953-2baa8f00-98fc-11ea-901b-3c84cc4c73cf.png">
