### PR TITLE
feat: add types for Vega-Expression package

### DIFF
--- a/packages/vega-expression/README.md
+++ b/packages/vega-expression/README.md
@@ -36,7 +36,7 @@ function names to function values. The values may either be strings (which will 
 - *globalvar*: (Required) The name of the variable upon which to lookup global variables. This variable name will be included in the generated code as the scope for any global variable references. Alternatively, this property can be a function that maps from variable names in the source input to generated code to write to the output.
 
 <a name="constants" href="#constants">#</a>
-<b>constants</b>(<i>codegen</i>)
+<b>constants</b>
 [<>](https://github.com/vega/vega/blob/master/packages/vega-expression/src/constants.js "Source")
 
 An object defining default constant values for the Vega expression language. The object maps from constant identifiers to JavaScript code to defining the constant value (for example, `'PI'` maps to `'Math.PI`').

--- a/packages/vega-expression/index.d.ts
+++ b/packages/vega-expression/index.d.ts
@@ -1,21 +1,51 @@
-// TODO: add missing types
+/** Parse a JavaScript *expression* string and return the resulting abstract syntax tree in the ESTree format */
+export function parse(expression: string): object;
 
-export function parse(expression: string): any;
+/**
+ * Create a new output code generator configured according to the provided options:
+ * - `constants` — a hash of allowed top-level constant values
+ * - `functions` — a function that is given an AST visitor instance as input and returns an object of allowed functions
+ * - `blacklist` — an array of variable names that may not be referenced within the expression scope
+ * - `whitelist` — an array of variable names that may be referenced within the expression scope
+ * - `fieldvar` — the name of the primary data input argument within the generated expression function
+ * - `globalvar` — the name of the variable upon which to lookup global variables
+ */
+export function codegen(options: {
+  /** A hash of allowed top-level constant values */
+  constants?: { [cn: string]: string };
 
-export function codegen(params: {
-  constants?: object;
-  functions?: { [fn: string]: Function };
+  /** A function that is given an AST visitor instance as input and returns an object of allowed functions */
+  functions?: (astVisitor) => { [fn: string]: string | ((args) => string) };
+
+  /** An array of variable names that may not be referenced within the expression scope */
   blacklist?: string[];
+
+  /** An array of variable names that may be referenced within the expression scope */
   whitelist?: string[];
+
+  /** The name of the primary data input argument within the generated expression function */
   fieldvar?: string;
-  globalvar: string;
-}): (
-  ast: any
-) => {
-  /** The generated code as a string. */
+
+  /** The name of the variable upon which to lookup global variables */
+  globalvar: string | ((id: string) => string);
+}): (ast) => {
+  /** The generated code as a string */
   code: string;
-  /** A hash of all properties referenced within the fieldvar scope. */
+
+  /** A hash of all properties referenced within the _fieldvar_ scope */
   fields: string[];
+
   /** A hash of all properties referenced outside a provided whitelist */
   globals: string[];
 };
+
+/** An object defining default constant values for the Vega expression language */
+export const constants: { [cn: string]: string };
+
+/** Given a *codegen* instance as input, returns an object defining all valid function names for use within an expression */
+export function functions(codegen): {
+  [fn: string]: string | (() => string);
+};
+
+/** Constructor for a node in an expression abstract syntax tree (AST) */
+export function ASTNode(type: string): void;

--- a/packages/vega-expression/index.d.ts
+++ b/packages/vega-expression/index.d.ts
@@ -1,16 +1,7 @@
 /** Parse a JavaScript *expression* string and return the resulting abstract syntax tree in the ESTree format */
 export function parse(expression: string): object;
 
-/**
- * Create a new output code generator configured according to the provided options:
- * - `constants` — a hash of allowed top-level constant values
- * - `functions` — a function that is given an AST visitor instance as input and returns an object of allowed functions
- * - `blacklist` — an array of variable names that may not be referenced within the expression scope
- * - `whitelist` — an array of variable names that may be referenced within the expression scope
- * - `fieldvar` — the name of the primary data input argument within the generated expression function
- * - `globalvar` — the name of the variable upon which to lookup global variables
- */
-export function codegen(options: {
+interface CodegenOptions {
   /** A hash of allowed top-level constant values */
   constants?: { [cn: string]: string };
 
@@ -28,7 +19,10 @@ export function codegen(options: {
 
   /** The name of the variable upon which to lookup global variables */
   globalvar: string | ((id: string) => string);
-}): (ast) => {
+}
+
+/** Create a new output code generator configured according to the provided options */
+export function codegen(options: CodegenOptions): (ast) => {
   /** The generated code as a string */
   code: string;
 


### PR DESCRIPTION
## This PR improves the definition of the types for Vega-Expression

Fix `constants` in the Vega-Expression documentation

`constants` is an object, not a function; it doesn't take arguments

---

Improve types for Vega-Expression

- Correct the types for `parse` and `codegen`
- Add the types for `constants`, `functions`, and `ASTNode`
- Add documentation helping development:
![image](https://user-images.githubusercontent.com/29386932/86503233-8c275a00-bdde-11ea-88a8-9d2768fdad3b.png)

---

Please let me know if you'd like me to change anything.