### PR TITLE
fix: fix typings for locale specification and view api

### DIFF
--- a/packages/vega-typings/types/runtime/index.d.ts
+++ b/packages/vega-typings/types/runtime/index.d.ts
@@ -1,4 +1,12 @@
-import { DataType, EncodeEntryName, Format, SignalValue, Spec } from '../spec';
+import {
+  DataType,
+  EncodeEntryName,
+  Format,
+  NumberLocale,
+  SignalValue,
+  Spec,
+  TimeLocale,
+} from '../spec';
 import { Renderers } from './renderer';
 import { Transform, Changeset } from './dataflow';
 
@@ -25,7 +33,7 @@ export type NumberFormat = (number: number) => string;
 export type TimeFormat = (date: Date | number) => string;
 export type TimeParse = (dateString: string) => Date;
 
-export interface Locale {
+export interface LocaleFormatters {
   format: (spec: string) => NumberFormat;
   formatPrefix: (spec: string, value: number) => NumberFormat;
   formatFloat: (spec: string) => NumberFormat;
@@ -52,8 +60,8 @@ export class View {
   loader(): Loader;
   loader(loader: Loader): this;
 
-  locale(): Locale;
-  locale(locale: Locale): this;
+  locale(): LocaleFormatters;
+  locale(locale: LocaleFormatters): this;
 
   hover(hoverSet?: EncodeEntryName, leaveSet?: EncodeEntryName): this;
   run(encode?: string): this;

--- a/packages/vega-typings/types/spec/index.d.ts
+++ b/packages/vega-typings/types/spec/index.d.ts
@@ -28,6 +28,7 @@ export * from './encode';
 export * from './expr';
 export * from './layout';
 export * from './legend';
+export * from './locale';
 export * from './mark';
 export * from './marktype';
 export * from './on-events';

--- a/packages/vega-typings/types/spec/locale.d.ts
+++ b/packages/vega-typings/types/spec/locale.d.ts
@@ -1,78 +1,82 @@
 import { Vector2, Vector7, Vector10, Vector12 } from '.';
 
 export interface Locale {
+  number?: NumberLocale;
+  time?: TimeLocale;
+}
+
+/**
+ * Locale definition for formatting numbers.
+ */
+export interface NumberLocale {
   /**
-   * Locale definition for formatting numbers.
+   * The decimal point (e.g., ".").
    */
-  number?: {
-    /**
-     * The decimal point (e.g., ".").
-     */
-    decimal: string;
-    /**
-     * The group separator (e.g., ",").
-     */
-    thousands: string;
-    /**
-     * The array of group sizes (e.g., [3]), cycled as needed.
-     */
-    grouping: number[];
-    /**
-     * The currency prefix and suffix (e.g., ["$", ""]).
-     */
-    currency: Vector2<string>;
-    /**
-     * An array of ten strings to replace the numerals 0-9.
-     */
-    numerals?: Vector10<string>;
-    /**
-     * The percent sign (defaults to "%").
-     */
-    percent?: string;
-    /**
-     * The minus sign (defaults to hyphen-minus, "-").
-     */
-    minus?: string;
-    /**
-     * The not-a-number value (defaults to "NaN").
-     */
-    nan?: string;
-  };
+  decimal: string;
   /**
-   * Locale definition for formatting dates and times.
+   * The group separator (e.g., ",").
    */
-  time?: {
-    /**
-     * The date and time (%c) format specifier (e.g., "%a %b %e %X %Y").
-     */
-    dateTime: string;
-    /**
-     * The date (%x) format specifier (e.g., "%m/%d/%Y").
-     */
-    date: string;
-    /**
-     * The time (%X) format specifier (e.g., "%H:%M:%S").
-     */
-    time: string;
-    /**
-     * The A.M. and P.M. equivalents (e.g., ["AM", "PM"]).
-     */
-    periods: Vector2<string>;
-    /**
-     * The full names of the weekdays, starting with Sunday.
-     */
-    days: Vector7<string>;
-    /**
-     * The abbreviated names of the weekdays, starting with Sunday.
-     */
-    shortDays: Vector7<string>;
-    /**
-     * The full names of the months (starting with January).
-     */
-    months: Vector12<string>;
-    /**
-     * The abbreviated names of the months (starting with January).
-     */
-    shortMonths: Vector12<string>;
-  };
+  thousands: string;
+  /**
+   * The array of group sizes (e.g., [3]), cycled as needed.
+   */
+  grouping: number[];
+  /**
+   * The currency prefix and suffix (e.g., ["$", ""]).
+   */
+  currency: Vector2<string>;
+  /**
+   * An array of ten strings to replace the numerals 0-9.
+   */
+  numerals?: Vector10<string>;
+  /**
+   * The percent sign (defaults to "%").
+   */
+  percent?: string;
+  /**
+   * The minus sign (defaults to hyphen-minus, "-").
+   */
+  minus?: string;
+  /**
+   * The not-a-number value (defaults to "NaN").
+   */
+  nan?: string;
+}
+
+/**
+ * Locale definition for formatting dates and times.
+ */
+export interface TimeLocale {
+  /**
+   * The date and time (%c) format specifier (e.g., "%a %b %e %X %Y").
+   */
+  dateTime: string;
+  /**
+   * The date (%x) format specifier (e.g., "%m/%d/%Y").
+   */
+  date: string;
+  /**
+   * The time (%X) format specifier (e.g., "%H:%M:%S").
+   */
+  time: string;
+  /**
+   * The A.M. and P.M. equivalents (e.g., ["AM", "PM"]).
+   */
+  periods: Vector2<string>;
+  /**
+   * The full names of the weekdays, starting with Sunday.
+   */
+  days: Vector7<string>;
+  /**
+   * The abbreviated names of the weekdays, starting with Sunday.
+   */
+  shortDays: Vector7<string>;
+  /**
+   * The full names of the months (starting with January).
+   */
+  months: Vector12<string>;
+  /**
+   * The abbreviated names of the months (starting with January).
+   */
+  shortMonths: Vector12<string>;
 }


### PR DESCRIPTION
Ensures

1. `vega-typings` exports the `Locale` specification type, additionally splitting it into a `NumberLocale` and a `TimeLocale`.
2. ~`View` API typings for the `locale` function correctly match the `vega-view` implementation and documentation.~
3.  No type collision between `vega-typings/runtime` and `vega-typings/spec` by renaming the `Locale` definition in `runtime` to `LocaleFormatters`. 