### PR TITLE
fix: simplify voice over text for titles and subtitles

### DIFF
--- a/packages/vega-scenegraph/src/util/aria.js
+++ b/packages/vega-scenegraph/src/util/aria.js
@@ -37,11 +37,11 @@ const AriaGuides = {
   'legend': {desc: 'legend', caption: legendCaption},
   'title-text': {
     desc: 'title',
-    caption: item => `Title text '${titleCaption(item)}'`
+    caption: item => titleCaption(item)
   },
   'title-subtitle': {
     desc: 'subtitle',
-    caption: item => `Subtitle text '${titleCaption(item)}'`
+    caption: item => titleCaption(item)
   }
 };
 


### PR DESCRIPTION
This pull request changes the description of titles to be just the title. https://developer.apple.com/videos/play/wwdc2019/254/ suggests that descriptions should be as concise as possible so we may not want to repeat that the text is the title or subtitle (similar to buttons in the video).

Marked as draft since I need to think more about whether text should even have an aria label. 