### PR TITLE
Fix: Vega refresh fails when using streaming data

### DIFF
--- a/packages/vega-encode/src/DataJoin.js
+++ b/packages/vega-encode/src/DataJoin.js
@@ -81,7 +81,7 @@ prototype.transform = function(_, pulse) {
     const k = key(t),
           x = map.get(k);
 
-    if (t === x.datum && !x.exit) {
+    if (x && t === x.datum && !x.exit) {
       out.rem.push(x);
       x.exit = true;
       ++map.empty;


### PR DESCRIPTION
I'm not sure of the analysis :
When using vega with streaming data and within nested specifications i found a case where x is undefined and vega refresh fails.
Just testing if x is defined solved the problem