### PR TITLE
style: prefer const

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,6 +18,7 @@ module.exports = {
     'no-fallthrough': ['error', { commentPattern: 'break omitted' }],
     'semi': 'error',
     'quotes': ['error', 'single', { avoidEscape: true }],
+    'prefer-const': 'warn',  // TODO: make error when we don't define multiple variables at once anymore
     'sort-imports': ['error', {
       ignoreCase: false,
       ignoreDeclarationSort: true

--- a/packages/vega-dataflow/src/ChangeSet.js
+++ b/packages/vega-dataflow/src/ChangeSet.js
@@ -28,7 +28,7 @@ export default function changeset() {
       return this;
     },
     modify(t, field, value) {
-      let m = {field: field, value: constant(value)};
+      const m = {field: field, value: constant(value)};
       if (isFunction(t)) {
         m.filter = t;
         modp.push(m);

--- a/packages/vega-functions/src/codegen.js
+++ b/packages/vega-functions/src/codegen.js
@@ -294,7 +294,7 @@ export const codeGenerator = codegen(codegenParams);
 function buildFunctions(codegen) {
   const fn = functions(codegen);
   eventFunctions.forEach(name => fn[name] = eventPrefix + name);
-  for (let name in functionContext) { fn[name] = thisPrefix + name; }
+  for (const name in functionContext) { fn[name] = thisPrefix + name; }
   extend(fn, internalScaleFunctions(codegen, functionContext, astVisitors));
   return fn;
 }

--- a/packages/vega-functions/src/functions/modify.js
+++ b/packages/vega-functions/src/functions/modify.js
@@ -18,7 +18,7 @@ function equalArray(a, b) {
 }
 
 function equalObject(a, b) {
-  for (let key in a) {
+  for (const key in a) {
     if (!equal(a[key], b[key])) return false;
   }
   return true;

--- a/packages/vega-functions/test/scale-gradient-test.js
+++ b/packages/vega-functions/test/scale-gradient-test.js
@@ -3,7 +3,7 @@ var tape = require('tape'),
     {scaleGradient} = require('../');
 
 tape('scaleGradient handles zero-span domain', function(t) {
-  let s = scale('linear')().range(['#f00', '#00f']);
+  const s = scale('linear')().range(['#f00', '#00f']);
 
   function testGradient(domain) {
     const g = scaleGradient.call({}, s.domain(domain), [0, 0], [1, 0], 3),

--- a/packages/vega-geo/src/util/density2D.js
+++ b/packages/vega-geo/src/util/density2D.js
@@ -63,7 +63,7 @@ export default function() {
 
     // scale density estimates
     // density in points per square pixel or probability density
-    let s = counts ? Math.pow(2, -2 * k) : 1 / sum(values);
+    const s = counts ? Math.pow(2, -2 * k) : 1 / sum(values);
     for (let i=0, sz=n*m; i<sz; ++i) values[i] *= s;
 
     return {

--- a/packages/vega-label/src/util/placeAreaLabel/placeFloodFill.js
+++ b/packages/vega-label/src/util/placeAreaLabel/placeFloodFill.js
@@ -6,7 +6,7 @@ const X_DIR = [-1, -1, 1, 1];
 const Y_DIR = [-1, 1, -1, 1];
 
 export default function($, bitmaps, avoidBaseMark, markIndex) {
-  let width = $.width,
+  const width = $.width,
       height = $.height,
       bm0 = bitmaps[0], // where labels have been placed
       bm1 = bitmaps[1], // area outlines

--- a/packages/vega-label/src/util/placeAreaLabel/placeNaive.js
+++ b/packages/vega-label/src/util/placeAreaLabel/placeNaive.js
@@ -1,7 +1,7 @@
 import {textMetrics} from 'vega-scenegraph';
 
 export default function($, bitmaps, avoidBaseMark, markIndex) {
-  let width = $.width,
+  const width = $.width,
       height = $.height;
   
   // try to place a label within an input area mark

--- a/packages/vega-label/src/util/placeAreaLabel/placeReducedSearch.js
+++ b/packages/vega-label/src/util/placeAreaLabel/placeReducedSearch.js
@@ -2,7 +2,7 @@ import {textMetrics} from 'vega-scenegraph';
 import {collision, outOfBounds} from './common';
 
 export default function($, bitmaps, avoidBaseMark, markIndex) {
-  let width = $.width,
+  const width = $.width,
       height = $.height,
       bm0 = bitmaps[0], // where labels have been placed
       bm1 = bitmaps[1]; // area outlines

--- a/packages/vega-scenegraph/src/intersect.js
+++ b/packages/vega-scenegraph/src/intersect.js
@@ -26,7 +26,7 @@ function intersectMark(mark, box, filter, hits) {
       }
     } else {
       for (const test = Marks[type].isect; i<n; ++i) {
-        let item = items[i];
+        const item = items[i];
         if (intersectItem(item, box, test)) hits.push(item);
       }
     }

--- a/packages/vega-schema/src/util.js
+++ b/packages/vega-schema/src/util.js
@@ -61,7 +61,7 @@ export function object(properties, addl) {
   const p = {},
         r = [];
 
-  for (let key in properties) {
+  for (const key in properties) {
     let k = key;
     if (key.startsWith('_') && key.endsWith('_')) {
       r.push(k = key.slice(1, -1));

--- a/packages/vega-statistics/src/regression/points.js
+++ b/packages/vega-statistics/src/regression/points.js
@@ -34,7 +34,7 @@ export function points(data, x, y, sort) {
 export function visitPoints(data, x, y, callback) {
   let i = -1, u, v;
 
-  for (let d of data) {
+  for (const d of data) {
     u = x(d);
     v = y(d);
     if (u != null && (u = +u) >= u && v != null && (v = +v) >= v) {

--- a/packages/vega-transforms/src/Extent.js
+++ b/packages/vega-transforms/src/Extent.js
@@ -37,7 +37,7 @@ inherits(Extent, Transform, {
     }
 
     pulse.visit(mod ? pulse.SOURCE : pulse.ADD, t => {
-      let v = toNumber(field(t));
+      const v = toNumber(field(t));
       if (v != null) {
         // NaNs will fail all comparisons!
         if (v < min) min = v;

--- a/packages/vega-transforms/src/util/WindowOps.js
+++ b/packages/vega-transforms/src/util/WindowOps.js
@@ -1,7 +1,7 @@
 import {error, zero} from 'vega-util';
 
 export function WindowOp(op, field, param, as) {
-  let fn = WindowOps[op](field, param);
+  const fn = WindowOps[op](field, param);
   return {
     init:   fn.init || zero,
     update: function(w, t) { t[as] = fn.next(w); }
@@ -19,7 +19,7 @@ export const WindowOps = {
     return {
       init: () => rank = 1,
       next: w => {
-        let i = w.index,
+        const i = w.index,
             data = w.data;
         return (i && w.compare(data[i - 1], data[i])) ? (rank = i + 1) : rank;
       }
@@ -30,14 +30,14 @@ export const WindowOps = {
     return {
       init: () => drank = 1,
       next: w => {
-        let i = w.index,
+        const i = w.index,
             d = w.data;
         return (i && w.compare(d[i - 1], d[i])) ? ++drank : drank;
       }
     };
   },
   percent_rank: function() {
-    let rank = WindowOps.rank(),
+    const rank = WindowOps.rank(),
         next = rank.next;
     return {
       init: rank.init,
@@ -63,7 +63,7 @@ export const WindowOps = {
   ntile: function(field, num) {
     num = +num;
     if (!(num > 0)) error('ntile num must be greater than zero.');
-    let cume = WindowOps.cume_dist(),
+    const cume = WindowOps.cume_dist(),
         next = cume.next;
     return {
       init: cume.init,
@@ -75,7 +75,7 @@ export const WindowOps = {
     offset = +offset || 1;
     return {
       next: w => {
-        let i = w.index - offset;
+        const i = w.index - offset;
         return i >= 0 ? field(w.data[i]) : null;
       }
     };
@@ -84,7 +84,7 @@ export const WindowOps = {
     offset = +offset || 1;
     return {
       next: w => {
-        let i = w.index + offset,
+        const i = w.index + offset,
             d = w.data;
         return i < d.length ? field(d[i]) : null;
       }
@@ -106,7 +106,7 @@ export const WindowOps = {
     if (!(nth > 0)) error('nth_value nth must be greater than zero.');
     return {
       next: w => {
-        let i = w.i0 + (nth - 1);
+        const i = w.i0 + (nth - 1);
         return i < w.i1 ? field(w.data[i]) : null;
       }
     };
@@ -117,7 +117,7 @@ export const WindowOps = {
     return {
       init: () => prev = null,
       next: w => {
-        let v = field(w.data[w.index]);
+        const v = field(w.data[w.index]);
         return v != null ? (prev = v) : prev;
       }
     };
@@ -127,7 +127,7 @@ export const WindowOps = {
     return {
       init: () => (v = null, i = -1),
       next: w => {
-        let d = w.data;
+        const d = w.data;
         return w.index <= i ? v
           : (i = find(field, d, w.index)) < 0
             ? (i = d.length, v = null)
@@ -139,7 +139,7 @@ export const WindowOps = {
 
 function find(field, data, index) {
   for (let n = data.length; index < n; ++index) {
-    let v = field(data[index]);
+    const v = field(data[index]);
     if (v != null) return index;
   }
   return -1;

--- a/packages/vega-transforms/src/util/WindowState.js
+++ b/packages/vega-transforms/src/util/WindowState.js
@@ -23,7 +23,7 @@ export default function WindowState(_) {
   visitInputs(_.sort);
 
   ops.forEach(function(op, i) {
-    let field = fields[i],
+    const field = fields[i],
         mname = accessorName(field),
         name = measureName(op, mname, as[i]);
 
@@ -89,7 +89,7 @@ prototype.update = function(w, t) {
 function cell(measures, counts, countOnly) {
   measures = measures.map(m => compileMeasures(m, m.field));
 
-  let cell = {
+  const cell = {
     num:   0,
     agg:   null,
     store: false,

--- a/packages/vega-view-transforms/src/ViewLayout.js
+++ b/packages/vega-view-transforms/src/ViewLayout.js
@@ -95,7 +95,7 @@ function layoutGroup(view, group, _) {
     });
 
     // perform grid layout for each orient group
-    for (let orient in l) {
+    for (const orient in l) {
       const g = l[orient];
       gridLayout(view, g, legendParams(
         g, orient, _.legends, xBounds, yBounds, width, height


### PR DESCRIPTION
There are still many places where we can't use const because multiple variables are defined with a single `var/let` but we can fix those later.

Maybe we can run a codemod (https://github.com/facebook/codemod) to upgrade all of the code automatically. But at the same time we should probably switch to prettier and babel. 