### PR TITLE
Add cursor target customization, use local cursor style by default.

### DIFF
--- a/packages/vega-view/src/View.js
+++ b/packages/vega-view/src/View.js
@@ -343,8 +343,9 @@ prototype.removeDataListener = function(name, handler) {
 prototype.globalCursor = function(_) {
   if (arguments.length) {
     if (this._globalCursor !== !!_) {
-      setCursor(this, null); // clear previous cursor target
+      const prev = setCursor(this, null); // clear previous cursor
       this._globalCursor = !!_;
+      if (prev) setCursor(this, prev); // swap cursor
     }
     return this;
   } else {

--- a/packages/vega-view/src/View.js
+++ b/packages/vega-view/src/View.js
@@ -1,6 +1,6 @@
 import {ariaLabel} from './aria';
 import background from './background';
-import cursor from './cursor';
+import cursor, {setCursor} from './cursor';
 import {change, data, dataref, insert, remove} from './data';
 import {events, initializeEventConfig} from './events';
 import hover from './hover';
@@ -62,6 +62,7 @@ export default function View(spec, options) {
   view._tooltip = options.tooltip || defaultTooltip,
   view._redraw = true;
   view._handler = new CanvasHandler().scene(root);
+  view._globalCursor = false;
   view._preventDefault = false;
   view._timers = [];
   view._eventListeners = [];
@@ -69,6 +70,7 @@ export default function View(spec, options) {
 
   // initialize event configuration
   view._eventConfig = initializeEventConfig(spec.eventConfig);
+  view.globalCursor(view._eventConfig.globalCursor);
 
   // initialize dataflow graph
   const ctx = runtime(view, spec, options.functions);
@@ -336,6 +338,18 @@ prototype.addDataListener = function(name, handler) {
 
 prototype.removeDataListener = function(name, handler) {
   return removeOperatorListener(this, dataref(this, name).values, handler);
+};
+
+prototype.globalCursor = function(_) {
+  if (arguments.length) {
+    if (this._globalCursor !== !!_) {
+      setCursor(this, null); // clear previous cursor target
+      this._globalCursor = !!_;
+    }
+    return this;
+  } else {
+    return this._globalCursor;
+  }
 };
 
 prototype.preventDefault = function(_) {

--- a/packages/vega-view/src/cursor.js
+++ b/packages/vega-view/src/cursor.js
@@ -1,30 +1,30 @@
 import {isString} from 'vega-util';
 
-var Default = 'default';
+const Default = 'default';
 
 export default function(view) {
-  var cursor = view._signals.cursor;
-
-  // add cursor signal to dataflow, if needed
-  if (!cursor) {
-    view._signals.cursor = (cursor = view.add({user: Default, item: null}));
-  }
+  // get cursor signal, add to dataflow if needed
+  const cursor = view._signals.cursor || (view._signals.cursor = view.add({
+    user: Default,
+    item: null
+  }));
 
   // evaluate cursor on each mousemove event
   view.on(view.events('view', 'mousemove'), cursor,
     function(_, event) {
-      var value = cursor.value,
-          user = value ? (isString(value) ? value : value.user) : Default,
-          item = event.item && event.item.cursor || null;
+      const value = cursor.value,
+            user = value ? (isString(value) ? value : value.user) : Default,
+            item = event.item && event.item.cursor || null;
 
-      return (value && user === value.user && item == value.item) ? value
+      return (value && user === value.user && item == value.item)
+        ? value
         : {user: user, item: item};
     }
   );
 
   // when cursor signal updates, set visible cursor
   view.add(null, function(_) {
-    var user = _.cursor,
+    let user = _.cursor,
         item = this.value;
 
     if (!isString(user)) {
@@ -32,16 +32,22 @@ export default function(view) {
       user = user.user;
     }
 
-    setCursor(user && user !== Default ? user : (item || user));
+    setCursor(view, user && user !== Default ? user : (item || user));
 
     return item;
   }, {cursor: cursor});
 }
 
-function setCursor(cursor) {
-  // set cursor on document body
-  // this ensures cursor applies even if dragging out of view
-  if (typeof document !== 'undefined' && document.body) {
-    document.body.style.cursor = cursor;
+export function setCursor(view, cursor) {
+  const el = view.globalCursor()
+    ? (typeof document !== 'undefined' && document.body)
+    : view.container();
+
+  if (el) {
+    if (cursor == null) {
+      el.style.removeProperty('cursor');
+    } else {
+      el.style.cursor = cursor;
+    }
   }
 }

--- a/packages/vega-view/src/cursor.js
+++ b/packages/vega-view/src/cursor.js
@@ -44,10 +44,8 @@ export function setCursor(view, cursor) {
     : view.container();
 
   if (el) {
-    if (cursor == null) {
-      el.style.removeProperty('cursor');
-    } else {
-      el.style.cursor = cursor;
-    }
+    return cursor == null
+      ? el.style.removeProperty('cursor')
+      : (el.style.cursor = cursor);
   }
 }


### PR DESCRIPTION
Previously Vega updated the `cursor` style on the HTML document body. This has the nice effect of controlling the cursor even during interactions (such as drags) that may leave the Vega View component. However, it also can result in large performance penalties in Chrome, which re-evaluates CSS styles in response. This PR changes the default behavior of Vega to set the cursor locally on the Vega View component. If a global cursor is desired, the boolean config property `events.globalCursor` can be set `true` or the View method `globalCursor` can be invoked to change the setting at runtime.

**vega-view**

- Add `globalCursor` method and event configuration.
- Update to make the Vega view container the default cursor target.

Close #2439