### PR TITLE
Add subflow garbage collection.

### DIFF
--- a/packages/vega-dataflow/src/ChangeSet.js
+++ b/packages/vega-dataflow/src/ChangeSet.js
@@ -11,6 +11,7 @@ export default function changeset() {
       mod = [],  // modify tuples
       remp = [], // remove by predicate
       modp = [], // modify by predicate
+      clean = null,
       reflow = false;
 
   return {
@@ -40,6 +41,10 @@ export default function changeset() {
     encode: function(t, set) {
       if (isFunction(t)) modp.push({filter: t, field: set});
       else mod.push({tuple: t, field: set});
+      return this;
+    },
+    clean: function(value) {
+      clean = value;
       return this;
     },
     reflow: function() {
@@ -130,6 +135,11 @@ export default function changeset() {
           : tuples.slice();
       } else {
         for (id in out) pulse.mod.push(out[id]);
+      }
+
+      // set pulse garbage collection request
+      if (clean || clean == null && (rem.length || remp.length)) {
+        pulse.clean(true);
       }
 
       return pulse;

--- a/packages/vega-dataflow/src/Operator.js
+++ b/packages/vega-dataflow/src/Operator.js
@@ -188,6 +188,25 @@ prototype.marshall = function(stamp) {
 };
 
 /**
+ * Detach this operator from the dataflow.
+ * Unregisters listeners on upstream dependencies.
+ */
+prototype.detach = function() {
+  var argops = this._argops,
+      i, n, item, op;
+
+  if (argops) {
+    for (i=0, n=argops.length; i<n; ++i) {
+      item = argops[i];
+      op = item.op;
+      if (op._targets) {
+        op._targets.remove(this);
+      }
+    }
+  }
+};
+
+/**
  * Delegate method to perform operator processing.
  * Subclasses can override this method to perform custom processing.
  * By default, it marshalls parameters and calls the update function

--- a/packages/vega-runtime/src/parameters.js
+++ b/packages/vega-runtime/src/parameters.js
@@ -131,6 +131,7 @@ function getSubflow(_, ctx) {
           op = subctx.get(spec.operators[0].id),
           p = subctx.signals.parent;
     if (p) p.set(parent);
+    op.detachSubflow = () => ctx.detach(subctx);
     return op;
   };
 }

--- a/packages/vega-transforms/src/Aggregate.js
+++ b/packages/vega-transforms/src/Aggregate.js
@@ -85,6 +85,10 @@ prototype.transform = function(_, pulse) {
     aggr.cross();
   }
 
+  if (pulse.clean() && aggr._drop) {
+    out.clean(true).runAfter(() => this.clean());
+  }
+
   return aggr.changes(out);
 };
 
@@ -258,6 +262,15 @@ prototype.newtuple = function(t, p) {
   }
 
   return p ? replace(p.tuple, x) : ingest(x);
+};
+
+prototype.clean = function() {
+  const cells = this.value;
+  for (const key in cells) {
+    if (cells[key].num === 0) {
+      delete cells[key];
+    }
+  }
 };
 
 // -- Process Tuples -----

--- a/packages/vega-transforms/src/Facet.js
+++ b/packages/vega-transforms/src/Facet.js
@@ -16,29 +16,32 @@ export default function Facet(params) {
 
   // keep track of active subflows, use as targets array for listeners
   // this allows us to limit propagation to only updated subflows
-  var a = this._targets = [];
+  const a = this._targets = [];
   a.active = 0;
-  a.forEach = function(f) {
-    for (var i=0, n=a.active; i<n; ++i) f(a[i], i, a);
+  a.forEach = f => {
+    for (let i=0, n=a.active; i<n; ++i) {
+      f(a[i], i, a);
+    }
   };
 }
 
-var prototype = inherits(Facet, Transform);
+const prototype = inherits(Facet, Transform);
 
 prototype.activate = function(flow) {
   this._targets[this._targets.active++] = flow;
 };
 
+// parent argument provided by PreFacet subclass
 prototype.subflow = function(key, flow, pulse, parent) {
-  var flows = this.value,
+  let flows = this.value,
       sf = hasOwnProperty(flows, key) && flows[key],
       df, p;
 
   if (!sf) {
     p = parent || (p = this._group[key]) && p.tuple;
     df = pulse.dataflow;
-    sf = df.add(new Subflow(pulse.fork(pulse.NO_SOURCE), this))
-      .connect(flow(df, key, p));
+    sf = new Subflow(pulse.fork(pulse.NO_SOURCE), this);
+    df.add(sf).connect(flow(df, key, p));
     flows[key] = sf;
     this.activate(sf);
   } else if (sf.value.stamp < pulse.stamp) {
@@ -49,41 +52,57 @@ prototype.subflow = function(key, flow, pulse, parent) {
   return sf;
 };
 
-prototype.transform = function(_, pulse) {
-  var df = pulse.dataflow,
-      self = this,
-      key = _.key,
-      flow = _.subflow,
-      cache = this._keys,
-      rekey = _.modified('key');
-
-  function subflow(key) {
-    return self.subflow(key, flow, pulse);
+prototype.clean = function() {
+  const flows = this.value;
+  for (const key in flows) {
+    if (flows[key].count === 0) {
+      const detach = flows[key].detachSubflow;
+      if (detach) detach();
+      delete flows[key];
+    }
   }
+};
+
+prototype.initTargets = function() {
+  const a = this._targets,
+        n = a.length;
+  for (let i=0; i<n && a[i] != null; ++i) {
+    a[i] = null; // ensure old flows can be garbage collected
+  }
+  a.active = 0;
+};
+
+prototype.transform = function(_, pulse) {
+  const df = pulse.dataflow,
+        key = _.key,
+        flow = _.subflow,
+        cache = this._keys,
+        rekey = _.modified('key'),
+        subflow = key => this.subflow(key, flow, pulse);
 
   this._group = _.group || {};
-  this._targets.active = 0; // reset list of active subflows
+  this.initTargets(); // reset list of active subflows
 
-  pulse.visit(pulse.REM, function(t) {
-    var id = tupleid(t),
-        k = cache.get(id);
+  pulse.visit(pulse.REM, t => {
+    const id = tupleid(t),
+           k = cache.get(id);
     if (k !== undefined) {
       cache.delete(id);
       subflow(k).rem(t);
     }
   });
 
-  pulse.visit(pulse.ADD, function(t) {
-    var k = key(t);
+  pulse.visit(pulse.ADD, t => {
+    const k = key(t);
     cache.set(tupleid(t), k);
     subflow(k).add(t);
   });
 
   if (rekey || pulse.modified(key.fields)) {
-    pulse.visit(pulse.MOD, function(t) {
-      var id = tupleid(t),
-          k0 = cache.get(id),
-          k1 = key(t);
+    pulse.visit(pulse.MOD, t => {
+      const id = tupleid(t),
+            k0 = cache.get(id),
+            k1 = key(t);
       if (k0 === k1) {
         subflow(k1).mod(t);
       } else {
@@ -93,16 +112,16 @@ prototype.transform = function(_, pulse) {
       }
     });
   } else if (pulse.changed(pulse.MOD)) {
-    pulse.visit(pulse.MOD, function(t) {
+    pulse.visit(pulse.MOD, t => {
       subflow(cache.get(tupleid(t))).mod(t);
     });
   }
 
   if (rekey) {
-    pulse.visit(pulse.REFLOW, function(t) {
-      var id = tupleid(t),
-          k0 = cache.get(id),
-          k1 = key(t);
+    pulse.visit(pulse.REFLOW, t => {
+      const id = tupleid(t),
+            k0 = cache.get(id),
+            k1 = key(t);
       if (k0 !== k1) {
         cache.set(id, k1);
         subflow(k0).rem(t);
@@ -111,6 +130,11 @@ prototype.transform = function(_, pulse) {
     });
   }
 
-  if (cache.empty > df.cleanThreshold) df.runAfter(cache.clean);
+  if (pulse.clean()) {
+    df.runAfter(() => { this.clean(); cache.clean(); });
+  } else if (cache.empty > df.cleanThreshold) {
+    df.runAfter(cache.clean);
+  }
+
   return pulse;
 };

--- a/packages/vega-transforms/src/Load.js
+++ b/packages/vega-transforms/src/Load.js
@@ -55,5 +55,6 @@ function output(op, pulse, data) {
   out.rem = op.value;
   op.value = out.source = out.add = data;
   op._pending = null;
+  if (out.rem.length) out.clean(true);
   return out;
 }

--- a/packages/vega-transforms/src/PreFacet.js
+++ b/packages/vega-transforms/src/PreFacet.js
@@ -15,33 +15,43 @@ export default function PreFacet(params) {
   Facet.call(this, params);
 }
 
-var prototype = inherits(PreFacet, Facet);
+const prototype = inherits(PreFacet, Facet);
 
 prototype.transform = function(_, pulse) {
-  var self = this,
-      flow = _.subflow,
-      field = _.field;
+  const flow = _.subflow,
+        field = _.field,
+        subflow = t => this.subflow(tupleid(t), flow, pulse, t);
 
   if (_.modified('field') || field && pulse.modified(accessorFields(field))) {
     error('PreFacet does not support field modification.');
   }
 
-  this._targets.active = 0; // reset list of active subflows
+  this.initTargets(); // reset list of active subflows
 
-  pulse.visit(pulse.MOD, function(t) {
-    var sf = self.subflow(tupleid(t), flow, pulse, t);
-    field ? field(t).forEach(function(_) { sf.mod(_); }) : sf.mod(t);
-  });
+  if (field) {
+    pulse.visit(pulse.MOD, t => {
+      const sf = subflow(t);
+      field(t).forEach(_ => sf.mod(_));
+    });
 
-  pulse.visit(pulse.ADD, function(t) {
-    var sf = self.subflow(tupleid(t), flow, pulse, t);
-    field ? field(t).forEach(function(_) { sf.add(ingest(_)); }) : sf.add(t);
-  });
+    pulse.visit(pulse.ADD, t => {
+      const sf = subflow(t);
+      field(t).forEach(_ => sf.add(ingest(_)));
+    });
 
-  pulse.visit(pulse.REM, function(t) {
-    var sf = self.subflow(tupleid(t), flow, pulse, t);
-    field ? field(t).forEach(function(_) { sf.rem(_); }) : sf.rem(t);
-  });
+    pulse.visit(pulse.REM, t => {
+      const sf = subflow(t);
+      field(t).forEach(_ => sf.rem(_));
+    });
+  } else {
+    pulse.visit(pulse.MOD, t => subflow(t).mod(t));
+    pulse.visit(pulse.ADD, t => subflow(t).add(t));
+    pulse.visit(pulse.REM, t => subflow(t).rem(t));
+  }
+
+  if (pulse.clean()) {
+    pulse.runAfter(() => this.clean());
+  }
 
   return pulse;
 };

--- a/packages/vega-transforms/src/Subflow.js
+++ b/packages/vega-transforms/src/Subflow.js
@@ -7,16 +7,21 @@ import {inherits} from 'vega-util';
  * @constructor
  * @param {Pulse} pulse - A pulse to use as the value of this operator.
  * @param {Transform} parent - The parent transform (typically a Facet instance).
- * @param {Transform} target - A transform that receives the subflow of tuples.
  */
 export default function Subflow(pulse, parent) {
   Operator.call(this, pulse);
   this.parent = parent;
+  this.count = 0;
 }
 
 var prototype = inherits(Subflow, Operator);
 
+/**
+ * Routes pulses from this subflow to a target transform.
+ * @param {Transform} target - A transform that receives the subflow of tuples.
+ */
 prototype.connect = function(target) {
+  this.detachSubflow = target.detachSubflow;
   this.targets().add(target);
   return (target.source = this);
 };
@@ -26,6 +31,7 @@ prototype.connect = function(target) {
  * @param {Tuple} t - The tuple being added.
  */
 prototype.add = function(t) {
+  this.count += 1;
   this.value.add.push(t);
 };
 
@@ -34,6 +40,7 @@ prototype.add = function(t) {
  * @param {Tuple} t - The tuple being removed.
  */
 prototype.rem = function(t) {
+  this.count -= 1;
   this.value.rem.push(t);
 };
 

--- a/packages/vega-transforms/test/facet-test.js
+++ b/packages/vega-transforms/test/facet-test.js
@@ -1,5 +1,5 @@
 var tape = require('tape'),
-    util = require('vega-util'),
+    {field, truthy} = require('vega-util'),
     vega = require('vega-dataflow'),
     tx = require('../'),
     changeset = vega.changeset,
@@ -23,59 +23,90 @@ tape('Facet facets tuples', function(t) {
   function subtest(len) {
     return function(s, i) {
       var d = s.data.value;
-      t.equal(d.length, len===undefined ? i+1 : len);
-      t.equal(d.every(function(t) { return t.k === s.key; }), true);
+      t.equal(d.length, len === undefined ? i + 1 : len);
+      t.equal(d.every(t => t.k === s.key), true);
     };
   }
 
-  var key = util.field('k'),
+  var key = field('k'),
       df = new vega.Dataflow(),
       source = df.add(Collect),
       facet = df.add(Facet, {subflow:subflow, key:key, pulse:source});
 
   // -- test adds
-  df.pulse(source, changeset().insert(data)).run();
+  df.pulse(source, changeset()
+    .insert(data)
+  ).run();
   t.equal(facet.targets().active, 3); // 3 subflows updated
   t.equal(subs.length, 3); // 3 subflows added
   subs.forEach(subtest(2)); // each subflow should have 2 tuples
 
   // -- test mods - key change
-  df.pulse(source, changeset().modify(data[0], 'k', 'c')).run();
+  df.pulse(source, changeset()
+    .modify(data[3], 'k', 'c')
+  ).run();
   t.equal(facet.targets().active, 2); // 2 subflows updated
   t.equal(subs.length, 3); // no new subflows added
   subs.forEach(subtest()); // subflows should have 1,2,3 tuples respectively
 
   // -- test mods - value change
-  df.pulse(source, changeset().modify(data[1], 'v', 100)).run();
+  df.pulse(source, changeset()
+    .modify(data[1], 'v', 100)
+  ).run();
   t.equal(facet.targets().active, 1); // 1 subflow updated
   t.equal(subs.length, 3); // no new subflows added
   subs.forEach(subtest()); // subflows should have 1,2,3 tuples respectively
 
   // -- test rems - no disconnects
-  df.pulse(source, changeset().remove([data[0], data[2], data[4]])).run();
+  df.pulse(source, changeset()
+    .remove([data[2], data[3], data[4]])
+  ).run();
   t.equal(facet.targets().active, 2); // 2 subflows updated
   t.equal(subs.length, 3); // no new subflows added
   subs.forEach(subtest(1)); // each subflow should have 1 tuple
 
   // -- test rems - empty out a subflow
-  df.pulse(source, changeset().remove([data[1], data[3], data[5]])).run();
+  df.pulse(source, changeset()
+    .remove([data[0], data[1], data[5]])
+    .clean(false) // don't remove subflows
+  ).run();
   t.equal(facet.targets().active, 3); // 3 subflows updated
   t.equal(subs.length, 3); // no new subflows added
   subs.forEach(subtest(0)); // each subflow should now be empty
 
   // -- test adds - repopulate subflows
-  df.pulse(source, changeset().insert(data)).run();
+  df.pulse(source, changeset()
+    .insert(data)
+  ).run();
   t.equal(facet.targets().active, 3); // 3 subflows updated
   t.equal(subs.length, 3); // no new subflows added
   subs.forEach(subtest()); // subflows should have 1,2,3 tuples respectively
 
   // -- test adds - new subflow
-  df.pulse(source, changeset().insert([
-    {k:'d', v:4}, {k:'d', v:8}, {k:'d', v:6}, {k:'d', v:0}
-  ])).run();
+  df.pulse(source, changeset()
+    .insert([{k:'d', v:4}, {k:'d', v:8}, {k:'d', v:6}, {k:'d', v:0}])
+  ).run();
   t.equal(facet.targets().active, 1); // 1 subflow updated
   t.equal(subs.length, 4); // 1 subflow added
   subs.forEach(subtest()); // subflows should have 1,2,3,4 tuples respectively
+
+  // -- test rems - empty out a subflow with cleaning
+  df.pulse(source, changeset()
+    .remove(truthy)
+    .clean(true) // remove subflows from internal map
+  ).run();
+  t.equal(facet.targets().active, 4); // 4 subflows updated
+  t.equal(subs.length, 4); // no new subflows added
+  subs.forEach(subtest(0)); // each subflow should now be empty
+
+  // -- test adds - repopulate subflows
+  df.pulse(source, changeset()
+    .insert(data)
+  ).run();
+  t.equal(facet.targets().active, 3); // 3 subflows updated
+  t.equal(subs.length, 7); // three new subflows added
+  subs.slice(0, 3).forEach(subtest(0)); // prior subflows should be empty
+  subs.slice(-3).forEach(subtest()); // subflows should have 1,2,3 tuples respectively
 
   t.end();
 });
@@ -97,13 +128,13 @@ tape('Facet handles key parameter change', function(t) {
   function subtest(len) {
     return function(s, i) {
       var d = s.data.value;
-      t.equal(d.length, len===undefined ? i+1 : len);
-      t.equal(d.every(function(t) { return t.k2 === s.key; }), true);
+      t.equal(d.length, len === undefined ? i + 1 : len);
+      t.equal(d.every(t => t.k2 === s.key), true);
     };
   }
 
-  var key1 = util.field('k1'),
-      key2 = util.field('k2'),
+  var key1 = field('k1'),
+      key2 = field('k2'),
       df = new vega.Dataflow(),
       source = df.add(Collect),
       facet = df.add(Facet, {subflow:subflow, key:key1, pulse:source});
@@ -123,14 +154,14 @@ tape('Facet handles key parameter change', function(t) {
 tape('Facet key cache does not leak memory', function(t) {
   var df = new vega.Dataflow(),
       c0 = df.add(Collect),
-      ft = df.add(Facet, {subflow:subflow, key:util.field('key'), pulse:c0}),
-      n = df.cleanThreshold + 1;
+      ft = df.add(Facet, {subflow:subflow, key:field('key'), pulse:c0}),
+      N = df.cleanThreshold + 1;
 
   function subflow(df) {
     return df.add(Collect);
   }
 
-  function generate() {
+  function generate(n) {
     for (var data = [], i=0; i<n; ++i) {
       data.push({id: i, key: i % 4});
     }
@@ -138,8 +169,13 @@ tape('Facet key cache does not leak memory', function(t) {
   }
 
   // burn in by filling up to threshold, then remove all
-  df.pulse(c0, changeset().insert(generate())).run();
-  df.pulse(c0, changeset().remove(util.truthy)).run();
+  df.pulse(c0, changeset().insert(generate(N))).run();
+  df.pulse(c0, changeset().remove(truthy).clean(false)).run();
+  t.equal(ft._keys.empty, 0, 'Zero empty map entries');
+
+  // now test with explicit clean request
+  df.pulse(c0, changeset().insert(generate(50))).run();
+  df.pulse(c0, changeset().remove(truthy).clean(true)).run();
   t.equal(ft._keys.empty, 0, 'Zero empty map entries');
 
   t.end();

--- a/packages/vega-util/src/fastmap.js
+++ b/packages/vega-util/src/fastmap.js
@@ -16,10 +16,10 @@ export default function(input) {
     empty: 0,
     object: obj,
     has: has,
-    get: function(key) {
+    get(key) {
       return has(key) ? obj[key] : undefined;
     },
-    set: function(key, value) {
+    set(key, value) {
       if (!has(key)) {
         ++map.size;
         if (obj[key] === NULL) --map.empty;
@@ -27,7 +27,7 @@ export default function(input) {
       obj[key] = value;
       return this;
     },
-    delete: function(key) {
+    delete(key) {
       if (has(key)) {
         --map.size;
         ++map.empty;
@@ -35,11 +35,11 @@ export default function(input) {
       }
       return this;
     },
-    clear: function() {
+    clear() {
       map.size = map.empty = 0;
       map.object = obj = {};
     },
-    test: function(_) {
+    test(_) {
       if (arguments.length) {
         test = _;
         return map;
@@ -47,7 +47,7 @@ export default function(input) {
         return test;
       }
     },
-    clean: function() {
+    clean() {
       var next = {},
           size = 0,
           key, value;

--- a/packages/vega-util/src/visitArray.js
+++ b/packages/vega-util/src/visitArray.js
@@ -1,7 +1,7 @@
 export default function(array, filter, visitor) {
   if (array) {
-    var i = 0, n = array.length, t;
     if (filter) {
+      var i = 0, n = array.length, t;
       for (; i<n; ++i) {
         if (t = filter(array[i])) visitor(t, i, array);
       }

--- a/packages/vega/test/web/stream-nested.html
+++ b/packages/vega/test/web/stream-nested.html
@@ -32,15 +32,19 @@ const runtimeSpec = vega.parse({
       "name": "xscale",
       "type": "band",
       "range": "width",
-      "domain": {"data": "table", "field": "u"}
+      "domain": {"signal": "sequence(1, 21, 1)"},
     },
     {
       "name": "yscale",
       "type": "linear",
       "range": "height",
-      "domain": {"data": "table", "field": "v"},
-      "zero": true,
-      "nice": true
+      "domain": [0, 100]
+    },
+    {
+      "name": "color",
+      "type": "ordinal",
+      "domain": {"signal": "sequence(0, 20, 1)"},
+      "range": {"scheme": "category20"}
     }
   ],
 
@@ -51,20 +55,27 @@ const runtimeSpec = vega.parse({
 
   "marks": [
     {
-      "type": "rect",
-      "from": {"data": "table"},
-      "encode": {
-        "update": {
-          "x": {"scale": "xscale", "field": "u", "offset": 1},
-          "width": {"scale": "xscale", "band": 1, "offset": -1},
-          "y": {"scale": "yscale", "field": "v"},
-          "y2": {"scale": "yscale", "value": 0},
-          "fill": {"value": "steelblue"}
-        },
-        "hover": {
-          "fill": {"value": "red"}
+      "type": "group",
+      "from": {
+        "facet": {
+          "data": "table",
+          "name": "facet",
+          "groupby": ["k"]
         }
-      }
+      },
+      "marks": [
+        {
+          "type": "line",
+          "from": {"data": "facet"},
+          "encode": {
+            "update": {
+              "x": {"scale": "xscale", "field": "u", "band": 0.5},
+              "y": {"scale": "yscale", "field": "v"},
+              "stroke": {"scale": "color", "signal": "(datum.k-1) % 20"}
+            }
+          }
+        }
+      ]
     },
     {
       "type": "text",
@@ -83,11 +94,18 @@ const runtimeSpec = vega.parse({
   ]
 });
 
-let key = 0;
+let k = 0;
 function generate(n) {
   const data = [];
-  for (let i=0; i<n; ++i) {
-    data.push({u: 1 + (key++ % 100), v: 5 + ~~(90 * Math.random())});
+  for (let j=0; j<n; ++j) {
+    ++k;
+    for (let i=0; i<20; ++i) {
+      data.push({
+        k: k,
+        u: i + 1,
+        v: i ? (data[data.length-1].v + (2*Math.random() - 1)) : (5 + ~~(90 * Math.random()))
+      });
+    }
   }
   return data;
 }
@@ -98,7 +116,18 @@ const view = new vega.View(runtimeSpec, {
   hover:     true
 });
 
-const join = view._runtime.nodes[85];
+const facet = view._runtime.nodes[94];
+
+function step() {
+  view.change('table', vega.changeset()
+      .insert(generate(1))
+      .remove(d => d.k === k-20)
+    )
+    .signal('count', view.signal('count') + 1) // cycles so far
+    .signal('size', Object.keys(facet.value).length
+      + '/' + view._runtime.subcontext.length)
+    .runAsync();
+}
 
 view.insert('table', generate(20))
     .signal('count', 20)
@@ -106,19 +135,10 @@ view.insert('table', generate(20))
 
 // clean caches once they have 500 empty slots
 view.cleanThreshold = 500;
-let clean = true;
 
-function step() {
-  view.change('table', vega.changeset().clean(clean)
-      .remove(view.data('table')[0])
-      .insert(generate(1)))
-    .signal('count', view.signal('count') + 1) // tuples so far
-    .signal('size', join.value.size) // datajoin map size
-    .runAsync();
-}
+let intId;
 
-function start(gc) {
-  clean = !!gc;
+function start() {
   intId = setInterval(step, 10);
 }
 


### PR DESCRIPTION
For performance, Vega caches a lot of internal data structures, including calculated tuples, scenegraph items, and SVG DOM nodes. Previously, nested scopes (such as those created for facetted data) that result in vega-runtime subcontexts were never cleaned. If no external View API calls are made, this is fine, and actually improves performance for interaction-driven dynamic filtering (as we can reuse cached objects rather than reinstantiating them). However, when providing streaming data to Vega through the View API, uncleaned caches and subcontexts can result in substantial memory leaks that also eventually degrade performance.

This PR adds new external mechanisms for clearing caches and detaching subflows to support streaming data within nested specifications. When input data is removed via a View API call or signal-valued URL, Vega will now by default trigger garbage collection to reclaim resources. This behavior can be disabled by calling `clean(false)` on a constructed ChangeSet before passing it to the View API.

**vega**

- Update `stream.html` and `stream-nested.html` performance test pages.

**vega-dataflow**

- Add `detach` method to `Operator` to remove adjacent edges (listeners) from the dataflow graph.
- Add `clean` setter to `ChangeSet`, set to `true` by default if any tuples are removed.
- Add `clean` getter/setter to Pulse, propagate value to forked pulses if they share a data `source`.

**vega-encode**

- Update `DataJoin` transform to clean internal map when `pulse.clean()` is true.

**vega-runtime**

- Add runtime `detach` method to remove subcontexts. Export as `detachSubflow` on the head operator of a generated subflow.

**vega-transforms**

- Update `Aggregate` transform to clean internal map when `pulse.clean()` is true.
- Update `Facet`, `PreFacet`, and `Subflow` transforms to prune subflows in response to `pulse.clean()`.
- Update `Load` transform to set `pulse.clean(true)` when removing loaded data.

**vega-util**

- Refactor code for `fastmap` and `visitArray` utilities.