### PR TITLE
Prevent scaleX/Y SVG transforms on non-path marks.

### DIFF
--- a/packages/vega-scenegraph/src/marks/markItemPath.js
+++ b/packages/vega-scenegraph/src/marks/markItemPath.js
@@ -3,13 +3,13 @@ import context from '../bound/boundContext';
 import {intersectPath} from '../util/intersect';
 import {drawAll} from '../util/canvas/draw';
 import {pickPath} from '../util/canvas/pick';
-import {transformItem} from '../util/svg/transform';
+import {rotateItem} from '../util/svg/transform';
 import {DegToRad} from '../util/constants';
 
 export default function(type, shape, isect) {
 
   function attr(emit, item) {
-    emit('transform', transformItem(item));
+    emit('transform', rotateItem(item));
     emit('d', shape(null, item));
   }
 

--- a/packages/vega-scenegraph/src/util/svg/transform.js
+++ b/packages/vega-scenegraph/src/util/svg/transform.js
@@ -14,8 +14,13 @@ export function translateItem(item) {
   return translate(item.x || 0, item.y || 0);
 }
 
+export function rotateItem(item) {
+  return translate(item.x || 0, item.y || 0)
+    + (item.angle ? ' ' + rotate(item.angle) : '');
+}
+
 export function transformItem(item) {
   return translate(item.x || 0, item.y || 0)
     + (item.angle ? ' ' + rotate(item.angle) : '')
-    + (item.scaleX || item.scaleY ? ' ' + scale(item.scaleX || 1, item.scaleY || 1) : '');   
+    + (item.scaleX || item.scaleY ? ' ' + scale(item.scaleX || 1, item.scaleY || 1) : '');
 }


### PR DESCRIPTION
**vega-scenegraph**

- Fix leaking SVG scaleX/Y transforms on non-path marks.

Fix #2738.