### PR TITLE
Don't pass rem tuples to newly instantiated operators.

### DIFF
--- a/packages/vega-dataflow/src/Pulse.js
+++ b/packages/vega-dataflow/src/Pulse.js
@@ -173,11 +173,16 @@ Pulse.prototype = {
    */
   addAll() {
     let p = this;
-    if (!p.source || p.source.length === p.add.length) {
+    const reuse = !p.source
+      || p.add === p.rem // special case for indexed set (e.g., crossfilter)
+      || (!p.rem.length && p.source.length === p.add.length);
+
+    if (reuse) {
       return p;
     } else {
       p = new Pulse(this.dataflow).init(this);
       p.add = p.source;
+      p.rem = []; // new operators can ignore rem #2769
       return p;
     }
   },

--- a/packages/vega-transforms/src/util/AggregateKeys.js
+++ b/packages/vega-transforms/src/util/AggregateKeys.js
@@ -1,6 +1,6 @@
 export function multikey(f) {
-  return function(x) {
-    var n = f.length,
+  return x => {
+    let n = f.length,
         i = 1,
         k = String(f[0](x));
 

--- a/packages/vega-transforms/src/util/AggregateOps.js
+++ b/packages/vega-transforms/src/util/AggregateOps.js
@@ -192,9 +192,9 @@ function set(t) {
 }
 
 export function compileMeasures(agg, field) {
-  var get = field || identity,
-      ops = resolve(agg),
-      out = agg.slice().sort(compareIndex);
+  const get = field || identity,
+        ops = resolve(agg),
+        out = agg.slice().sort(compareIndex);
 
   function ctr(cell) {
     this._ops = ops;

--- a/packages/vega-transforms/src/util/Distributions.js
+++ b/packages/vega-transforms/src/util/Distributions.js
@@ -8,7 +8,7 @@ import {
 
 import {error, hasOwnProperty} from 'vega-util';
 
-var Distributions = {
+const Distributions = {
   kde:       randomKDE,
   mixture:   randomMixture,
   normal:    randomNormal,
@@ -16,9 +16,9 @@ var Distributions = {
   uniform:   randomUniform
 };
 
-var DISTRIBUTIONS = 'distributions',
-    FUNCTION = 'function',
-    FIELD = 'field';
+const DISTRIBUTIONS = 'distributions',
+      FUNCTION = 'function',
+      FIELD = 'field';
 
 /**
  * Parse a parameter object for a probability distribution.
@@ -32,14 +32,14 @@ var DISTRIBUTIONS = 'distributions',
  * @return {object} - The output distribution object.
  */
 export default function parse(def, data) {
-  var func = def[FUNCTION];
+  const func = def[FUNCTION];
   if (!hasOwnProperty(Distributions, func)) {
     error('Unknown distribution function: ' + func);
   }
 
-  var d = Distributions[func]();
+  const d = Distributions[func]();
 
-  for (var name in def) {
+  for (const name in def) {
     // if data field, extract values
     if (name === FIELD) {
       d.data((def.from || data()).map(def[name]));
@@ -47,7 +47,7 @@ export default function parse(def, data) {
 
     // if distribution mixture, recurse to parse each definition
     else if (name === DISTRIBUTIONS) {
-      d[name](def[name].map(function(_) { return parse(_, data); }));
+      d[name](def[name].map(_ => parse(_, data)));
     }
 
     // otherwise, simply set the parameter

--- a/packages/vega-transforms/src/util/SortedList.js
+++ b/packages/vega-transforms/src/util/SortedList.js
@@ -1,19 +1,19 @@
 import {merge} from 'vega-util';
 
 export default function(idFunc, source, input) {
-  var $ = idFunc,
+  let $ = idFunc,
       data = source || [],
       add = input || [],
       rem = {},
       cnt = 0;
 
   return {
-    add: function(t) { add.push(t); },
-    remove: function(t) { rem[$(t)] = ++cnt; },
-    size: function() { return data.length; },
-    data: function(compare, resort) {
+    add: t => add.push(t),
+    remove: t => rem[$(t)] = ++cnt,
+    size: () => data.length,
+    data: (compare, resort) => {
       if (cnt) {
-        data = data.filter(function(t) { return !rem[$(t)]; });
+        data = data.filter(t => !rem[$(t)]);
         rem = {};
         cnt = 0;
       }

--- a/packages/vega-transforms/src/util/TupleStore.js
+++ b/packages/vega-transforms/src/util/TupleStore.js
@@ -7,7 +7,7 @@ export default function TupleStore(key) {
   this.reset();
 }
 
-var prototype = TupleStore.prototype;
+const prototype = TupleStore.prototype;
 
 prototype.reset = function() {
   this._add = [];
@@ -29,7 +29,7 @@ prototype.values = function() {
   this._get = null;
   if (this._rem.length === 0) return this._add;
 
-  var a = this._add,
+  let a = this._add,
       r = this._rem,
       k = this._key,
       n = a.length,
@@ -56,7 +56,7 @@ prototype.values = function() {
 // memoizing statistics methods
 
 prototype.distinct = function(get) {
-  var v = this.values(),
+  let v = this.values(),
       n = v.length,
       map = {},
       count = 0, s;
@@ -74,8 +74,8 @@ prototype.distinct = function(get) {
 
 prototype.extent = function(get) {
   if (this._get !== get || !this._ext) {
-    var v = this.values(),
-        i = extentIndex(v, get);
+    const v = this.values(),
+          i = extentIndex(v, get);
     this._ext = [v[i[0]], v[i[1]]];
     this._get = get;
   }
@@ -91,12 +91,12 @@ prototype.argmax = function(get) {
 };
 
 prototype.min = function(get) {
-  var m = this.extent(get)[0];
+  const m = this.extent(get)[0];
   return m != null ? get(m) : undefined;
 };
 
 prototype.max = function(get) {
-  var m = this.extent(get)[1];
+  const m = this.extent(get)[1];
   return m != null ? get(m) : undefined;
 };
 

--- a/packages/vega-transforms/src/util/WindowOps.js
+++ b/packages/vega-transforms/src/util/WindowOps.js
@@ -145,4 +145,4 @@ function find(field, data, index) {
   return -1;
 }
 
-export var ValidWindowOps = Object.keys(WindowOps);
+export const ValidWindowOps = Object.keys(WindowOps);

--- a/packages/vega-transforms/src/util/util.js
+++ b/packages/vega-transforms/src/util/util.js
@@ -3,14 +3,12 @@ import {accessorName} from 'vega-util';
 // use either provided alias or accessor field name
 export function fieldNames(fields, as) {
   if (!fields) return null;
-  return fields.map(function(f, i) {
-    return as[i] || accessorName(f);
-  });
+  return fields.map((f, i) => as[i] || accessorName(f));
 }
 
 export function partition(data, groupby, field) {
-  var groups = [],
-      get = function(f) { return f(t); },
+  let groups = [],
+      get = f => f(t),
       map, i, n, t, k, g;
 
   // partition data points into groups


### PR DESCRIPTION
**vega-dataflow**
- Fix Pulse `addAll` to clear rem set when applicable. This prevents tuple removal from being invoked on newly instantiated operators that never observed those tuples in the first place.

**vega-transforms**
- Update transform utils to use leaner, more modern, syntax.

Close #2605 (this PR supercedes it)