### PR TITLE
fix: always resolve item for all events before calling handlers

### DIFF
--- a/packages/vega-scenegraph/src/CanvasHandler.js
+++ b/packages/vega-scenegraph/src/CanvasHandler.js
@@ -9,6 +9,7 @@ import {
 import point from './util/point';
 import {domFind} from './util/dom';
 import {inherits} from 'vega-util';
+import resolveItem from './util/resolveItem';
 
 export default function CanvasHandler(loader, tooltip) {
   Handler.call(this, loader, tooltip);
@@ -141,7 +142,7 @@ prototype.touchend = function(evt) {
 
 // fire an event
 prototype.fire = function(type, evt, touch) {
-  const a = touch ? this._touch : this._active,
+  const a = resolveItem(touch ? this._touch : this._active, evt, this.canvas(), this._origin),
         h = this._handlers[type];
 
   // set event type relative to scenegraph items

--- a/packages/vega-scenegraph/src/Handler.js
+++ b/packages/vega-scenegraph/src/Handler.js
@@ -1,5 +1,4 @@
 import {domCreate} from './util/dom';
-import resolveItem from './util/resolveItem';
 import {loader} from 'vega-loader';
 
 /**
@@ -161,7 +160,6 @@ prototype.handleHref = function(event, item, href) {
  */
 prototype.handleTooltip = function(event, item, show) {
   if (item && item.tooltip != null) {
-    item = resolveItem(item, event, this.canvas(), this._origin);
     const value = (show && item && item.tooltip) || null;
     this._tooltip.call(this._obj, this, event, item, value);
   }

--- a/packages/vega-scenegraph/src/SVGHandler.js
+++ b/packages/vega-scenegraph/src/SVGHandler.js
@@ -2,6 +2,7 @@ import Handler from './Handler';
 import {domFind} from './util/dom';
 import {HrefEvent, TooltipHideEvent, TooltipShowEvent} from './util/events';
 import {inherits} from 'vega-util';
+import resolveItem from './util/resolveItem';
 
 export default function SVGHandler(loader, tooltip) {
   Handler.call(this, loader, tooltip);
@@ -40,6 +41,7 @@ prototype.canvas = function() {
 const listener = (context, handler) => evt => {
   let item = evt.target.__data__;
   item = Array.isArray(item) ? item[0] : item;
+  item = resolveItem(item, evt, context.canvas(), context._origin);
   evt.vegaType = evt.type;
   handler.call(context._obj, evt, item);
 };


### PR DESCRIPTION
For area and line marks the data point reported to all event handlers was always the first point in the series regardless where along the area or line the cursor was positioned. However, for tooltips the values displayed were correct. After looking at the code a bit I found that the `resolveItem` function was only being called in the tooltip handler so this moves the resolution up one level to the base event handlers for both SVG and Canvas so everything has the correct data.