### PR TITLE
chore: upgrade to ts 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "rollup": "^2.26.3",
     "tape": "^5.0.1",
     "terser": "^5.1.0",
-    "typescript": "^3.9.7",
+    "typescript": "~4.0.2",
     "vega-datasets": "^2.1.0"
   },
   "workspaces": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -7598,10 +7598,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.9.7:
-  version "3.9.7"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
-  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+typescript@~4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.2.tgz#7ea7c88777c723c681e33bf7988be5d008d05ac2"
+  integrity sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==
 
 uglify-js@^3.1.4:
   version "3.10.1"


### PR DESCRIPTION
Ts doesn't follow semantic versioning so I switched to ~ instead of ^. 