### PR TITLE
Treat empty string as null in aggregates and statistics.

### DIFF
--- a/docs/docs/transforms/aggregate.md
+++ b/docs/docs/transforms/aggregate.md
@@ -25,8 +25,8 @@ All valid aggregate operations.
 | Operation | Description  |
 | :-------- | :------------|
 | count     | The total count of data objects in the group.|
-| valid     | The count of field values that are not null, undefined or NaN.|
-| missing   | The count of null or undefined field values.|
+| valid     | The count of field values that are not missing or `NaN`.|
+| missing   | The count of `null`, `undefined`, or empty string (`''`) field values.|
 | distinct  | The count of distinct field values.|
 | sum       | The sum of field values.|
 | product   | The product of field values. {% include tag ver="5.10" %}|

--- a/packages/vega-statistics/src/numbers.js
+++ b/packages/vega-statistics/src/numbers.js
@@ -1,14 +1,15 @@
 export default function*(values, valueof) {
-  if (valueof === undefined) {
+  if (valueof == null) {
     for (let value of values) {
-      if (value != null && (value = +value) >= value) {
+      if (value != null && value !== '' && (value = +value) >= value) {
         yield value;
       }
     }
   } else {
     let index = -1;
     for (let value of values) {
-      if ((value = valueof(value, ++index, values)) != null && (value = +value) >= value) {
+      value = valueof(value, ++index, values);
+      if (value != null && value !== '' && (value = +value) >= value) {
         yield value;
       }
     }

--- a/packages/vega-statistics/test/quartiles-test.js
+++ b/packages/vega-statistics/test/quartiles-test.js
@@ -13,3 +13,16 @@ tape('quartiles calculates quartile values', function(t) {
 
   t.end();
 });
+
+tape('quartiles ignores invalid values', function(t) {
+  // unsorted
+  var a = [9, 7, null, 8, 1, NaN, 2, 3, undefined, 4, 5, '', 6];
+
+  // with number array
+  t.deepEqual([3, 5, 7], quartiles(a));
+
+  // with object array
+  t.deepEqual([3, 5, 7], quartiles(a.map(_ => ({v:_})), _ => _.v));
+
+  t.end();
+});

--- a/packages/vega-transforms/src/util/AggregateOps.js
+++ b/packages/vega-transforms/src/util/AggregateOps.js
@@ -173,14 +173,14 @@ function init() {
 }
 
 function add(v, t) {
-  if (v == null) { ++this.missing; return; }
+  if (v == null || v === '') { ++this.missing; return; }
   if (v !== v) return;
   ++this.valid;
   this._ops.forEach(op => op.add(this, v, t));
 }
 
 function rem(v, t) {
-  if (v == null) { --this.missing; return; }
+  if (v == null || v === '') { --this.missing; return; }
   if (v !== v) return;
   --this.valid;
   this._ops.forEach(op => op.rem(this, v, t));


### PR DESCRIPTION
**vega-statistics**

- Fix `numbers` utility to exclude empty string.

**vega-transforms**

- Fix aggregate ops to treat empty string as a missing value.

Fix #2676.