### PR TITLE
ES6 Modernization: convert var to const or let

### DIFF
--- a/packages/vega-canvas/test/canvas-test.js
+++ b/packages/vega-canvas/test/canvas-test.js
@@ -3,7 +3,7 @@ var tape = require('tape'),
     canvas = require('canvas');
 
 tape('Canvas loader loads node canvas', t => {
-  var c = vega.canvas(10, 20);
+  let c = vega.canvas(10, 20);
   t.ok(c);
   t.ok(c.getContext);
   t.equal(c.width, 10);

--- a/packages/vega-crossfilter/test/crossfilter-test.js
+++ b/packages/vega-crossfilter/test/crossfilter-test.js
@@ -8,7 +8,7 @@ var tape = require('tape'),
     ResolveFilter = xf.resolvefilter;
 
 tape('Crossfilter filters tuples', t => {
-  var data = [
+  const data = [
     {a: 1, b: 1, c:0}, {a: 2, b: 2, c:1},
     {a: 4, b: 4, c:2}, {a: 3, b: 3, c:3}
   ];
@@ -80,7 +80,7 @@ tape('Crossfilter filters tuples', t => {
 });
 
 tape('Crossfilter consolidates after remove', t => {
-  var data = [
+  const data = [
     {a: 1, b: 1, c:0}, {a: 2, b: 2, c:1},
     {a: 4, b: 4, c:2}, {a: 3, b: 3, c:3}
   ];
@@ -106,7 +106,7 @@ tape('Crossfilter consolidates after remove', t => {
   cf._dims.map(dim => {
     t.equal(dim.size(), 2);
 
-    var idx = dim.index();
+    const idx = dim.index();
     t.equal(idx[0], 1);
     t.equal(idx[1], 0);
   });

--- a/packages/vega-dataflow/test/changeset-test.js
+++ b/packages/vega-dataflow/test/changeset-test.js
@@ -2,7 +2,7 @@ var tape = require('tape'),
     vega = require('../');
 
 tape('ChangeSet adds/removes/modifies tuples', t => {
-  var data = [
+  const data = [
     {key: 'a', value: 1},
     {key: 'b', value: 2},
     {key: 'c', value: 3}
@@ -76,7 +76,7 @@ tape('ChangeSet adds/removes/modifies tuples', t => {
 });
 
 tape('ChangeSet handles conflicting changes', t => {
-  var data = [
+  const data = [
     {key: 'a', value: 1},
     {key: 'b', value: 2},
     {key: 'c', value: 3}
@@ -175,7 +175,7 @@ tape('ChangeSet handles conflicting changes', t => {
 });
 
 tape('ChangeSet handles reflow', t => {
-  var data = [
+  const data = [
     {key: 'a', value: 1},
     {key: 'b', value: 2},
     {key: 'c', value: 3}

--- a/packages/vega-dataflow/test/parameters-test.js
+++ b/packages/vega-dataflow/test/parameters-test.js
@@ -2,7 +2,7 @@ var tape = require('tape'),
     vega = require('../');
 
 tape('Parameters handles parameter values', t => {
-  var p = new vega.Parameters;
+  const p = new vega.Parameters;
 
   // test initial state
   t.equal(p.modified('foo'), false);
@@ -20,7 +20,7 @@ tape('Parameters handles parameter values', t => {
   t.equal(p.foo, 3);
 
   // test array parameter
-  var bar = ['a', 'b', 'c'];
+  const bar = ['a', 'b', 'c'];
   t.equal(p.set('bar', -1, bar), p);
   t.equal(p.modified('bar'), true);
   t.equal(p.modified('bar', 0), true);

--- a/packages/vega-encode/src/Encode.js
+++ b/packages/vega-encode/src/Encode.js
@@ -59,10 +59,10 @@ inherits(Encode, Transform, {
     }
 
     if (reenter || set !== falsy) {
-      var flag = pulse.MOD | (_.modified() ? pulse.REFLOW : 0);
+      const flag = pulse.MOD | (_.modified() ? pulse.REFLOW : 0);
       if (reenter) {
         pulse.visit(flag, t => {
-          var mod = enter(t, _) || fmod;
+          const mod = enter(t, _) || fmod;
           if (set(t, _) || mod) out.mod.push(t);
         });
         if (out.mod.length) out.modifies(enter.output);

--- a/packages/vega-encode/src/Scale.js
+++ b/packages/vega-encode/src/Scale.js
@@ -126,7 +126,7 @@ function isContinuousColor(_) {
 
 function configureDomain(scale, _, df) {
   // check raw domain, if provided use that and exit early
-  var raw = rawDomain(scale, _.domainRaw, df);
+  const raw = rawDomain(scale, _.domainRaw, df);
   if (raw > -1) return raw;
 
   var domain = _.domain,

--- a/packages/vega-encode/test/datajoin-test.js
+++ b/packages/vega-encode/test/datajoin-test.js
@@ -7,7 +7,7 @@ var tape = require('tape'),
     DataJoin = encode.datajoin;
 
 tape('DataJoin joins tuples and items', t => {
-  var data = [
+  const data = [
     {key: 'a', value: 1},
     {key: 'b', value: 2},
     {key: 'c', value: 3}

--- a/packages/vega-encode/test/scale-test.js
+++ b/packages/vega-encode/test/scale-test.js
@@ -51,7 +51,7 @@ tape('Scale respects domain configuration', t => {
 });
 
 tape('Scale respects domain padding', t => {
-  var d;
+  let d;
 
   // test linear scale padding
   d = scale({

--- a/packages/vega-encode/test/stack-test.js
+++ b/packages/vega-encode/test/stack-test.js
@@ -7,7 +7,7 @@ var tape = require('tape'),
     Stack = encode.stack;
 
 tape('Stack stacks numeric values', t => {
-  var data = [
+  const data = [
     {key: 'a', value: 1},
     {key: 'a', value: 2},
     {key: 'b', value: 3},
@@ -29,7 +29,7 @@ tape('Stack stacks numeric values', t => {
   t.equal(st.pulse.rem.length, 0);
   t.equal(st.pulse.mod.length, 0);
 
-  var d = c0.value;
+  let d = c0.value;
   t.equal(d[0].y0, 0);
   t.equal(d[0].y1, 1);
   t.equal(d[1].y0, 1);
@@ -59,7 +59,7 @@ tape('Stack stacks numeric values', t => {
 });
 
 tape('Stack stacks negative values', t => {
-  var data = [
+  const data = [
     {key: 'a', value: -1},
     {key: 'a', value: 2},
     {key: 'b', value: 3},
@@ -81,7 +81,7 @@ tape('Stack stacks negative values', t => {
   t.equal(st.pulse.rem.length, 0);
   t.equal(st.pulse.mod.length, 0);
 
-  var d = c0.value;
+  let d = c0.value;
   t.equal(d[0].y0, 0);
   t.equal(d[0].y1, -1);
   t.equal(d[1].y0, 0);
@@ -111,7 +111,7 @@ tape('Stack stacks negative values', t => {
 });
 
 tape('Stack stacks coerced string values', t => {
-  var data = [
+  const data = [
     {key: 'a', value: '1'},
     {key: 'a', value: '2'},
     {key: 'b', value: '3'},
@@ -133,7 +133,7 @@ tape('Stack stacks coerced string values', t => {
   t.equal(st.pulse.rem.length, 0);
   t.equal(st.pulse.mod.length, 0);
 
-  var d = c0.value;
+  let d = c0.value;
   t.equal(d[0].y0, 0);
   t.equal(d[0].y1, 1);
   t.equal(d[1].y0, 1);

--- a/packages/vega-event-selector/test/event-selector-test.js
+++ b/packages/vega-event-selector/test/event-selector-test.js
@@ -2,7 +2,7 @@ var tape = require('tape'),
     vega = require('../');
 
 tape('Parser parses event selector strings', t => {
-  var events;
+  let events;
 
   events = vega.selector('rect:mousedown');
   t.equal(events.length, 1);
@@ -178,7 +178,7 @@ tape('Parser parses event selector strings', t => {
 });
 
 tape('Parser allows configurable source', t => {
-  var events = vega.selector('rect:mousedown', 'scope');
+  const events = vega.selector('rect:mousedown', 'scope');
   t.equal(events.length, 1);
   t.deepEqual(events[0], {
     source: 'scope',

--- a/packages/vega-expression/src/parser.js
+++ b/packages/vega-expression/src/parser.js
@@ -152,7 +152,7 @@ function isIdentifierPart(ch) {
 
 // 7.6.1.1 Keywords
 
-var keywords = {
+const keywords = {
   'if':1, 'in':1, 'do':1,
   'var':1, 'for':1, 'new':1, 'try':1, 'let':1,
   'this':1, 'else':1, 'case':1, 'void':1, 'with':1, 'enum':1,
@@ -165,7 +165,7 @@ var keywords = {
 };
 
 function skipComment() {
-  var ch;
+  let ch;
 
   while (index < length) {
     ch = source.charCodeAt(index);
@@ -456,7 +456,7 @@ function scanPunctuator() {
 // 7.8.3 Numeric Literals
 
 function scanHexLiteral(start) {
-  var number = '';
+  let number = '';
 
   while (index < length) {
     if (!isHexDigit(source[index])) {
@@ -482,7 +482,7 @@ function scanHexLiteral(start) {
 }
 
 function scanOctalLiteral(start) {
-  var number = '0' + source[index++];
+  let number = '0' + source[index++];
   while (index < length) {
     if (!isOctalDigit(source[index])) {
       break;
@@ -679,7 +679,7 @@ function scanStringLiteral() {
 }
 
 function testRegExp(pattern, flags) {
-  var tmp = pattern;
+  let tmp = pattern;
 
   if (flags.indexOf('u') >= 0) {
     // Replace each astral symbol and every Unicode code point
@@ -825,7 +825,7 @@ function isIdentifierName(token) {
 }
 
 function advance() {
-  var ch;
+  let ch;
 
   skipComment();
 
@@ -871,7 +871,7 @@ function advance() {
 }
 
 function lex() {
-  var token;
+  let token;
 
   token = lookahead;
   index = token.end;
@@ -884,7 +884,7 @@ function lex() {
 }
 
 function peek() {
-  var pos;
+  let pos;
 
   pos = index;
 
@@ -893,13 +893,13 @@ function peek() {
 }
 
 function finishArrayExpression(elements) {
-  var node = new ASTNode(SyntaxArrayExpression);
+  const node = new ASTNode(SyntaxArrayExpression);
   node.elements = elements;
   return node;
 }
 
 function finishBinaryExpression(operator, left, right) {
-  var node = new ASTNode((operator === '||' || operator === '&&') ? SyntaxLogicalExpression : SyntaxBinaryExpression);
+  const node = new ASTNode((operator === '||' || operator === '&&') ? SyntaxLogicalExpression : SyntaxBinaryExpression);
   node.operator = operator;
   node.left = left;
   node.right = right;
@@ -907,14 +907,14 @@ function finishBinaryExpression(operator, left, right) {
 }
 
 function finishCallExpression(callee, args) {
-  var node = new ASTNode(SyntaxCallExpression);
+  const node = new ASTNode(SyntaxCallExpression);
   node.callee = callee;
   node.arguments = args;
   return node;
 }
 
 function finishConditionalExpression(test, consequent, alternate) {
-  var node = new ASTNode(SyntaxConditionalExpression);
+  const node = new ASTNode(SyntaxConditionalExpression);
   node.test = test;
   node.consequent = consequent;
   node.alternate = alternate;
@@ -922,13 +922,13 @@ function finishConditionalExpression(test, consequent, alternate) {
 }
 
 function finishIdentifier(name) {
-  var node = new ASTNode(SyntaxIdentifier);
+  const node = new ASTNode(SyntaxIdentifier);
   node.name = name;
   return node;
 }
 
 function finishLiteral(token) {
-  var node = new ASTNode(SyntaxLiteral);
+  const node = new ASTNode(SyntaxLiteral);
   node.value = token.value;
   node.raw = source.slice(token.start, token.end);
   if (token.regex) {
@@ -941,7 +941,7 @@ function finishLiteral(token) {
 }
 
 function finishMemberExpression(accessor, object, property) {
-  var node = new ASTNode(SyntaxMemberExpression);
+  const node = new ASTNode(SyntaxMemberExpression);
   node.computed = accessor === '[';
   node.object = object;
   node.property = property;
@@ -950,13 +950,13 @@ function finishMemberExpression(accessor, object, property) {
 }
 
 function finishObjectExpression(properties) {
-  var node = new ASTNode(SyntaxObjectExpression);
+  const node = new ASTNode(SyntaxObjectExpression);
   node.properties = properties;
   return node;
 }
 
 function finishProperty(kind, key, value) {
-  var node = new ASTNode(SyntaxProperty);
+  const node = new ASTNode(SyntaxProperty);
   node.key = key;
   node.value = value;
   node.kind = kind;
@@ -964,7 +964,7 @@ function finishProperty(kind, key, value) {
 }
 
 function finishUnaryExpression(operator, argument) {
-  var node = new ASTNode(SyntaxUnaryExpression);
+  const node = new ASTNode(SyntaxUnaryExpression);
   node.operator = operator;
   node.argument = argument;
   node.prefix = true;
@@ -1022,7 +1022,7 @@ function throwUnexpected(token) {
 // If not, an exception will be thrown.
 
 function expect(value) {
-  var token = lex();
+  const token = lex();
   if (token.type !== TokenPunctuator || token.value !== value) {
     throwUnexpected(token);
   }
@@ -1043,7 +1043,7 @@ function matchKeyword(keyword) {
 // 11.1.4 Array Initialiser
 
 function parseArrayInitialiser() {
-  var elements = [];
+  const elements = [];
 
   index = lookahead.start;
   expect('[');
@@ -1069,7 +1069,7 @@ function parseArrayInitialiser() {
 // 11.1.5 Object Initialiser
 
 function parseObjectPropertyKey() {
-  var token;
+  let token;
 
   index = lookahead.start;
   token = lex();
@@ -1148,7 +1148,7 @@ function parseObjectInitialiser() {
 // 11.1.6 The Grouping Operator
 
 function parseGroupExpression() {
-  var expr;
+  let expr;
 
   expect('(');
 
@@ -1162,7 +1162,7 @@ function parseGroupExpression() {
 
 // 11.1 Primary Expressions
 
-var legalKeywords = {
+const legalKeywords = {
   'if': 1
 };
 
@@ -1215,7 +1215,7 @@ function parsePrimaryExpression() {
 // 11.2 Left-Hand-Side Expressions
 
 function parseArguments() {
-  var args = [];
+  const args = [];
 
   expect('(');
 
@@ -1235,7 +1235,7 @@ function parseArguments() {
 }
 
 function parseNonComputedProperty() {
-  var token;
+  let token;
   index = lookahead.start;
   token = lex();
 
@@ -1253,7 +1253,7 @@ function parseNonComputedMember() {
 }
 
 function parseComputedMember() {
-  var expr;
+  let expr;
 
   expect('[');
 
@@ -1290,7 +1290,7 @@ function parseLeftHandSideExpressionAllowCall() {
 // 11.3 Postfix Expressions
 
 function parsePostfixExpression() {
-  var expr = parseLeftHandSideExpressionAllowCall();
+  const expr = parseLeftHandSideExpressionAllowCall();
 
   if (lookahead.type === TokenPunctuator) {
     if ((match('++') || match('--'))) {
@@ -1324,7 +1324,7 @@ function parseUnaryExpression() {
 }
 
 function binaryPrecedence(token) {
-  var prec = 0;
+  let prec = 0;
 
   if (token.type !== TokenPunctuator && token.type !== TokenKeyword) {
     return 0;
@@ -1474,7 +1474,7 @@ function parseConditionalExpression() {
 // 11.14 Comma Operator
 
 function parseExpression() {
-  var expr = parseConditionalExpression();
+  const expr = parseConditionalExpression();
 
   if (match(',')) {
     throw new Error(DISABLED); // no sequence expressions
@@ -1491,7 +1491,7 @@ export default function(code) {
 
   peek();
 
-  var expr = parseExpression();
+  const expr = parseExpression();
 
   if (lookahead.type !== TokenEOF) {
     throw new Error('Unexpect token after expression.');

--- a/packages/vega-expression/test/codegen-test.js
+++ b/packages/vega-expression/test/codegen-test.js
@@ -13,8 +13,8 @@ tape('Evaluate expressions without white or black list', t => {
   });
 
   function evaluate(str) {
-    var value = codegen(vega.parse(str));
-    var fn = Function('"use strict"; return (' + value.code + ')');
+    const value = codegen(vega.parse(str));
+    const fn = Function('"use strict"; return (' + value.code + ')');
     return fn();
   }
 
@@ -23,7 +23,7 @@ tape('Evaluate expressions without white or black list', t => {
   };
 
   // should access globals object
-  var unicode = 'd\u00A9';
+  const unicode = 'd\u00A9';
   global._val_ = 5;
   global[unicode] = 3.14;
   t.equal(evaluate('global._val_+1'), 6);
@@ -50,9 +50,9 @@ tape('Evaluate expressions with black list', t => {
   });
 
   function evaluate(str) {
-    var d = {a: 2, föö: 5};
-    var value = codegen(vega.parse(str));
-    var fn = Function('d', '"use strict";return(' + value.code + ')');
+    const d = {a: 2, föö: 5};
+    const value = codegen(vega.parse(str));
+    const fn = Function('d', '"use strict";return(' + value.code + ')');
     return fn(d);
   }
 
@@ -79,13 +79,13 @@ tape('Evaluate expressions with white list', t => {
   });
 
   function evaluate(str) {
-    var datum = {a: 2, föö: 5};
-    var evt = {type: 'mousemove'};
-    var value = codegen(vega.parse(str));
+    const datum = {a: 2, föö: 5};
+    const evt = {type: 'mousemove'};
+    const value = codegen(vega.parse(str));
     if (value.globals.length > 0) {
       throw Error('Found non-whitelisted global identifier.');
     }
-    var fn = Function('datum', 'event', 'signals', 'return (' + value.code + ')');
+    const fn = Function('datum', 'event', 'signals', 'return (' + value.code + ')');
     return fn(datum, evt);
   }
 
@@ -188,8 +188,8 @@ tape('Evaluate expressions with white list', t => {
   t.equal(evaluate('sin(1)'), Math.sin(1));
   t.equal(evaluate('sqrt(2)'), Math.sqrt(2));
   t.equal(evaluate('tan(1)'), Math.tan(1));
-  for (var i=0; i<5; ++i) {
-    var r = evaluate('random()');
+  for (let i=0; i<5; ++i) {
+    const r = evaluate('random()');
     t.equal(r >= 0 && r <= 1, true);
   }
 
@@ -256,7 +256,7 @@ tape('Evaluate expressions with white list', t => {
   t.equal(evaluate('utcseconds(datetime(2001,1,1))'), d.getUTCSeconds());
   t.equal(evaluate('utcmilliseconds(datetime(2001,1,1))'), d.getUTCMilliseconds());
 
-  for (var date=1; date<=7; ++date) {
+  for (let date=1; date<=7; ++date) {
     d = new Date(2001, 1, date);
     t.equal(evaluate('date(datetime(2001,1,'+date+'))'), d.getDate());
     t.equal(evaluate('utcdate(datetime(2001,1,'+date+'))'), d.getUTCDate());

--- a/packages/vega-expression/test/parser-test.js
+++ b/packages/vega-expression/test/parser-test.js
@@ -534,7 +534,7 @@ tape('Parser should parse escape sequences', t => {
 });
 
 tape('Parser should ignore whitespace', t => {
-  var tree = {
+  const tree = {
     type: 'BinaryExpression',
     operator: '+',
     left: {type: 'Literal', value: 1, raw: '1'},

--- a/packages/vega-force/test/force-test.js
+++ b/packages/vega-force/test/force-test.js
@@ -4,7 +4,7 @@ var tape = require('tape'),
     Force = require('../').force;
 
 tape('Force places points', t => {
-  var data = [
+  const data = [
     {label: 'a'},
     {label: 'b'},
     {label: 'c'},

--- a/packages/vega-format/test/time-format-test.js
+++ b/packages/vega-format/test/time-format-test.js
@@ -66,7 +66,7 @@ tape('utcFormat supports specifier strings', t => {
 });
 
 tape('utcFormat supports specifier objects', t => {
-  var f = locale.utcFormat();
+  let f = locale.utcFormat();
   t.equal(f(utc(2001, 0, 1)), '2001');
   t.equal(f(utc(2001, 1, 1)), 'February');
   t.equal(f(utc(2001, 1, 2)), 'Fri 02');

--- a/packages/vega-geo/src/GeoPath.js
+++ b/packages/vega-geo/src/GeoPath.js
@@ -46,7 +46,7 @@ inherits(GeoPath, Transform, {
         : out.ADD;
     }
 
-    var prev = initPath(path, _.pointRadius);
+    const prev = initPath(path, _.pointRadius);
     out.visit(flag, t => t[as] = path(field(t)));
     path.pointRadius(prev);
 
@@ -55,7 +55,7 @@ inherits(GeoPath, Transform, {
 });
 
 function initPath(path, pointRadius) {
-  var prev = path.pointRadius();
+  const prev = path.pointRadius();
   path.context(null);
   if (pointRadius != null) {
     path.pointRadius(pointRadius);

--- a/packages/vega-geo/src/GeoPoint.js
+++ b/packages/vega-geo/src/GeoPoint.js
@@ -37,7 +37,7 @@ inherits(GeoPoint, Transform, {
         mod;
 
     function set(t) {
-      var xy = proj([lon(t), lat(t)]);
+      const xy = proj([lon(t), lat(t)]);
       if (xy) {
         t[x] = xy[0];
         t[y] = xy[1];

--- a/packages/vega-geo/src/GeoShape.js
+++ b/packages/vega-geo/src/GeoShape.js
@@ -53,7 +53,7 @@ inherits(GeoShape, Transform, {
 });
 
 function shapeGenerator(path, field, pointRadius) {
-  var shape = pointRadius == null
+  const shape = pointRadius == null
     ? _ => path(field(_))
     : _ => {
       var prev = path.pointRadius(),

--- a/packages/vega-geo/src/Graticule.js
+++ b/packages/vega-geo/src/Graticule.js
@@ -34,7 +34,7 @@ inherits(Graticule, Transform, {
         gen = this.generator, t;
 
     if (!src.length || _.modified()) {
-      for (var prop in _) {
+      for (const prop in _) {
         if (isFunction(gen[prop])) {
           gen[prop](_[prop]);
         }

--- a/packages/vega-geo/src/Projection.js
+++ b/packages/vega-geo/src/Projection.js
@@ -36,13 +36,13 @@ inherits(Projection, Transform, {
 });
 
 function fit(proj, _) {
-  var data = collectGeoJSON(_.fit);
+  const data = collectGeoJSON(_.fit);
   _.extent ? proj.fitExtent(_.extent, data)
     : _.size ? proj.fitSize(_.size, data) : 0;
 }
 
 function create(type) {
-  var constructor = projection((type || 'mercator').toLowerCase());
+  const constructor = projection((type || 'mercator').toLowerCase());
   if (!constructor) error('Unrecognized projection type: ' + type);
   return constructor();
 }

--- a/packages/vega-geo/src/constants.js
+++ b/packages/vega-geo/src/constants.js
@@ -1,3 +1,3 @@
-export var Feature = 'Feature';
-export var FeatureCollection = 'FeatureCollection';
-export var MultiPoint = 'MultiPoint';
+export const Feature = 'Feature';
+export const FeatureCollection = 'FeatureCollection';
+export const MultiPoint = 'MultiPoint';

--- a/packages/vega-geo/src/util/contours.js
+++ b/packages/vega-geo/src/util/contours.js
@@ -206,7 +206,7 @@ function ringContains(ring, point) {
 }
 
 function segmentContains(a, b, c) {
-  var i; return collinear(a, b, c) && within(a[i = +(a[0] === b[0])], c[i], b[i]);
+  let i; return collinear(a, b, c) && within(a[i = +(a[0] === b[0])], c[i], b[i]);
 }
 
 function collinear(a, b, c) {

--- a/packages/vega-geo/test/geojson-test.js
+++ b/packages/vega-geo/test/geojson-test.js
@@ -13,7 +13,7 @@ function geodata() {
 }
 
 tape('GeoJSON transform consolidates lon/lat data', t => {
-  var data = geodata();
+  const data = geodata();
 
   var df = new vega.Dataflow(),
       lon = util.field('lon'),
@@ -37,7 +37,7 @@ tape('GeoJSON transform consolidates lon/lat data', t => {
 });
 
 tape('GeoJSON transform consolidates geojson data', t => {
-  var data = geodata();
+  const data = geodata();
 
   var df = new vega.Dataflow(),
       geo = util.field('geo'),
@@ -60,7 +60,7 @@ tape('GeoJSON transform consolidates geojson data', t => {
 });
 
 tape('GeoJSON transform consolidates both lon/lat and geojson data', t => {
-  var data = geodata();
+  const data = geodata();
 
   var df = new vega.Dataflow(),
       lon = util.field('lon'),

--- a/packages/vega-geo/test/projection-test.js
+++ b/packages/vega-geo/test/projection-test.js
@@ -15,7 +15,7 @@ tape('Projection transform fits parameters to GeoJSON data', t => {
 
   df.run();
 
-  var proj = pr.value;
+  const proj = pr.value;
   t.equal(proj.scale(), 250);
   t.equal(Math.round(proj.translate()[0]), 250);
   t.equal(Math.round(proj.translate()[1]), 250);
@@ -34,7 +34,7 @@ tape('Projection transform handles fit input with null data', t => {
 
   df.run();
 
-  var proj = pr.value;
+  const proj = pr.value;
   t.equal(proj.scale(), 250);
   t.equal(Math.round(proj.translate()[0]), 250);
   t.equal(Math.round(proj.translate()[1]), 250);

--- a/packages/vega-hierarchy/src/Tree.js
+++ b/packages/vega-hierarchy/src/Tree.js
@@ -2,7 +2,7 @@ import HierarchyLayout from './HierarchyLayout';
 import {error, hasOwnProperty, inherits} from 'vega-util';
 import {cluster, tree} from 'd3-hierarchy';
 
-var Layouts = {
+const Layouts = {
   tidy: tree,
   cluster: cluster
 };
@@ -38,7 +38,7 @@ inherits(Tree, HierarchyLayout, {
    * Tree layout generator. Supports both 'tidy' and 'cluster' layouts.
    */
   layout(method) {
-    var m = method || 'tidy';
+    const m = method || 'tidy';
     if (hasOwnProperty(Layouts, m)) return Layouts[m]();
     else error('Unrecognized Tree layout method: ' + m);
   },

--- a/packages/vega-hierarchy/src/lookup.js
+++ b/packages/vega-hierarchy/src/lookup.js
@@ -1,8 +1,8 @@
 // Build lookup table mapping tuple keys to tree node instances
 export default function(tree, key, filter) {
-  var map = {};
+  const map = {};
   tree.each(node => {
-    var t = node.data;
+    const t = node.data;
     if (filter(t)) map[key(t)] = node;
   });
   tree.lookup = map;

--- a/packages/vega-hierarchy/test/nest-test.js
+++ b/packages/vega-hierarchy/test/nest-test.js
@@ -26,8 +26,8 @@ tape('Nest tuples', t => {
   // -- test adds
   df.pulse(collect, vega.changeset().insert([dataA, dataB])).run();
 
-  var expected = [dataA, dataB];
-  var expectedRoot = {
+  let expected = [dataA, dataB];
+  let expectedRoot = {
     data: {values: [nodeA, nodeB]},
     height: 2,
     depth: 0,
@@ -43,7 +43,7 @@ tape('Nest tuples', t => {
   };
 
   // test and remove circular properties first
-  var d = out.value;
+  let d = out.value;
   t.equal(d.root.children[0].parent, d.root);
   t.equal(d.root.children[1].parent, d.root);
   t.equal(d.root.lookup['1'].parent, d.root.children[0]);

--- a/packages/vega-hierarchy/test/stratify-test.js
+++ b/packages/vega-hierarchy/test/stratify-test.js
@@ -6,7 +6,7 @@ var tape = require('tape'),
     Stratify = require('../').stratify;
 
 tape('Stratify tuples', t => {
-  var data = [
+  const data = [
     {id: 'a'},
     {id: 'b', pid: 'a'},
     {id: 'c', pid: 'a'},

--- a/packages/vega-interpreter/test/scene-test.js
+++ b/packages/vega-interpreter/test/scene-test.js
@@ -40,7 +40,7 @@ tape('Vega generates scenegraphs for specifications', t => {
 
       if (OUTPUT_FAILURES && !isEqual) {
         pair.forEach((scene, i) => {
-          var prefix = vega.pad(index, 2, '0', 'left');
+          const prefix = vega.pad(index, 2, '0', 'left');
           fs.writeFileSync(
             `${prefix}-scene-${i?'expect':'actual'}-${name}.json`,
             JSON.stringify(scene, 0, 2)

--- a/packages/vega-label/test/label-test.js
+++ b/packages/vega-label/test/label-test.js
@@ -31,7 +31,7 @@ tape('Label performs label layout over input points', t => {
     .pulse(c0, vega.changeset().insert(data()))
     .run();
   t.equal(lb.stamp, df.stamp());
-  var out = c0.value;
+  let out = c0.value;
   t.equal(out.length, data().length);
   closeTo(t, out[0].x, 18);
   closeTo(t, out[0].y, 15);
@@ -156,7 +156,7 @@ tape('Label performs label layout with base mark reactive geometry', t => {
     .pulse(c0, vega.changeset().insert(data()))
     .run();
   t.equal(lb.stamp, df.stamp());
-  var out = c0.value;
+  let out = c0.value;
   t.equal(out.length, data().length);
   closeTo(t, out[0].x, 18);
   closeTo(t, out[0].y, 16);

--- a/packages/vega-loader/index.browser.js
+++ b/packages/vega-loader/index.browser.js
@@ -1,6 +1,6 @@
 import loaderFactory from './src/loader';
 
-export var loader = loaderFactory(
+export const loader = loaderFactory(
   typeof fetch !== 'undefined' && fetch, // use built-in fetch API
   null // no file system access
 );

--- a/packages/vega-loader/index.js
+++ b/packages/vega-loader/index.js
@@ -1,6 +1,6 @@
 import loaderFactory from './src/loader';
 
-export var loader = loaderFactory(
+export const loader = loaderFactory(
   require('node-fetch'),
   require('fs')
 );

--- a/packages/vega-loader/test/loader-test.js
+++ b/packages/vega-loader/test/loader-test.js
@@ -2,15 +2,15 @@ var tape = require('tape'),
     vega = require('../'),
     loader = vega.loader();
 
-var host = 'vega.github.io';
-var dir = '/datalib/';
-var base = 'http://' + host + dir;
-var uri = 'data/flare.json';
-var url = base + uri;
-var rel = '//' + host + dir + uri;
-var file = './test/' + uri;
-var fake = 'https://vega.github.io/vega/dne.html';
-var text = require('fs').readFileSync(file, 'utf8');
+const host = 'vega.github.io';
+const dir = '/datalib/';
+const base = 'http://' + host + dir;
+const uri = 'data/flare.json';
+const url = base + uri;
+const rel = '//' + host + dir + uri;
+const file = './test/' + uri;
+const fake = 'https://vega.github.io/vega/dne.html';
+const text = require('fs').readFileSync(file, 'utf8');
 
 function sanityTest(t, uri, options, result) {
   if (result != null) {

--- a/packages/vega-loader/test/read-test.js
+++ b/packages/vega-loader/test/read-test.js
@@ -3,30 +3,30 @@ var tape = require('tape'),
     vega = require('../'),
     read = vega.read;
 
-var fields = ['a', 'b', 'c', 'd', 'e'];
+const fields = ['a', 'b', 'c', 'd', 'e'];
 
-var data = [
+const data = [
   {a:1, b:'aaa', c:true,  d:'1/1/2001', e:1.2},
   {a:2, b:'bbb', c:false, d:'1/2/2001', e:3.4},
   {a:3, b:'ccc', c:false, d:'1/3/2001', e:5.6},
   {a:4, b:'ddd', c:true,  d:'1/4/2001', e:7.8}
 ];
 
-var parsed = [
+const parsed = [
   {a:1, b:'aaa', c:true,  d:Date.parse('1/1/2001'), e:1.2},
   {a:2, b:'bbb', c:false, d:Date.parse('1/2/2001'), e:3.4},
   {a:3, b:'ccc', c:false, d:Date.parse('1/3/2001'), e:5.6},
   {a:4, b:'ddd', c:true,  d:Date.parse('1/4/2001'), e:7.8}
 ];
 
-var strings = [
+const strings = [
   {a:'1', b:'aaa', c:'true',  d:'1/1/2001', e:'1.2'},
   {a:'2', b:'bbb', c:'false', d:'1/2/2001', e:'3.4'},
   {a:'3', b:'ccc', c:'false', d:'1/3/2001', e:'5.6'},
   {a:'4', b:'ddd', c:'true',  d:'1/4/2001', e:'7.8'}
 ];
 
-var types = {
+let types = {
   a: 'integer',
   b: 'string',
   c: 'boolean',
@@ -35,9 +35,9 @@ var types = {
 };
 
 function toDelimitedText(data, delimiter) {
-  var head = fields.join(delimiter);
-  var body = data.map(row => fields.map(f => {
-    var v = row[f];
+  const head = fields.join(delimiter);
+  const body = data.map(row => fields.map(f => {
+    const v = row[f];
     return typeof v === 'string' ? ('"'+v+'"') : v;
   }).join(delimiter));
   return head + '\n' + body.join('\n');
@@ -45,7 +45,7 @@ function toDelimitedText(data, delimiter) {
 
 // JSON
 
-var json = JSON.stringify(data);
+const json = JSON.stringify(data);
 
 tape('JSON reader should read json data', t => {
   t.deepEqual(read(json), data);
@@ -66,7 +66,7 @@ tape('JSON reader should auto-parse json fields', t => {
 });
 
 tape('JSON reader should read json from property', t => {
-  var json = JSON.stringify({foo: data});
+  const json = JSON.stringify({foo: data});
   t.deepEqual(read(json, {type:'json', property:'foo'}), data);
   t.end();
 });
@@ -213,7 +213,7 @@ tape('JSON reader should throw error if format is unrecognized', t => {
 
 // CSV
 
-var csv = toDelimitedText(data, ',');
+const csv = toDelimitedText(data, ',');
 
 tape('CSV reader should read csv data', t => {
   t.deepEqual(read(csv, {type:'csv'}), strings);
@@ -233,7 +233,7 @@ tape('CSV reader should auto-parse csv fields', t => {
 
 // TSV
 
-var tsv = toDelimitedText(data, '\t');
+const tsv = toDelimitedText(data, '\t');
 
 tape('TSV reader should read tsv data', t => {
   t.deepEqual(read(tsv, {type:'tsv'}), strings);
@@ -253,7 +253,7 @@ tape('TSV reader should auto-parse tsv fields', t => {
 
 // // DSV
 
-var psv = toDelimitedText(data, '|');
+const psv = toDelimitedText(data, '|');
 
 tape('DSV reader should read dsv data', t => {
   t.deepEqual(read(psv, {type:'dsv', delimiter:'|'}), strings);
@@ -262,7 +262,7 @@ tape('DSV reader should read dsv data', t => {
 });
 
 tape('DSV reader should accept header parameter', t => {
-  var body = psv.slice(psv.indexOf('\n')+1);
+  const body = psv.slice(psv.indexOf('\n')+1);
   t.deepEqual(read(body, {
     type: 'dsv',
     delimiter: '|',
@@ -283,39 +283,39 @@ tape('DSV reader should auto-parse dsv fields', t => {
 
 // TopoJSON
 
-var worldText = require('fs').readFileSync('./test/data/world-110m.json', 'utf8');
-var world = JSON.parse(worldText);
+const worldText = require('fs').readFileSync('./test/data/world-110m.json', 'utf8');
+const world = JSON.parse(worldText);
 
 tape('TopoJSON reader should read TopoJSON mesh', t => {
   var mesh = read(worldText, {type:'topojson', mesh: 'countries'});
-  var tj = topojson.mesh(world, world.objects['countries']);
+  const tj = topojson.mesh(world, world.objects['countries']);
   t.equal(JSON.stringify(tj), JSON.stringify(mesh[0]));
   t.end();
 });
 
 tape('TopoJSON reader should read TopoJSON mesh interior', t => {
   var mesh = read(worldText, {type:'topojson', mesh: 'countries', filter: 'interior'});
-  var tj = topojson.mesh(world, world.objects['countries'], (a, b) => a !== b);
+  const tj = topojson.mesh(world, world.objects['countries'], (a, b) => a !== b);
   t.equal(JSON.stringify(tj), JSON.stringify(mesh[0]));
   t.end();
 });
 
 tape('TopoJSON reader should read TopoJSON mesh exterior', t => {
   var mesh = read(worldText, {type:'topojson', mesh: 'countries', filter: 'exterior'});
-  var tj = topojson.mesh(world, world.objects['countries'], (a, b) => a === b);
+  const tj = topojson.mesh(world, world.objects['countries'], (a, b) => a === b);
   t.equal(JSON.stringify(tj), JSON.stringify(mesh[0]));
   t.end();
 });
 
 tape('TopoJSON reader should read TopoJSON feature', t => {
   var feature = read(worldText, {type:'topojson', feature: 'countries'});
-  var tj = topojson.feature(world, world.objects['countries']).features;
+  const tj = topojson.feature(world, world.objects['countries']).features;
   t.equal(JSON.stringify(tj), JSON.stringify(feature));
   t.end();
 });
 
 tape('TopoJSON reader should throw error if TopoJSON is invalid', t => {
-  var data = {objects: {}};
+  const data = {objects: {}};
   t.throws(() => { read(data, {type:'topojson', feature: 'countries'}); });
   t.throws(() => { read(data, {type:'topojson', mesh: 'countries'}); });
   t.end();

--- a/packages/vega-loader/test/type-test.js
+++ b/packages/vega-loader/test/type-test.js
@@ -5,23 +5,23 @@ var tape = require('tape'),
     inferTypes = vega.inferTypes,
     typeParsers = vega.typeParsers;
 
-var fields = ['a', 'b', 'c', 'd', 'e'];
+const fields = ['a', 'b', 'c', 'd', 'e'];
 
-var data = [
+const data = [
   {a:1, b:'aaa', c:true,  d:'1/1/2001', e:1.2},
   {a:2, b:'bbb', c:false, d:'1/2/2001', e:3.4},
   {a:3, b:'ccc', c:false, d:'1/3/2001', e:5.6},
   {a:4, b:'ddd', c:true,  d:'1/4/2001', e:7.8}
 ];
 
-var strings = [
+const strings = [
   {a:'1', b:'aaa', c:'true',  d:'1/1/2001', e:'1.2'},
   {a:'2', b:'bbb', c:'false', d:'1/2/2001', e:'3.4'},
   {a:'3', b:'ccc', c:'false', d:'1/3/2001', e:'5.6'},
   {a:'4', b:'ddd', c:'true',  d:'1/4/2001', e:'7.8'}
 ];
 
-var types = {
+const types = {
   a: 'integer',
   b: 'string',
   c: 'boolean',
@@ -59,7 +59,7 @@ tape('inferType should infer strings when all else fails', t => {
 });
 
 tape('inferType should handle fields', t => {
-  var data = [
+  const data = [
     {a:'1', b:'true'},
     {a:'2', b:'false'},
     {a:'3', b:null}

--- a/packages/vega-parser/src/parsers/guides/axis-config.js
+++ b/packages/vega-parser/src/parsers/guides/axis-config.js
@@ -89,7 +89,7 @@ export default function(spec, scope) {
     or = config['axis' + orient[0].toUpperCase() + orient.slice(1)];
   }
 
-  var result = (xy || or || band)
+  const result = (xy || or || band)
     ? extend({}, axis, xy, or, band)
     : axis;
 

--- a/packages/vega-parser/test/axis-test.js
+++ b/packages/vega-parser/test/axis-test.js
@@ -2,7 +2,7 @@ var tape = require('tape'),
     parse = require('../').parse;
 
 tape('Parser parses Vega specs with axes', t => {
-  var spec = {
+  const spec = {
     'scales': [
       {
         'name': 'xscale',
@@ -18,7 +18,7 @@ tape('Parser parses Vega specs with axes', t => {
     ]
   };
 
-  var dfs = parse(spec);
+  const dfs = parse(spec);
 
   t.equal(dfs.operators.length, 47);
 

--- a/packages/vega-parser/test/config-test.js
+++ b/packages/vega-parser/test/config-test.js
@@ -3,7 +3,7 @@ var tape = require('tape'),
     config = require('../').config;
 
 tape('Config generates defaults', t => {
-  var c = config();
+  const c = config();
 
   t.equal(c.autosize, 'pad');
   t.equal(c.style.point.shape, 'circle');
@@ -12,9 +12,9 @@ tape('Config generates defaults', t => {
 });
 
 tape('Config overrides with extended defaults', t => {
-  var as = {type: 'pad', resize: 'true'};
+  const as = {type: 'pad', resize: 'true'};
 
-  var c = util.mergeConfig(
+  const c = util.mergeConfig(
     config(),
     {autosize: as},
     {style: {point: {shape: 'triangle-right'}}},

--- a/packages/vega-parser/test/mark-test.js
+++ b/packages/vega-parser/test/mark-test.js
@@ -2,7 +2,7 @@ var tape = require('tape'),
     parse = require('../').parse;
 
 tape('Parser parses Vega specs with marks', t => {
-  var spec = {
+  const spec = {
     'signals': [
       { 'name': 'color', 'value': 'steelblue' }
     ],
@@ -40,7 +40,7 @@ tape('Parser parses Vega specs with marks', t => {
     ]
   };
 
-  var dfs = parse(spec);
+  const dfs = parse(spec);
 
   t.equal(dfs.operators.length, 26);
 

--- a/packages/vega-parser/test/projection-test.js
+++ b/packages/vega-parser/test/projection-test.js
@@ -1,7 +1,7 @@
 var tape = require('tape'),
     parse = require('../').parse;
 
-var geojson = {
+const geojson = {
   'type': 'FeatureCollection',
   'features': [
     {
@@ -19,7 +19,7 @@ var geojson = {
 };
 
 tape('Parser parses Vega specs with projection', t => {
-  var spec = {
+  const spec = {
     'projections': [
         {
           'name': 'projection',
@@ -30,7 +30,7 @@ tape('Parser parses Vega specs with projection', t => {
     ]
   };
 
-  var dfs = parse(spec);
+  const dfs = parse(spec);
 
   t.equal(dfs.operators.length, 15);
   t.equal(dfs.operators[10].type, 'projection');

--- a/packages/vega-parser/test/scale-test.js
+++ b/packages/vega-parser/test/scale-test.js
@@ -2,7 +2,7 @@ var tape = require('tape'),
     parse = require('../').parse;
 
 tape('Parser parses Vega specs with scales', t => {
-  var spec = {
+  const spec = {
     'width': 500,
     'height': 300,
     'signals': [
@@ -52,7 +52,7 @@ tape('Parser parses Vega specs with scales', t => {
     ]
   };
 
-  var dfs = parse(spec);
+  const dfs = parse(spec);
 
   t.equal(dfs.operators.length, 28);
   t.deepEqual(dfs.operators.map(o => o.type),
@@ -68,7 +68,7 @@ tape('Parser parses Vega specs with scales', t => {
 });
 
 tape('Parser parses Vega specs with multi-domain scales', t => {
-  var spec = {
+  const spec = {
     'data': [
       {
         'name': 'table',
@@ -126,7 +126,7 @@ tape('Parser parses Vega specs with multi-domain scales', t => {
     ]
   };
 
-  var dfs = parse(spec);
+  const dfs = parse(spec);
 
   t.equal(dfs.operators.length, 34);
   t.deepEqual(dfs.operators.map(o => o.type),

--- a/packages/vega-parser/test/signal-test.js
+++ b/packages/vega-parser/test/signal-test.js
@@ -7,7 +7,7 @@ function parseSignal(spec, scope) {
 }
 
 tape('Parser parses static signals', t => {
-  var scope = new vega.Scope();
+  const scope = new vega.Scope();
 
   vega.signal({name: 'a', value: 'foo'}, scope);
   vega.signal({name: 'b', value: 'bar', react: true}, scope);
@@ -26,7 +26,7 @@ tape('Parser parses static signals', t => {
 });
 
 tape('Parser parses updating signals', t => {
-  var scope = new vega.Scope();
+  const scope = new vega.Scope();
 
   parseSignal({name: 'a', update: '5 * 2'}, scope);
   parseSignal({name: 'b', update: 'a + 3'}, scope);

--- a/packages/vega-parser/test/transform-test.js
+++ b/packages/vega-parser/test/transform-test.js
@@ -6,7 +6,7 @@ var tape = require('tape'),
 util.extend(vega.transforms, require('vega-transforms'));
 
 tape('Parser parses Vega specs with data transforms', t => {
-  var spec = {
+  const spec = {
     'signals': [
       { 'name': 'ufield', 'value': 'u' },
       { 'name': 'fields', 'value': ['u', 'v'] }
@@ -45,7 +45,7 @@ tape('Parser parses Vega specs with data transforms', t => {
     ]
   };
 
-  var dfs = parse(spec);
+  const dfs = parse(spec);
 
   t.equal(dfs.operators.length, 33);
 

--- a/packages/vega-projection-extended/rollup.js
+++ b/packages/vega-projection-extended/rollup.js
@@ -3,7 +3,7 @@ var rollup = require('rollup'),
     externals = process.argv[2] === '-e',
     output = 'vega-projections' + (externals ? '-core' : '') + '.js';
 
-var modules = ['vega-projection'].concat(
+const modules = ['vega-projection'].concat(
   externals ? ['d3-array', 'd3-geo'] : []
 );
 

--- a/packages/vega-regression/test/loess-test.js
+++ b/packages/vega-regression/test/loess-test.js
@@ -6,7 +6,7 @@ var tape = require('tape'),
     changeset = vega.changeset;
 
   tape('Loess handles repeated x-values', t => {
-    var data = [
+    const data = [
       {k: 'a', u: 1, v: 1}, {k: 'a', u: 2, v: 2}, {k: 'a', u: 3, v: 5},
       {k: 'b', u: 1, v: 3}, {k: 'b', u: 2, v: 6}, {k: 'b', u: 3, v: 7}
     ];
@@ -20,7 +20,7 @@ var tape = require('tape'),
 
     // -- test adds
     df.pulse(col, changeset().insert(data)).run();
-    var d = out.value;
+    const d = out.value;
     t.equal(d.length, 3);
     t.equal(d[0].u, 1);
     t.equal(d[1].u, 2);
@@ -33,7 +33,7 @@ var tape = require('tape'),
   });
 
 tape('Loess adapts bandwidth when too small', t => {
-  var data = [
+  const data = [
     {k: 'a', u: 1, v: 1}, {k: 'a', u: 2, v: 2}, {k: 'a', u: 3, v: 5},
     {k: 'b', u: 1, v: 2}, {k: 'b', u: 2, v: 5}, {k: 'b', u: 3, v: 6}
   ];
@@ -54,9 +54,9 @@ tape('Loess adapts bandwidth when too small', t => {
 
   // -- test adds
   df.pulse(col, changeset().insert(data)).run();
-  var d = out.value;
+  const d = out.value;
 
-  var a = d.filter(_ => _.k === 'a');
+  const a = d.filter(_ => _.k === 'a');
   t.equal(a.length, 3);
   t.equal(a[0].u, 1);
   t.equal(a[0].v, 1);
@@ -65,7 +65,7 @@ tape('Loess adapts bandwidth when too small', t => {
   t.equal(a[2].u, 3);
   t.equal(a[2].v, 5);
 
-  var b = d.filter(_ => _.k === 'b');
+  const b = d.filter(_ => _.k === 'b');
   t.equal(b.length, 3);
   t.equal(b[0].u, 1);
   t.equal(b[0].v, 2);

--- a/packages/vega-regression/test/regression-test.js
+++ b/packages/vega-regression/test/regression-test.js
@@ -6,7 +6,7 @@ var tape = require('tape'),
     changeset = vega.changeset;
 
 tape('Regression fits linear regression model', t => {
-  var data = [
+  const data = [
     {k: 'a', u: 2, v: 2}, {k: 'a', u: 1, v: 1},
     {k: 'b', u: 3, v: 2}, {k: 'b', u: 2, v: 1}
   ];
@@ -27,7 +27,7 @@ tape('Regression fits linear regression model', t => {
 
   // -- test adds
   df.pulse(col, changeset().insert(data)).run();
-  var d = out.value;
+  const d = out.value;
   t.equal(d.length, 4);
 
   t.equal(d[0].k, 'a');
@@ -60,7 +60,7 @@ tape('Regression fits quadratic regression model', t => {
 
   // -- test adds
   df.pulse(col, changeset().insert(data)).run();
-  var d = out.value;
+  const d = out.value;
   t.equal(d[0].x, 0);
   t.equal(d[0].y, 1);
   t.equal(d[d.length-1].x, 3);
@@ -80,7 +80,7 @@ tape('Regression outputs model parameters', t => {
 
   // -- test adds
   df.pulse(col, changeset().insert(data)).run();
-  var d = out.value;
+  const d = out.value;
   t.equal(d.length, 1);
   t.deepEqual(d[0].coef, [1, 0, 1]);
   t.equal(d[0].rSquared, 1);

--- a/packages/vega-runtime/src/context.js
+++ b/packages/vega-runtime/src/context.js
@@ -96,7 +96,7 @@ Context.prototype = Subcontext.prototype = {
     }
 
     if (spec.parent) {
-      var p = ctx.get(spec.parent.$ref);
+      let p = ctx.get(spec.parent.$ref);
       if (p) {
         df.connect(p, [op]);
         op.targets().add(p);

--- a/packages/vega-runtime/src/expression.js
+++ b/packages/vega-runtime/src/expression.js
@@ -6,7 +6,7 @@ function expression(ctx, args, code) {
   if (code[code.length-1] !== ';') {
     code = 'return(' + code + ');';
   }
-  var fn = Function.apply(null, args.concat(code));
+  const fn = Function.apply(null, args.concat(code));
   return ctx && ctx.functions ? fn.bind(ctx.functions) : fn;
 }
 

--- a/packages/vega-runtime/src/state.js
+++ b/packages/vega-runtime/src/state.js
@@ -1,6 +1,6 @@
 import {truthy} from 'vega-util';
 
-var SKIP = {skip: true};
+const SKIP = {skip: true};
 
 export function getState(options) {
   var ctx = this,
@@ -9,7 +9,7 @@ export function getState(options) {
   if (options.signals) {
     var signals = (state.signals = {});
     Object.keys(ctx.signals).forEach(key => {
-      var op = ctx.signals[key];
+      const op = ctx.signals[key];
       if (options.signals(key, op)) {
         signals[key] = op.value;
       }
@@ -19,7 +19,7 @@ export function getState(options) {
   if (options.data) {
     var data = (state.data = {});
     Object.keys(ctx.data).forEach(key => {
-      var dataset = ctx.data[key];
+      const dataset = ctx.data[key];
       if (options.data(key, dataset)) {
         data[key] = dataset.input.value;
       }
@@ -51,7 +51,7 @@ export function setState(state) {
   });
 
   (state.subcontext  || []).forEach((substate, i) => {
-    var subctx = ctx.subcontext[i];
+    const subctx = ctx.subcontext[i];
     if (subctx) subctx.setState(substate);
   });
 }

--- a/packages/vega-runtime/test/dataflow-test.js
+++ b/packages/vega-runtime/test/dataflow-test.js
@@ -5,14 +5,14 @@ var tape = require('tape'),
     runtime = require('../');
 
 tape('Parser parses dataflow specs', t => {
-  var values = [
+  const values = [
     {'x': 1,  'y': 28},
     {'x': 2,  'y': 43},
     {'x': 3,  'y': 81},
     {'x': 4,  'y': 19},
     {'x': 4,  'y': 20}
   ];
-  var spec = {operators: [
+  const spec = {operators: [
     {id:0, type:'Operator', value:500},
     {id:1, type:'Operator', value:300},
     {id:2, type:'Collect',  value:{$ingest: values}},
@@ -48,13 +48,13 @@ tape('Parser parses dataflow specs', t => {
 
   t.deepEqual(ops[5].value, [1, 2, 3, 4]);
 
-  var sx = ops[6].value;
+  const sx = ops[6].value;
   t.deepEqual(sx.domain(), [1, 2, 3, 4]);
   t.deepEqual(sx.range(), [0, 500]);
 
   t.deepEqual(ops[7].value, [19, 81]);
 
-  var sy = ops[8].value;
+  const sy = ops[8].value;
   t.deepEqual(sy.domain(), [19, 81]);
   t.deepEqual(sy.range(), [300, 0]);
 

--- a/packages/vega-runtime/test/events.js
+++ b/packages/vega-runtime/test/events.js
@@ -1,9 +1,9 @@
-var vega = require('vega-dataflow');
+const vega = require('vega-dataflow');
 
-var registry = {};
+const registry = {};
 
 function events(source, type, filter) {
-  var handlers = registry[source] || (registry[source] = {});
+  const handlers = registry[source] || (registry[source] = {});
   return (handlers[type] = new vega.EventStream(filter));
 }
 

--- a/packages/vega-runtime/test/expression-test.js
+++ b/packages/vega-runtime/test/expression-test.js
@@ -5,14 +5,14 @@ var tape = require('tape'),
     runtime = require('../');
 
 tape('Parser parses expressions', t => {
-  var values = [
+  const values = [
     {'x': 1,  'y': 28},
     {'x': 2,  'y': 43},
     {'x': 3,  'y': 81},
     {'x': 4,  'y': 19}
   ];
 
-  var spec = {operators: [
+  const spec = {operators: [
     {id:0, type:'Operator', value: 50},
     {id:1, type:'Operator', update: {code: '2 * _.foo'}, params: {foo:{$ref:0}}},
     {id:2, type:'Collect',  value: {$ingest: values}},

--- a/packages/vega-runtime/test/facet-test.js
+++ b/packages/vega-runtime/test/facet-test.js
@@ -4,14 +4,14 @@ var tape = require('tape'),
     runtime = require('../');
 
 tape('Parser parses faceted dataflow specs', t => {
-  var values = [
+  const values = [
     {'k': 'a', 'x': 1,  'y': 28},
     {'k': 'b', 'x': 2,  'y': 43},
     {'k': 'a', 'x': 3,  'y': 81},
     {'k': 'b', 'x': 4,  'y': 19}
   ];
 
-  var spec = {operators: [
+  const spec = {operators: [
     {id:0, type:'Collect', value:{$ingest: values}},
     {id:1, type:'Facet', params:{
       key: {$field: 'k'},
@@ -36,10 +36,10 @@ tape('Parser parses faceted dataflow specs', t => {
     }}
   ]};
 
-  var len0 = 3; // number of operators in 1st subflow (ignore Subflow op)
-  var len1 = 1; // number of operators in 2nd subflow (ignore Subflow op)
-  var nkey = 2; // number of facet keys per level
-  var size = 2; // number of tuples per facet in 1st subflow
+  const len0 = 3; // number of operators in 1st subflow (ignore Subflow op)
+  const len1 = 1; // number of operators in 2nd subflow (ignore Subflow op)
+  const nkey = 2; // number of facet keys per level
+  const size = 2; // number of tuples per facet in 1st subflow
 
   // ----
 

--- a/packages/vega-runtime/test/stream-test.js
+++ b/packages/vega-runtime/test/stream-test.js
@@ -5,7 +5,7 @@ var tape = require('tape'),
 
 tape('Parser parses event streams', t => {
 
-  var spec = {
+  const spec = {
     streams: [
       { id:0, source:'window', type:'mousemove' },
       { id:1, source:'window', type:'mousedown' },
@@ -17,7 +17,7 @@ tape('Parser parses event streams', t => {
     ]
   };
 
-  var df = new vega.Dataflow();
+  const df = new vega.Dataflow();
   df.events = events.events;
   df.fire = events.fire;
 

--- a/packages/vega-runtime/test/update-test.js
+++ b/packages/vega-runtime/test/update-test.js
@@ -5,7 +5,7 @@ var tape = require('tape'),
 
 tape('Parser parses event-driven operator updates', t => {
 
-  var spec = {
+  const spec = {
     operators: [
       { id:0, type:'Operator', value:50 },
       { id:1, type:'Operator', value:0 },
@@ -27,7 +27,7 @@ tape('Parser parses event-driven operator updates', t => {
     ]
   };
 
-  var df = new vega.Dataflow();
+  const df = new vega.Dataflow();
   df.events = events.events;
   df.fire = events.fire;
 

--- a/packages/vega-scale/test/band-scale-test.js
+++ b/packages/vega-scale/test/band-scale-test.js
@@ -3,7 +3,7 @@ var tape = require('tape'),
     bandScale = vega.scale('band');
 
 tape('band.invert inverts single value', t => {
-  var s = bandScale().domain(['foo', 'bar']);
+  const s = bandScale().domain(['foo', 'bar']);
 
   // ascending range
   s.range([0,2]);
@@ -49,7 +49,7 @@ tape('band.invert inverts single value', t => {
 });
 
 tape('band.invertRange inverts value range', t => {
-  var s = bandScale().domain(['foo', 'bar']);
+  const s = bandScale().domain(['foo', 'bar']);
 
   // empty and invalid ranges should fail
   t.deepEqual(s.invertRange([]), undefined);

--- a/packages/vega-scale/test/ticks-test.js
+++ b/packages/vega-scale/test/ticks-test.js
@@ -3,28 +3,28 @@ var tape = require('tape'),
     timeInterval = require('vega-time').timeInterval;
 
 tape('validTicks uses count correctly', t => {
-  var data = [0, 1, 2, 3, 4, 5, 6, 7];
+  const data = [0, 1, 2, 3, 4, 5, 6, 7];
 
-  var identity = function(x) { return x; };
+  const identity = function(x) { return x; };
   identity.range = function() { return [0, 10]; };
 
-  var t1 = validTicks(identity, data, 5);
+  const t1 = validTicks(identity, data, 5);
   t.deepEqual(t1, [0, 2, 4, 6]);
 
   // don't change ticks if count is large
-  var t2 = validTicks(identity, data, 100);
+  const t2 = validTicks(identity, data, 100);
   t.deepEqual(t2, data);
 
   // special case for low number of ticks
-  var t3 = validTicks(identity, data, 3);
+  const t3 = validTicks(identity, data, 3);
   t.deepEqual(t3, [0, 7]);
 
   // validTicks ignores interval function
-  var t4 = validTicks(identity, data, timeInterval('hour'));
+  const t4 = validTicks(identity, data, timeInterval('hour'));
   t.deepEqual(t4, data);
 
   // single tick should pass through
-  var t5 = validTicks(identity, [1], 5);
+  const t5 = validTicks(identity, [1], 5);
   t.deepEqual(t5, [1]);
 
   t.end();

--- a/packages/vega-scenegraph/src/Gradient.js
+++ b/packages/vega-scenegraph/src/Gradient.js
@@ -1,4 +1,4 @@
-var gradient_id = 0;
+let gradient_id = 0;
 
 export function resetSVGGradientId() {
   gradient_id = 0;

--- a/packages/vega-scenegraph/src/Renderer.js
+++ b/packages/vega-scenegraph/src/Renderer.js
@@ -93,7 +93,7 @@ Renderer.prototype = {
    * @return {Renderer} - This renderer instance.
    */
   render(scene) {
-    var r = this;
+    const r = this;
 
     // bind arguments into a render call, and cache it
     // this function may be subsequently called for async redraw
@@ -127,7 +127,7 @@ Renderer.prototype = {
    * @return {Promise} - A Promise that resolves when rendering is complete.
    */
   renderAsync(scene) {
-    var r = this.render(scene);
+    const r = this.render(scene);
     return this._ready
       ? this._ready.then(() => r)
       : Promise.resolve(r);
@@ -147,7 +147,7 @@ Renderer.prototype = {
 
     if (!r._ready) {
       // re-render the scene when loading completes
-      var call = r._call;
+      const call = r._call;
       r._ready = r._loader.ready()
         .then(redraw => {
           if (redraw) call();

--- a/packages/vega-scenegraph/src/ResourceLoader.js
+++ b/packages/vega-scenegraph/src/ResourceLoader.js
@@ -21,7 +21,7 @@ ResourceLoader.prototype = {
   },
 
   sanitizeURL(uri) {
-    var loader = this;
+    const loader = this;
     increment(loader);
 
     return loader._loader.sanitize(uri, {context:'href'})
@@ -67,7 +67,7 @@ ResourceLoader.prototype = {
   },
 
   ready() {
-    var loader = this;
+    const loader = this;
     return new Promise(accept => {
       function poll(value) {
         if (!loader.pending()) accept(value);

--- a/packages/vega-scenegraph/src/Scenegraph.js
+++ b/packages/vega-scenegraph/src/Scenegraph.js
@@ -22,7 +22,7 @@ Scenegraph.prototype = {
 
   mark(markdef, group, index) {
     group = group || this.root.items[0];
-    var mark = createMark(markdef, group);
+    const mark = createMark(markdef, group);
     group.items[index] = mark;
     if (mark.zindex) mark.group.zdirty = true;
     return mark;

--- a/packages/vega-scenegraph/src/marks/markMultiItemPath.js
+++ b/packages/vega-scenegraph/src/marks/markMultiItemPath.js
@@ -26,7 +26,7 @@ export default function(type, shape, tip) {
     shape(context, items);
   }
 
-  var hit = hitPath(draw);
+  const hit = hitPath(draw);
 
   function pick(context, scene, x, y, gx, gy) {
     var items = scene.items,

--- a/packages/vega-scenegraph/src/marks/text.js
+++ b/packages/vega-scenegraph/src/marks/text.js
@@ -10,13 +10,13 @@ import stroke from '../util/canvas/stroke';
 import {rotate, translate} from '../util/svg/transform';
 import {isArray} from 'vega-util';
 
-var textAlign = {
+const textAlign = {
   'left':   'start',
   'center': 'middle',
   'right':  'end'
 };
 
-var tempBounds = new Bounds();
+const tempBounds = new Bounds();
 
 function anchorPoint(item) {
   var x = item.x || 0,
@@ -165,7 +165,7 @@ function hit(context, item, x, y, gx, gy) {
 }
 
 function intersectText(item, box) {
-  var p = bound(tempBounds, item, 2);
+  const p = bound(tempBounds, item, 2);
   return intersectBoxLine(box, p[0], p[1], p[2], p[3])
       || intersectBoxLine(box, p[0], p[1], p[4], p[5])
       || intersectBoxLine(box, p[4], p[5], p[6], p[7])

--- a/packages/vega-scenegraph/src/modules.js
+++ b/packages/vega-scenegraph/src/modules.js
@@ -4,19 +4,19 @@ import SVGHandler from './SVGHandler';
 import SVGRenderer from './SVGRenderer';
 import SVGStringRenderer from './SVGStringRenderer';
 
-var Canvas = 'canvas';
-var PNG = 'png';
-var SVG = 'svg';
-var None = 'none';
+const Canvas = 'canvas';
+const PNG = 'png';
+const SVG = 'svg';
+const None = 'none';
 
-export var RenderType = {
+export const RenderType = {
   Canvas: Canvas,
   PNG:    PNG,
   SVG:    SVG,
   None:   None
 };
 
-var modules = {};
+const modules = {};
 
 modules[Canvas] = modules[PNG] = {
   renderer: CanvasRenderer,

--- a/packages/vega-scenegraph/src/path/arc.js
+++ b/packages/vega-scenegraph/src/path/arc.js
@@ -7,57 +7,57 @@ var join = [].join;
 
 // Copied from Inkscape svgtopdf, thanks!
 export function segments(x, y, rx, ry, large, sweep, rotateX, ox, oy) {
-  var key = join.call(arguments);
+  const key = join.call(arguments);
   if (segmentCache[key]) {
     return segmentCache[key];
   }
 
-  var th = rotateX * DegToRad;
-  var sin_th = Math.sin(th);
-  var cos_th = Math.cos(th);
+  const th = rotateX * DegToRad;
+  const sin_th = Math.sin(th);
+  const cos_th = Math.cos(th);
   rx = Math.abs(rx);
   ry = Math.abs(ry);
-  var px = cos_th * (ox - x) * 0.5 + sin_th * (oy - y) * 0.5;
-  var py = cos_th * (oy - y) * 0.5 - sin_th * (ox - x) * 0.5;
-  var pl = (px*px) / (rx*rx) + (py*py) / (ry*ry);
+  const px = cos_th * (ox - x) * 0.5 + sin_th * (oy - y) * 0.5;
+  const py = cos_th * (oy - y) * 0.5 - sin_th * (ox - x) * 0.5;
+  let pl = (px*px) / (rx*rx) + (py*py) / (ry*ry);
   if (pl > 1) {
     pl = Math.sqrt(pl);
     rx *= pl;
     ry *= pl;
   }
 
-  var a00 = cos_th / rx;
-  var a01 = sin_th / rx;
-  var a10 = (-sin_th) / ry;
-  var a11 = (cos_th) / ry;
-  var x0 = a00 * ox + a01 * oy;
-  var y0 = a10 * ox + a11 * oy;
-  var x1 = a00 * x + a01 * y;
-  var y1 = a10 * x + a11 * y;
+  const a00 = cos_th / rx;
+  const a01 = sin_th / rx;
+  const a10 = (-sin_th) / ry;
+  const a11 = (cos_th) / ry;
+  const x0 = a00 * ox + a01 * oy;
+  const y0 = a10 * ox + a11 * oy;
+  const x1 = a00 * x + a01 * y;
+  const y1 = a10 * x + a11 * y;
 
-  var d = (x1-x0) * (x1-x0) + (y1-y0) * (y1-y0);
-  var sfactor_sq = 1 / d - 0.25;
+  const d = (x1-x0) * (x1-x0) + (y1-y0) * (y1-y0);
+  let sfactor_sq = 1 / d - 0.25;
   if (sfactor_sq < 0) sfactor_sq = 0;
-  var sfactor = Math.sqrt(sfactor_sq);
+  let sfactor = Math.sqrt(sfactor_sq);
   if (sweep == large) sfactor = -sfactor;
-  var xc = 0.5 * (x0 + x1) - sfactor * (y1-y0);
-  var yc = 0.5 * (y0 + y1) + sfactor * (x1-x0);
+  const xc = 0.5 * (x0 + x1) - sfactor * (y1-y0);
+  const yc = 0.5 * (y0 + y1) + sfactor * (x1-x0);
 
-  var th0 = Math.atan2(y0-yc, x0-xc);
-  var th1 = Math.atan2(y1-yc, x1-xc);
+  const th0 = Math.atan2(y0-yc, x0-xc);
+  const th1 = Math.atan2(y1-yc, x1-xc);
 
-  var th_arc = th1-th0;
+  let th_arc = th1-th0;
   if (th_arc < 0 && sweep === 1) {
     th_arc += Tau;
   } else if (th_arc > 0 && sweep === 0) {
     th_arc -= Tau;
   }
 
-  var segs = Math.ceil(Math.abs(th_arc / (HalfPi + 0.001)));
-  var result = [];
-  for (var i=0; i<segs; ++i) {
-    var th2 = th0 + i * th_arc / segs;
-    var th3 = th0 + (i+1) * th_arc / segs;
+  const segs = Math.ceil(Math.abs(th_arc / (HalfPi + 0.001)));
+  const result = [];
+  for (let i=0; i<segs; ++i) {
+    const th2 = th0 + i * th_arc / segs;
+    const th3 = th0 + (i+1) * th_arc / segs;
     result[i] = [xc, yc, th2, th3, rx, ry, sin_th, cos_th];
   }
 
@@ -65,7 +65,7 @@ export function segments(x, y, rx, ry, large, sweep, rotateX, ox, oy) {
 }
 
 export function bezier(params) {
-  var key = join.call(params);
+  const key = join.call(params);
   if (bezierCache[key]) {
     return bezierCache[key];
   }
@@ -79,25 +79,25 @@ export function bezier(params) {
       sin_th = params[6],
       cos_th = params[7];
 
-  var a00 = cos_th * rx;
-  var a01 = -sin_th * ry;
-  var a10 = sin_th * rx;
-  var a11 = cos_th * ry;
+  const a00 = cos_th * rx;
+  const a01 = -sin_th * ry;
+  const a10 = sin_th * rx;
+  const a11 = cos_th * ry;
 
-  var cos_th0 = Math.cos(th0);
-  var sin_th0 = Math.sin(th0);
-  var cos_th1 = Math.cos(th1);
-  var sin_th1 = Math.sin(th1);
+  const cos_th0 = Math.cos(th0);
+  const sin_th0 = Math.sin(th0);
+  const cos_th1 = Math.cos(th1);
+  const sin_th1 = Math.sin(th1);
 
-  var th_half = 0.5 * (th1 - th0);
-  var sin_th_h2 = Math.sin(th_half * 0.5);
-  var t = (8/3) * sin_th_h2 * sin_th_h2 / Math.sin(th_half);
-  var x1 = cx + cos_th0 - t * sin_th0;
-  var y1 = cy + sin_th0 + t * cos_th0;
-  var x3 = cx + cos_th1;
-  var y3 = cy + sin_th1;
-  var x2 = x3 + t * sin_th1;
-  var y2 = y3 - t * cos_th1;
+  const th_half = 0.5 * (th1 - th0);
+  const sin_th_h2 = Math.sin(th_half * 0.5);
+  const t = (8/3) * sin_th_h2 * sin_th_h2 / Math.sin(th_half);
+  const x1 = cx + cos_th0 - t * sin_th0;
+  const y1 = cy + sin_th0 + t * cos_th0;
+  const x3 = cx + cos_th1;
+  const y3 = cy + sin_th1;
+  const x2 = x3 + t * sin_th1;
+  const y2 = y3 - t * cos_th1;
 
   return (bezierCache[key] = [
     a00 * x1 + a01 * y1,  a10 * x1 + a11 * y1,

--- a/packages/vega-scenegraph/src/path/render.js
+++ b/packages/vega-scenegraph/src/path/render.js
@@ -1,9 +1,9 @@
 import {bezier, segments} from './arc';
 
-var temp = ['l', 0, 0, 0, 0, 0, 0, 0];
+const temp = ['l', 0, 0, 0, 0, 0, 0, 0];
 
 function scale(current, sX, sY) {
-  var c = (temp[0] = current[0]);
+  const c = (temp[0] = current[0]);
   if (c === 'a' || c === 'A') {
     temp[1] = sX * current[1];
     temp[2] = sY * current[2];
@@ -306,7 +306,7 @@ export default function(context, path, l, t, sX, sY) {
 }
 
 function drawArc(context, x, y, coords) {
-  var seg = segments(
+  const seg = segments(
     coords[5], // end x
     coords[6], // end y
     coords[0], // radius x
@@ -316,8 +316,8 @@ function drawArc(context, x, y, coords) {
     coords[2], // rotation
     x, y
   );
-  for (var i=0; i<seg.length; ++i) {
-    var bez = bezier(seg[i]);
+  for (let i=0; i<seg.length; ++i) {
+    const bez = bezier(seg[i]);
     context.bezierCurveTo(bez[0], bez[1], bez[2], bez[3], bez[4], bez[5]);
   }
 }

--- a/packages/vega-scenegraph/src/path/symbols.js
+++ b/packages/vega-scenegraph/src/path/symbols.js
@@ -3,12 +3,12 @@ import pathRender from './render';
 import {HalfSqrt3, Tau} from '../util/constants';
 import {hasOwnProperty} from 'vega-util';
 
-var Tan30 = 0.5773502691896257;
+const Tan30 = 0.5773502691896257;
 
-var builtins = {
+const builtins = {
   'circle': {
     draw: function(context, size) {
-      var r = Math.sqrt(size) / 2;
+      const r = Math.sqrt(size) / 2;
       context.moveTo(r, 0);
       context.arc(0, 0, r, 0, Tau);
     }
@@ -34,7 +34,7 @@ var builtins = {
   },
   'diamond': {
     draw: function(context, size) {
-      var r = Math.sqrt(size) / 2;
+      const r = Math.sqrt(size) / 2;
       context.moveTo(-r, 0);
       context.lineTo(0, -r);
       context.lineTo(r, 0);
@@ -130,7 +130,7 @@ var builtins = {
   },
   'stroke': {
     draw: function(context, size) {
-      var r = Math.sqrt(size) / 2;
+      const r = Math.sqrt(size) / 2;
       context.moveTo(-r, 0);
       context.lineTo(r, 0);
     }
@@ -145,7 +145,7 @@ var custom = {};
 
 function customSymbol(path) {
   if (!hasOwnProperty(custom, path)) {
-    var parsed = pathParse(path);
+    const parsed = pathParse(path);
     custom[path] = {
       draw: function(context, size) {
         pathRender(context, parsed, 0, 0, Math.sqrt(size) / 2);

--- a/packages/vega-scenegraph/src/path/trail.js
+++ b/packages/vega-scenegraph/src/path/trail.js
@@ -10,7 +10,7 @@ export default function() {
       ready, x1, y1, r1;
 
   function point(x2, y2, w2) {
-    var r2 = w2 / 2;
+    const r2 = w2 / 2;
 
     if (ready) {
       var ux = y1 - y2,

--- a/packages/vega-scenegraph/src/util/canvas/pick.js
+++ b/packages/vega-scenegraph/src/util/canvas/pick.js
@@ -9,7 +9,7 @@ export function pick(test) {
     y *= context.pixelRatio;
 
     return pickVisit(scene, item => {
-      var b = item.bounds;
+      const b = item.bounds;
       // first hit test against bounding box
       if ((b && !b.contains(gx, gy)) || !b) return;
       // if in bounding box, perform more careful test

--- a/packages/vega-scenegraph/src/util/equal.js
+++ b/packages/vega-scenegraph/src/util/equal.js
@@ -1,7 +1,7 @@
 import pathParse from '../path/parse';
 import {isNumber, isObject} from 'vega-util';
 
-var TOLERANCE = 1e-9;
+const TOLERANCE = 1e-9;
 
 export function sceneEqual(a, b, key) {
   return (a === b) ? true

--- a/packages/vega-scenegraph/src/util/point.js
+++ b/packages/vega-scenegraph/src/util/point.js
@@ -1,5 +1,5 @@
 export default function(event, el) {
-  var rect = el.getBoundingClientRect();
+  const rect = el.getBoundingClientRect();
   return [
     event.clientX - rect.left - (el.clientLeft || 0),
     event.clientY - rect.top - (el.clientTop || 0)

--- a/packages/vega-scenegraph/src/util/serialize.js
+++ b/packages/vega-scenegraph/src/util/serialize.js
@@ -1,6 +1,6 @@
 import boundMark from '../bound/boundMark';
 
-var keys = [
+const keys = [
   'marktype', 'name', 'role', 'interactive', 'clip', 'items', 'zindex',
   'x', 'y', 'width', 'height', 'align', 'baseline',             // layout
   'fill', 'fillOpacity', 'opacity', 'blend',                    // fill
@@ -27,7 +27,7 @@ export function sceneToJSON(scene, indent) {
 }
 
 export function sceneFromJSON(json) {
-  var scene = (typeof json === 'string' ? JSON.parse(json) : json);
+  const scene = (typeof json === 'string' ? JSON.parse(json) : json);
   return initialize(scene);
 }
 

--- a/packages/vega-scenegraph/src/util/visit.js
+++ b/packages/vega-scenegraph/src/util/visit.js
@@ -22,7 +22,7 @@ export function visit(scene, visitor) {
   var items = scene.items, i, n;
   if (!items || !items.length) return;
 
-  var zitems = zorder(scene);
+  const zitems = zorder(scene);
 
   if (zitems && zitems.length) {
     for (i=0, n=items.length; i<n; ++i) {
@@ -40,7 +40,7 @@ export function pickVisit(scene, visitor) {
   var items = scene.items, hit, i;
   if (!items || !items.length) return null;
 
-  var zitems = zorder(scene);
+  const zitems = zorder(scene);
   if (zitems && zitems.length) items = zitems;
 
   for (i=items.length; --i >= 0;) {

--- a/packages/vega-scenegraph/test/__init__.js
+++ b/packages/vega-scenegraph/test/__init__.js
@@ -1,4 +1,4 @@
-var vega = require('../');
+const vega = require('../');
 
 // Standardize font metrics to suppress cross-platform variance.
 vega.textMetrics.canvas(false);
@@ -8,7 +8,7 @@ vega.textMetrics.canvas(false);
 vega.Marks.text.draw = function(context, scene) {
   vega.sceneVisit(scene, item => {
     if (!item.text) return;
-    var b = vega.Marks.text.bound(item.bounds, item);
+    const b = vega.Marks.text.bound(item.bounds, item);
     if (item.fill) {
       context.fillStyle = item.fill;
       context.fillRect(b.x1, b.y1, b.width(), b.height());

--- a/packages/vega-scenegraph/test/bounds-test.js
+++ b/packages/vega-scenegraph/test/bounds-test.js
@@ -2,7 +2,7 @@ var tape = require('tape'),
     Bounds = require('../').Bounds;
 
 tape('Bounds should support constructor without arguments', t => {
-  var b = new Bounds();
+  const b = new Bounds();
   t.equal(b.x1, +Number.MAX_VALUE);
   t.equal(b.y1, +Number.MAX_VALUE);
   t.equal(b.x2, -Number.MAX_VALUE);
@@ -11,7 +11,7 @@ tape('Bounds should support constructor without arguments', t => {
 });
 
 tape('Bounds should support constructor with bounds argument', t => {
-  var b = new Bounds((new Bounds()).set(1,1,2,2));
+  const b = new Bounds((new Bounds()).set(1,1,2,2));
   t.equal(b.x1, 1);
   t.equal(b.y1, 1);
   t.equal(b.x2, 2);
@@ -20,8 +20,8 @@ tape('Bounds should support constructor with bounds argument', t => {
 });
 
 tape('Bounds should support clone', t => {
-  var a = (new Bounds()).set(1,1,2,2);
-  var b = a.clone();
+  const a = (new Bounds()).set(1,1,2,2);
+  const b = a.clone();
   t.notEqual(a, b);
   t.equal(b.x1, 1);
   t.equal(b.y1, 1);
@@ -31,7 +31,7 @@ tape('Bounds should support clone', t => {
 });
 
 tape('Bounds should support set', t => {
-  var b = (new Bounds()).set(1,1,2,2);
+  const b = (new Bounds()).set(1,1,2,2);
   t.equal(b.x1, 1);
   t.equal(b.y1, 1);
   t.equal(b.x2, 2);
@@ -40,7 +40,7 @@ tape('Bounds should support set', t => {
 });
 
 tape('Bounds should support add point', t => {
-  var b = (new Bounds()).add(1,1).add(2,2);
+  const b = (new Bounds()).add(1,1).add(2,2);
   t.equal(b.x1, 1);
   t.equal(b.y1, 1);
   t.equal(b.x2, 2);
@@ -49,7 +49,7 @@ tape('Bounds should support add point', t => {
 });
 
 tape('Bounds should support expand', t => {
-  var b = (new Bounds()).add(1,1).add(2,2).expand(1);
+  const b = (new Bounds()).add(1,1).add(2,2).expand(1);
   t.equal(b.x1, 0);
   t.equal(b.y1, 0);
   t.equal(b.x2, 3);
@@ -58,7 +58,7 @@ tape('Bounds should support expand', t => {
 });
 
 tape('Bounds should support round', t => {
-  var b = (new Bounds()).add(0.5, 0.5).add(1.5, 1.5).round();
+  const b = (new Bounds()).add(0.5, 0.5).add(1.5, 1.5).round();
   t.equal(b.x1, 0);
   t.equal(b.y1, 0);
   t.equal(b.x2, 2);
@@ -67,7 +67,7 @@ tape('Bounds should support round', t => {
 });
 
 tape('Bounds should support translate', t => {
-  var b = (new Bounds()).set(1,1,2,2).translate(2,3);
+  const b = (new Bounds()).set(1,1,2,2).translate(2,3);
   t.equal(b.x1, 3);
   t.equal(b.y1, 4);
   t.equal(b.x2, 4);
@@ -76,7 +76,7 @@ tape('Bounds should support translate', t => {
 });
 
 tape('Bounds should support rotate', t => {
-  var b = (new Bounds()).set(0,0,2,2).rotate(Math.PI, 0, 0);
+  const b = (new Bounds()).set(0,0,2,2).rotate(Math.PI, 0, 0);
   t.true(Math.abs(b.x1 - -2) < 1e-10);
   t.true(Math.abs(b.y1 - -2) < 1e-10);
   t.true(Math.abs(b.x2 - 0) < 1e-10);
@@ -85,7 +85,7 @@ tape('Bounds should support rotate', t => {
 });
 
 tape('Bounds should support union', t => {
-  var b = (new Bounds()).set(1,1,3,3).union((new Bounds()).set(2,2,5,5));
+  const b = (new Bounds()).set(1,1,3,3).union((new Bounds()).set(2,2,5,5));
   t.equal(b.x1, 1);
   t.equal(b.y1, 1);
   t.equal(b.x2, 5);
@@ -133,7 +133,7 @@ tape('Bounds should support alignsWith', t => {
 });
 
 tape('Bounds should support contains', t => {
-  var b = (new Bounds()).set(1,1,3,3);
+  const b = (new Bounds()).set(1,1,3,3);
   t.false(b.contains(0,0));
   t.true(b.contains(1,1));
   t.true(b.contains(2,2));
@@ -143,13 +143,13 @@ tape('Bounds should support contains', t => {
 });
 
 tape('Bounds should support width', t => {
-  var b = (new Bounds()).set(1,1,3,5);
+  const b = (new Bounds()).set(1,1,3,5);
   t.equal(b.width(), 2);
   t.end();
 });
 
 tape('Bounds should support height', t => {
-  var b = (new Bounds()).set(1,1,3,5);
+  const b = (new Bounds()).set(1,1,3,5);
   t.equal(b.height(), 4);
   t.end();
 });

--- a/packages/vega-scenegraph/test/canvas-external-context-test.js
+++ b/packages/vega-scenegraph/test/canvas-external-context-test.js
@@ -34,7 +34,7 @@ tape('CanvasRenderer should support supplied external canvas context', t => {
 
   const image = externalCanvas.toBuffer();
   generate('png/external-context-rect.png', image);
-  var file = load('png/external-context-rect.png');
+  const file = load('png/external-context-rect.png');
   t.ok(image+'' == file);
   t.end();
 });

--- a/packages/vega-scenegraph/test/canvas-handler-test.js
+++ b/packages/vega-scenegraph/test/canvas-handler-test.js
@@ -8,10 +8,10 @@ var tape = require('tape'),
     win = (new jsdom.JSDOM()).window,
     doc = win.document;
 
-var res = './test/resources/';
+const res = './test/resources/';
 
-var marks = JSON.parse(load('marks.json'));
-for (var name in marks) { vega.sceneFromJSON(marks[name]); }
+const marks = JSON.parse(load('marks.json'));
+for (const name in marks) { vega.sceneFromJSON(marks[name]); }
 
 function load(file) {
   return fs.readFileSync(res + file, 'utf8');
@@ -23,7 +23,7 @@ function loadScene(file) {
 
 function render(scene, w, h) {
   global.document = doc;
-  var r = new Renderer()
+  const r = new Renderer()
     .initialize(doc.body, w, h)
     .render(scene);
   delete global.document;
@@ -40,7 +40,7 @@ function renderAsync(scene, w, h, callback) {
 }
 
 function event(name, x, y) {
-  var evt = new win.MouseEvent(name, {clientX: x, clientY: y});
+  const evt = new win.MouseEvent(name, {clientX: x, clientY: y});
   evt.changedTouches = [{
     clientX: x || 0,
     clientY: y || 0
@@ -99,16 +99,16 @@ tape('CanvasHandler should add/remove event callbacks', t => {
 });
 
 tape('CanvasHandler should handle input events', t => {
-  var scene = loadScene('scenegraph-rect.json');
-  var handler = new Handler()
+  const scene = loadScene('scenegraph-rect.json');
+  const handler = new Handler()
     .initialize(render(scene, 400, 200))
     .scene(scene);
 
   t.equal(handler.scene(), scene);
 
   var canvas = handler.canvas();
-  var count = 0;
-  var increment = function() { count++; };
+  let count = 0;
+  const increment = function() { count++; };
 
   handler.events.forEach(name => {
     handler.on(name, increment);
@@ -150,8 +150,8 @@ tape('CanvasHandler should handle input events', t => {
 });
 
 tape('CanvasHandler should pick elements in scenegraph', t => {
-  var scene = loadScene('scenegraph-rect.json');
-  var handler = new Handler().initialize(render(scene, 400, 200));
+  const scene = loadScene('scenegraph-rect.json');
+  const handler = new Handler().initialize(render(scene, 400, 200));
   t.ok(handler.pick(scene, 20, 180, 20, 180));
   t.notOk(handler.pick(scene, 0, 0, 0, 0));
   t.notOk(handler.pick(scene, 800, 800, 800, 800));
@@ -159,8 +159,8 @@ tape('CanvasHandler should pick elements in scenegraph', t => {
 });
 
 tape('CanvasHandler should pick arc mark', t => {
-  var mark = marks.arc;
-  var handler = new Handler().initialize(render(mark, 500, 500));
+  const mark = marks.arc;
+  const handler = new Handler().initialize(render(mark, 500, 500));
   t.ok(handler.pick(mark, 260, 300, 260, 300));
   t.notOk(handler.pick(mark, 248, 250, 248, 250));
   t.notOk(handler.pick(mark, 800, 800, 800, 800));
@@ -168,8 +168,8 @@ tape('CanvasHandler should pick arc mark', t => {
 });
 
 tape('CanvasHandler should pick area mark', t => {
-  var mark = marks['area-h'];
-  var handler = new Handler().initialize(render(mark, 500, 500));
+  let mark = marks['area-h'];
+  let handler = new Handler().initialize(render(mark, 500, 500));
   t.ok(handler.pick(mark, 100, 150, 100, 150));
   t.notOk(handler.pick(mark, 100, 50, 100, 50));
   t.notOk(handler.pick(mark, 800, 800, 800, 800));
@@ -185,23 +185,23 @@ tape('CanvasHandler should pick area mark', t => {
 });
 
 tape('CanvasHandler should pick group mark', t => {
-  var mark = {
+  const mark = {
     'marktype': 'group',
     'name': 'class-name',
     'items': [
       {'x':5, 'y':5, 'width':100, 'height':56, 'fill':'steelblue', 'clip':true, 'items':[]}
     ]
   };
-  var handler = new Handler().initialize(render(mark, 500, 500));
+  const handler = new Handler().initialize(render(mark, 500, 500));
   t.ok(handler.pick(mark, 50, 50, 50, 50));
   t.notOk(handler.pick(mark, 800, 800, 800, 800));
   t.end();
 });
 
 tape('CanvasHandler should pick image mark', t => {
-  var mark = marks.image;
+  const mark = marks.image;
   renderAsync(mark, 500, 500, el => {
-    var handler = new Handler().initialize(el);
+    const handler = new Handler().initialize(el);
     t.ok(handler.pick(mark, 250, 150, 250, 150));
     t.notOk(handler.pick(mark, 100, 305, 100, 305));
     t.notOk(handler.pick(mark, 800, 800, 800, 800));
@@ -210,13 +210,13 @@ tape('CanvasHandler should pick image mark', t => {
 });
 
 tape('CanvasHandler should pick line mark', t => {
-  var mark = marks['line-2'];
-  var handler = new Handler().initialize(render(mark, 500, 500));
+  let mark = marks['line-2'];
+  let handler = new Handler().initialize(render(mark, 500, 500));
   t.notOk(handler.pick(mark, 100, 144, 100, 144));
   t.notOk(handler.pick(mark, 800, 800, 800, 800));
 
   // fake isPointInStroke until node canvas supports it
-  var g = handler.context();
+  let g = handler.context();
   g.pixelRatio = 1.1;
   g.isPointInStroke = function() { return true; };
   t.ok(handler.pick(mark, 0, 144, 0, 144));
@@ -235,8 +235,8 @@ tape('CanvasHandler should pick line mark', t => {
 });
 
 tape('CanvasHandler should pick path mark', t => {
-  var mark = marks.path;
-  var handler = new Handler().initialize(render(mark, 500, 500));
+  const mark = marks.path;
+  const handler = new Handler().initialize(render(mark, 500, 500));
   t.ok(handler.pick(mark, 150, 150, 150, 150));
   t.notOk(handler.pick(mark, 200, 300, 300, 300));
   t.notOk(handler.pick(mark, 800, 800, 800, 800));
@@ -244,21 +244,21 @@ tape('CanvasHandler should pick path mark', t => {
 });
 
 tape('CanvasHandler should pick rect mark', t => {
-  var mark = marks.rect;
-  var handler = new Handler().initialize(render(mark, 500, 500));
+  const mark = marks.rect;
+  const handler = new Handler().initialize(render(mark, 500, 500));
   t.ok(handler.pick(mark, 50, 50, 50, 50));
   t.notOk(handler.pick(mark, 800, 800, 800, 800));
   t.end();
 });
 
 tape('CanvasHandler should pick rule mark', t => {
-  var mark = marks.rule;
-  var handler = new Handler().initialize(render(mark, 500, 500));
+  const mark = marks.rule;
+  const handler = new Handler().initialize(render(mark, 500, 500));
   t.notOk(handler.pick(mark, 100, 198, 100, 198));
   t.notOk(handler.pick(mark, 800, 800, 800, 800));
 
   // fake isPointInStroke until node canvas supports it
-  var g = handler.context();
+  const g = handler.context();
   g.pixelRatio = 1.1;
   g.isPointInStroke = function() { return true; };
   t.ok(handler.pick(mark, 5, 0, 5, 0));
@@ -267,8 +267,8 @@ tape('CanvasHandler should pick rule mark', t => {
 });
 
 tape('CanvasHandler should pick symbol mark', t => {
-  var mark = marks.symbol;
-  var handler = new Handler().initialize(render(mark, 500, 500));
+  const mark = marks.symbol;
+  const handler = new Handler().initialize(render(mark, 500, 500));
   t.ok(handler.pick(mark, 50, 90, 50, 90));
   t.notOk(handler.pick(mark, 155, 22, 155, 22));
   t.notOk(handler.pick(mark, 800, 800, 800, 800));
@@ -276,8 +276,8 @@ tape('CanvasHandler should pick symbol mark', t => {
 });
 
 tape('CanvasHandler should pick text mark', t => {
-  var mark = marks.text;
-  var handler = new Handler().initialize(render(mark, 500, 500));
+  const mark = marks.text;
+  const handler = new Handler().initialize(render(mark, 500, 500));
   t.ok(handler.pick(mark, 3, 45, 3, 45));
   t.ok(handler.pick(mark, 140, 160, 140, 160));
   t.ok(handler.pick(mark, 49, 120, 49, 120));
@@ -287,8 +287,8 @@ tape('CanvasHandler should pick text mark', t => {
 });
 
 tape('CanvasHandler should not pick empty marks', t => {
-  var scene = {marktype:'', items:[]};
-  var types = [
+  const scene = {marktype:'', items:[]};
+  const types = [
     'arc',
     'area',
     'group',

--- a/packages/vega-scenegraph/test/canvas-renderer-test.js
+++ b/packages/vega-scenegraph/test/canvas-renderer-test.js
@@ -8,10 +8,10 @@ var tape = require('tape'),
     Renderer = vega.CanvasRenderer,
     res = './test/resources/';
 
-var GENERATE = require('./resources/generate-tests');
+const GENERATE = require('./resources/generate-tests');
 
-var marks = JSON.parse(load('marks.json', 'utf-8'));
-for (var name in marks) { vega.sceneFromJSON(marks[name]); }
+const marks = JSON.parse(load('marks.json', 'utf-8'));
+for (const name in marks) { vega.sceneFromJSON(marks[name]); }
 
 function generate(path, image) {
   if (GENERATE) fs.writeFileSync(res + path, image);
@@ -57,17 +57,17 @@ function clearPathCache(mark) {
 }
 
 tape('CanvasRenderer should support argument free constructor', t => {
-  var r = new Renderer();
+  const r = new Renderer();
   t.notOk(r.canvas());
   t.notOk(r.context());
   t.end();
 });
 
 tape('CanvasRenderer should use DOM if available', t => {
-  var jsdom = require('jsdom');
+  const jsdom = require('jsdom');
   global.document = (new jsdom.JSDOM()).window.document;
 
-  var r = new Renderer().initialize(document.body, 100, 100);
+  const r = new Renderer().initialize(document.body, 100, 100);
   t.strictEqual(r.element(), document.body);
   t.strictEqual(r.canvas(), document.body.childNodes[0]);
 
@@ -76,22 +76,22 @@ tape('CanvasRenderer should use DOM if available', t => {
 });
 
 tape('CanvasRenderer should render scenegraph to canvas', t => {
-  var scene = loadScene('scenegraph-rect.json');
-  var image = render(scene, 400, 200);
+  const scene = loadScene('scenegraph-rect.json');
+  const image = render(scene, 400, 200);
   generate('png/scenegraph-rect.png', image);
-  var file = load('png/scenegraph-rect.png');
+  const file = load('png/scenegraph-rect.png');
   t.equal(comparePNGs(image, file), 0);
   t.end();
 });
 
 tape('CanvasRenderer should support clipping and gradients', t => {
-  var scene = loadScene('scenegraph-defs.json');
-  var image = render(scene, 102, 102);
+  const scene = loadScene('scenegraph-defs.json');
+  let image = render(scene, 102, 102);
   generate('png/scenegraph-defs.png', image);
-  var file = load('png/scenegraph-defs.png');
+  let file = load('png/scenegraph-defs.png');
   t.equal(comparePNGs(image, file), 0);
 
-  var scene2 = loadScene('scenegraph-defs.json');
+  const scene2 = loadScene('scenegraph-defs.json');
   scene2.items[0].clip = false;
   scene2.items[0].fill = 'red';
   image = render(scene2, 102, 102);
@@ -102,32 +102,32 @@ tape('CanvasRenderer should support clipping and gradients', t => {
 });
 
 tape('CanvasRenderer should support axes, legends and sub-groups', t => {
-  var scene = loadScene('scenegraph-barley.json');
-  var image = render(scene, 360, 740);
+  const scene = loadScene('scenegraph-barley.json');
+  const image = render(scene, 360, 740);
   generate('png/scenegraph-barley.png', image);
-  var file = load('png/scenegraph-barley.png');
+  const file = load('png/scenegraph-barley.png');
   t.equal(comparePNGs(image, file), 0);
   t.end();
 });
 
 tape('CanvasRenderer should support full redraw', t => {
-  var scene = loadScene('scenegraph-rect.json');
-  var r = new Renderer()
+  const scene = loadScene('scenegraph-rect.json');
+  const r = new Renderer()
     .initialize(null, 400, 200)
     .background('white')
     .render(scene);
 
-  var mark = scene.items[0].items[0].items;
-  var rect = mark[1]; rect.fill = 'red'; rect.width *= 2;
+  const mark = scene.items[0].items[0].items;
+  const rect = mark[1]; rect.fill = 'red'; rect.width *= 2;
   mark.push({
     mark: mark, x: 0, y: 0, width: 10, height: 10, fill: 'purple',
     bounds: new Bounds().set(0, 0, 10, 10)
   });
   r.render(scene);
 
-  var image = r.canvas().toBuffer();
+  let image = r.canvas().toBuffer();
   generate('png/scenegraph-full-redraw.png', image);
-  var file = load('png/scenegraph-full-redraw.png');
+  let file = load('png/scenegraph-full-redraw.png');
   t.equal(comparePNGs(image, file), 0);
 
   mark.pop();
@@ -141,20 +141,20 @@ tape('CanvasRenderer should support full redraw', t => {
 });
 
 tape('CanvasRenderer should support enter-item redraw', t => {
-  var scene = loadScene('scenegraph-rect.json');
-  var r = new Renderer()
+  const scene = loadScene('scenegraph-rect.json');
+  const r = new Renderer()
     .initialize(null, 400, 200)
     .background('white')
     .render(scene);
 
-  var rects = scene.items[0].items[0];
+  const rects = scene.items[0].items[0];
 
-  var rect1 = {x:10, y:10, width:50, height:50, fill:'red'};
+  const rect1 = {x:10, y:10, width:50, height:50, fill:'red'};
   rect1.mark = rects;
   rect1.bounds = new Bounds().set(10, 10, 60, 60);
   rects.items.push(rect1);
 
-  var rect2 = {x:70, y:10, width:50, height:50, fill:'blue'};
+  const rect2 = {x:70, y:10, width:50, height:50, fill:'blue'};
   rect2.mark = rects;
   rect2.bounds = new Bounds().set(70, 10, 120, 60);
   rects.items.push(rect2);
@@ -162,40 +162,40 @@ tape('CanvasRenderer should support enter-item redraw', t => {
   r.dirty(rect1);
   r.dirty(rect2);
   r.render(scene);
-  var image = r.canvas().toBuffer();
+  const image = r.canvas().toBuffer();
   generate('png/scenegraph-enter-redraw.png', image);
-  var file = load('png/scenegraph-enter-redraw.png');
+  const file = load('png/scenegraph-enter-redraw.png');
   t.equal(comparePNGs(image, file), 0);
   t.end();
 });
 
 tape('CanvasRenderer should support exit-item redraw', t => {
-  var scene = loadScene('scenegraph-rect.json');
-  var r = new Renderer()
+  const scene = loadScene('scenegraph-rect.json');
+  const r = new Renderer()
     .initialize(null, 400, 200)
     .background('white')
     .render(scene);
 
-  var rect = scene.items[0].items[0].items.pop();
+  const rect = scene.items[0].items[0].items.pop();
   rect.status = 'exit';
   r.dirty(rect);
   r.render(scene);
 
-  var image = r.canvas().toBuffer();
+  const image = r.canvas().toBuffer();
   generate('png/scenegraph-exit-redraw.png', image);
-  var file = load('png/scenegraph-exit-redraw.png');
+  const file = load('png/scenegraph-exit-redraw.png');
   t.equal(comparePNGs(image, file), 0);
   t.end();
 });
 
 tape('CanvasRenderer should support single-item redraw', t => {
-  var scene = loadScene('scenegraph-rect.json');
-  var r = new Renderer()
+  const scene = loadScene('scenegraph-rect.json');
+  const r = new Renderer()
     .initialize(null, 400, 200)
     .background('white')
     .render(scene);
 
-  var rect = scene.items[0].items[0].items[1];
+  const rect = scene.items[0].items[0].items[1];
   r.dirty(rect);
   rect.fill = 'red';
   rect.width *= 2;
@@ -203,59 +203,59 @@ tape('CanvasRenderer should support single-item redraw', t => {
   r.dirty(rect);
   r.render(scene);
 
-  var image = r.canvas().toBuffer();
+  const image = r.canvas().toBuffer();
   generate('png/scenegraph-single-redraw.png', image);
-  var file = load('png/scenegraph-single-redraw.png');
+  const file = load('png/scenegraph-single-redraw.png');
   t.equal(comparePNGs(image, file), 0);
   t.end();
 });
 
 tape('CanvasRenderer should support multi-item redraw', t => {
-  var scene = vega.sceneFromJSON(vega.sceneToJSON(marks['line-1']));
-  var r = new Renderer()
+  const scene = vega.sceneFromJSON(vega.sceneToJSON(marks['line-1']));
+  const r = new Renderer()
     .initialize(null, 400, 400)
     .background('white')
     .render(scene);
 
-  var line1 = scene.items[1]; line1.y = 5;                        // update
-  var line2 = scene.items.splice(2, 1)[0]; line2.status = 'exit'; // exit
-  var line3 = {x:400, y:200}; line3.mark = scene;                 // enter
+  const line1 = scene.items[1]; line1.y = 5;                        // update
+  const line2 = scene.items.splice(2, 1)[0]; line2.status = 'exit'; // exit
+  const line3 = {x:400, y:200}; line3.mark = scene;                 // enter
   scene.bounds.set(-1, -1, 401, 201);
   scene.items[0].pathCache = null;
   scene.items.push(line3);
 
   r.render(scene);
-  var image = r.canvas().toBuffer();
+  const image = r.canvas().toBuffer();
   generate('png/scenegraph-line-redraw.png', image);
-  var file = load('png/scenegraph-line-redraw.png');
+  const file = load('png/scenegraph-line-redraw.png');
   t.equal(comparePNGs(image, file), 0);
   t.end();
 });
 
 tape('CanvasRenderer should support enter-group redraw', t => {
-  var scene = loadScene('scenegraph-barley.json');
-  var r = new Renderer()
+  let scene = loadScene('scenegraph-barley.json');
+  const r = new Renderer()
     .initialize(null, 500, 600)
     .background('white')
     .render(scene);
 
-  var group = JSON.parse(vega.sceneToJSON(scene.items[0]));
+  const group = JSON.parse(vega.sceneToJSON(scene.items[0]));
   group.x = 200;
   scene = JSON.parse(vega.sceneToJSON(scene));
   scene.items.push(group);
   scene = vega.sceneFromJSON(scene);
 
   r.dirty(group);
-  var image = r.render(scene).canvas().toBuffer();
+  const image = r.render(scene).canvas().toBuffer();
   generate('png/scenegraph-enter-group-redraw.png', image);
-  var file = load('png/scenegraph-enter-group-redraw.png');
+  const file = load('png/scenegraph-enter-group-redraw.png');
   t.equal(comparePNGs(image, file), 0);
   t.end();
 });
 
 tape('CanvasRenderer should skip empty item sets', t => {
-  var scene = {marktype:'', items:[]};
-  var types = [
+  const scene = {marktype:'', items:[]};
+  const types = [
     'arc',
     'area',
     'group',
@@ -269,7 +269,7 @@ tape('CanvasRenderer should skip empty item sets', t => {
   ];
   var file = load('png/marks-empty.png'), image;
 
-  for (var i=0; i<types.length; ++i) {
+  for (let i=0; i<types.length; ++i) {
     scene.marktype = types[i];
     image = render(scene, 500, 500);
     t.equal(comparePNGs(image, file), 0);
@@ -278,17 +278,17 @@ tape('CanvasRenderer should skip empty item sets', t => {
 });
 
 tape('CanvasRenderer should render arc mark', t => {
-  var image = render(marks.arc, 500, 500);
+  const image = render(marks.arc, 500, 500);
   generate('png/marks-arc.png', image);
-  var file = load('png/marks-arc.png');
+  const file = load('png/marks-arc.png');
   t.equal(comparePNGs(image, file), 0);
   t.end();
 });
 
 tape('CanvasRenderer should render horizontal area mark', t => {
-  var image = render(marks['area-h'], 500, 500);
+  let image = render(marks['area-h'], 500, 500);
   generate('png/marks-area-h.png', image);
-  var file = load('png/marks-area-h.png');
+  const file = load('png/marks-area-h.png');
   t.equal(comparePNGs(image, file), 0);
 
   // clear path cache and re-render
@@ -298,9 +298,9 @@ tape('CanvasRenderer should render horizontal area mark', t => {
 });
 
 tape('CanvasRenderer should render vertical area mark', t => {
-  var image = render(marks['area-v'], 500, 500);
+  let image = render(marks['area-v'], 500, 500);
   generate('png/marks-area-v.png', image);
-  var file = load('png/marks-area-v.png');
+  const file = load('png/marks-area-v.png');
   t.equal(comparePNGs(image, file), 0);
 
   // clear path cache and re-render
@@ -310,25 +310,25 @@ tape('CanvasRenderer should render vertical area mark', t => {
 });
 
 tape('CanvasRenderer should render area mark with breaks', t => {
-  var image = render(marks['area-breaks'], 500, 500);
+  const image = render(marks['area-breaks'], 500, 500);
   generate('png/marks-area-breaks.png', image);
-  var file = load('png/marks-area-breaks.png');
+  const file = load('png/marks-area-breaks.png');
   t.equal(comparePNGs(image, file), 0);
   t.end();
 });
 
 tape('CanvasRenderer should render trail mark', t => {
-  var image = render(marks['trail'], 500, 500);
+  const image = render(marks['trail'], 500, 500);
   generate('png/marks-area-trail.png', image);
-  var file = load('png/marks-area-trail.png');
+  const file = load('png/marks-area-trail.png');
   t.equal(comparePNGs(image, file), 0);
   t.end();
 });
 
 tape('CanvasRenderer should render group mark', t => {
-  var image = render(marks.group, 500, 500);
+  const image = render(marks.group, 500, 500);
   generate('png/marks-group.png', image);
-  var file = load('png/marks-group.png');
+  const file = load('png/marks-group.png');
   t.equal(comparePNGs(image, file), 0);
   t.end();
 });
@@ -336,29 +336,29 @@ tape('CanvasRenderer should render group mark', t => {
 tape('CanvasRenderer should render image mark', t => {
   renderAsync(marks.image, 500, 500, image => {
     generate('png/marks-image.png', image);
-    var file = load('png/marks-image.png');
+    const file = load('png/marks-image.png');
     t.equal(comparePNGs(image, file), 0);
     t.end();
   });
 });
 
 tape('CanvasRenderer should skip invalid image', t => {
-  var scene = vega.sceneFromJSON({
+  const scene = vega.sceneFromJSON({
     marktype: 'image',
     items: [{url: 'does_not_exist.png'}]
   });
   renderAsync(scene, 500, 500, image => {
     generate('png/marks-empty.png', image);
-    var file = load('png/marks-empty.png');
+    const file = load('png/marks-empty.png');
     t.equal(comparePNGs(image, file), 0);
     t.end();
   });
 });
 
 tape('CanvasRenderer should render line mark', t => {
-  var image = render(marks['line-1'], 500, 500);
+  let image = render(marks['line-1'], 500, 500);
   generate('png/marks-line-1.png', image);
-  var file = load('png/marks-line-1.png');
+  let file = load('png/marks-line-1.png');
   t.equal(comparePNGs(image, file), 0);
 
   image = render(marks['line-2'], 500, 500);
@@ -373,17 +373,17 @@ tape('CanvasRenderer should render line mark', t => {
 });
 
 tape('CanvasRenderer should render line mark with breaks', t => {
-  var image = render(marks['line-breaks'], 500, 500);
+  const image = render(marks['line-breaks'], 500, 500);
   generate('png/marks-line-breaks.png', image);
-  var file = load('png/marks-line-breaks.png');
+  const file = load('png/marks-line-breaks.png');
   t.equal(comparePNGs(image, file), 0);
   t.end();
 });
 
 tape('CanvasRenderer should render path mark', t => {
-  var image = render(marks.path, 500, 500);
+  let image = render(marks.path, 500, 500);
   generate('png/marks-path.png', image);
-  var file = load('png/marks-path.png');
+  const file = load('png/marks-path.png');
   t.equal(comparePNGs(image, file), 0);
 
   // clear path cache and re-render
@@ -393,33 +393,33 @@ tape('CanvasRenderer should render path mark', t => {
 });
 
 tape('CanvasRenderer should render rect mark', t => {
-  var image = render(marks.rect, 500, 500);
+  const image = render(marks.rect, 500, 500);
   generate('png/marks-rect.png', image);
-  var file = load('png/marks-rect.png');
+  const file = load('png/marks-rect.png');
   t.equal(comparePNGs(image, file), 0);
   t.end();
 });
 
 tape('CanvasRenderer should render rule mark', t => {
-  var image = render(marks.rule, 500, 500);
+  const image = render(marks.rule, 500, 500);
   generate('png/marks-rule.png', image);
-  var file = load('png/marks-rule.png');
+  const file = load('png/marks-rule.png');
   t.equal(comparePNGs(image, file), 0);
   t.end();
 });
 
 tape('CanvasRenderer should render symbol mark', t => {
-  var image = render(marks.symbol, 500, 500);
+  const image = render(marks.symbol, 500, 500);
   generate('png/marks-symbol.png', image);
-  var file = load('png/marks-symbol.png');
+  const file = load('png/marks-symbol.png');
   t.equal(comparePNGs(image, file), 0);
   t.end();
 });
 
 tape('CanvasRenderer should render text mark', t => {
-  var image = render(marks.text, 500, 500);
+  const image = render(marks.text, 500, 500);
   generate('png/marks-text.png', image);
-  var file = load('png/marks-text.png');
+  const file = load('png/marks-text.png');
   t.equal(comparePNGs(image, file), 0);
   t.end();
 });

--- a/packages/vega-scenegraph/test/handler-test.js
+++ b/packages/vega-scenegraph/test/handler-test.js
@@ -3,18 +3,18 @@ var tape = require('tape'),
     Handler = vega.Handler;
 
 tape('Handler should support argument free constructor', t => {
-  var h = new Handler();
+  const h = new Handler();
   t.equal(h._active, null);
   t.ok(h._handlers);
   t.end();
 });
 
 tape('Handler should initialize', t => {
-  var el = {};
-  var obj = {};
-  var o = [1, 1];
-  var h = new Handler();
-  var s = h.initialize(el, o, obj);
+  const el = {};
+  const obj = {};
+  const o = [1, 1];
+  const h = new Handler();
+  const s = h.initialize(el, o, obj);
   t.equal(s, h);
   t.equal(h._el, el);
   t.equal(h._obj, obj);
@@ -28,15 +28,15 @@ tape('Handler should initialize', t => {
 });
 
 tape('Handler should parse event names', t => {
-  var h = new Handler();
+  const h = new Handler();
   t.equal(h.eventName('touchstart'), 'touchstart');
   t.equal(h.eventName('click.foo'), 'click');
   t.end();
 });
 
 tape('Handler should return array of handlers', t => {
-  var obj = {};
-  var h = new Handler();
+  const obj = {};
+  let h = new Handler();
   t.deepEqual(h.handlers(), []);
   h._handlers = {'click':[obj]};
   h = h.handlers();

--- a/packages/vega-scenegraph/test/path-test.js
+++ b/packages/vega-scenegraph/test/path-test.js
@@ -10,7 +10,7 @@ function bound(path, bounds) {
   return bounds;
 }
 
-var paths = [
+const paths = [
   'M 10,10 m 10,20',
   'M 10,10 l 10,20',
   'M 10,10 L 10,20',
@@ -70,7 +70,7 @@ var bounds = [
   { x1: -4.142135623730949, y1: 0, x2: 19.999999999999996, y2: 24.14213562373095 }
 ];
 
-var output = [
+const output = [
   'M10,10M20,30',
   'M10,10L20,30',
   'M10,10L10,20',
@@ -101,10 +101,10 @@ var output = [
 ];
 
 tape('pathParse should parse svg path', t => {
-  var s1 = 'M1,1L1,2';
-  var s2 = 'M 1 1 L 1 2';
-  var s3 = 'M 1,1 L 1 2';
-  var p = [['M',1,1], ['L',1,2]];
+  const s1 = 'M1,1L1,2';
+  const s2 = 'M 1 1 L 1 2';
+  const s3 = 'M 1,1 L 1 2';
+  const p = [['M',1,1], ['L',1,2]];
   t.deepEqual(pathParse(s1), p);
   t.deepEqual(pathParse(s2), p);
   t.deepEqual(pathParse(s3), p);
@@ -112,44 +112,44 @@ tape('pathParse should parse svg path', t => {
 });
 
 tape('pathParse should handle repeated arguments', t => {
-  var s = 'M 1 1 L 1 2 3 4';
-  var p = [['M',1,1], ['L',1,2], ['L',3,4]];
+  const s = 'M 1 1 L 1 2 3 4';
+  const p = [['M',1,1], ['L',1,2], ['L',3,4]];
   t.deepEqual(pathParse(s), p);
   t.end();
 });
 
 tape('pathParse should skip NaN parameters', t => {
-  var s = 'M 1 1 L 1 x';
-  var p = [['M',1,1], ['L',1]];
+  const s = 'M 1 1 L 1 x';
+  const p = [['M',1,1], ['L',1]];
   t.deepEqual(pathParse(s), p);
   t.end();
 });
 
 tape('pathParse should handle concatenated decimals', t => {
-  var s = 'M.5.5l.3.3';
-  var p = [['M',.5,.5], ['l',.3,.3]];
+  const s = 'M.5.5l.3.3';
+  const p = [['M',.5,.5], ['l',.3,.3]];
   t.deepEqual(pathParse(s), p);
   t.end();
 });
 
 tape('pathParse should handle implicit M lineTo', t => {
-  var s = 'M0,0 1,1 2,2';
-  var p = [['M',0,0], ['L',1,1], ['L',2,2]];
+  const s = 'M0,0 1,1 2,2';
+  const p = [['M',0,0], ['L',1,1], ['L',2,2]];
   t.deepEqual(pathParse(s), p);
   t.end();
 });
 
 tape('pathParse should handle implicit m lineTo', t => {
-  var s = 'm0,0 1,1 2,2';
-  var p = [['m',0,0], ['l',1,1], ['l',2,2]];
+  const s = 'm0,0 1,1 2,2';
+  const p = [['m',0,0], ['l',1,1], ['l',2,2]];
   t.deepEqual(pathParse(s), p);
   t.end();
 });
 
 tape('boundContext should calculate paths bounds', t => {
-  for (var i=0; i<paths.length; ++i) {
-    var p = pathParse(paths[i]);
-    var b = bound(p, new Bounds());
+  for (let i=0; i<paths.length; ++i) {
+    const p = pathParse(paths[i]);
+    const b = bound(p, new Bounds());
     t.equal(b.x1, bounds[i].x1);
     t.equal(b.x2, bounds[i].x2);
     t.equal(b.y1, bounds[i].y1);
@@ -160,7 +160,7 @@ tape('boundContext should calculate paths bounds', t => {
 
 tape('pathRender should render paths', t => {
   var ctx, p;
-  for (var i=0; i<paths.length; ++i) {
+  for (let i=0; i<paths.length; ++i) {
     p = pathParse(paths[i]);
     pathRender(ctx = context(), p, 0, 0);
     t.ok(vega.pathEqual(ctx+'', output[i]), 'path: ' + paths[i]);
@@ -169,14 +169,14 @@ tape('pathRender should render paths', t => {
 });
 
 tape('pathRender should translate paths', t => {
-  var ctx = context();
+  const ctx = context();
   pathRender(ctx, pathParse(paths[1]), 10, 50);
   t.equal(ctx+'', 'M20,60L30,80');
   t.end();
 });
 
 tape('pathRender should scale paths', t => {
-  var ctx = context();
+  const ctx = context();
   pathRender(ctx, pathParse(paths[1]), 0, 0, 2, 0.5);
   t.equal(ctx+'', 'M20,5L40,15');
   t.end();

--- a/packages/vega-scenegraph/test/renderer-test.js
+++ b/packages/vega-scenegraph/test/renderer-test.js
@@ -3,17 +3,17 @@ var tape = require('tape'),
     Renderer = vega.Renderer;
 
 tape('Renderer should support argument free constructor', t => {
-  var r = new Renderer();
+  const r = new Renderer();
   t.equal(r._el, null);
   t.equal(r._bgcolor, null);
   t.end();
 });
 
 tape('Renderer should initialize', t => {
-  var el = {};
-  var o = [1, 1];
-  var r = new Renderer();
-  var s = r.initialize(el, 1, 2, o);
+  const el = {};
+  const o = [1, 1];
+  const r = new Renderer();
+  const s = r.initialize(el, 1, 2, o);
   t.equal(s, r);
   t.equal(r._el, el);
   t.equal(r.element(), el);
@@ -24,9 +24,9 @@ tape('Renderer should initialize', t => {
 });
 
 tape('Renderer should resize', t => {
-  var o = [10, 10];
-  var r = new Renderer();
-  var s = r.resize(100, 200, o);
+  const o = [10, 10];
+  const r = new Renderer();
+  const s = r.resize(100, 200, o);
   t.equal(s, r);
   t.equal(r._width, 100);
   t.equal(r._height, 200);
@@ -35,22 +35,22 @@ tape('Renderer should resize', t => {
 });
 
 tape('Renderer should set background color', t => {
-  var r = new Renderer();
-  var s = r.background('steelblue');
+  const r = new Renderer();
+  const s = r.background('steelblue');
   t.equal(s, r);
   t.equal(r._bgcolor, 'steelblue');
   t.end();
 });
 
 tape('Renderer should use zero-padding if none is provided', t => {
-  var r = new Renderer().resize(100, 200, null);
+  const r = new Renderer().resize(100, 200, null);
   t.deepEqual(r._origin, [0, 0]);
   t.end();
 });
 
 tape('Renderer should return self from render method', t => {
-  var r = new Renderer();
-  var s = r.render();
+  const r = new Renderer();
+  const s = r.render();
   t.equal(s, r);
   t.end();
 });

--- a/packages/vega-scenegraph/test/schema-test.js
+++ b/packages/vega-scenegraph/test/schema-test.js
@@ -2,18 +2,18 @@ var fs = require('fs'),
     ajv = require('ajv'),
     tape = require('tape');
 
-var schemaFile = './build/vega-scenegraph-schema.json';
-var schema = JSON.parse(fs.readFileSync(schemaFile));
-var res = './test/resources/';
+const schemaFile = './build/vega-scenegraph-schema.json';
+const schema = JSON.parse(fs.readFileSync(schemaFile));
+const res = './test/resources/';
 
-var validator = new ajv({
+const validator = new ajv({
     allErrors: true,
     verbose: true,
     extendRefs: 'fail'
   })
   .addMetaSchema(require('ajv/lib/refs/json-schema-draft-06.json'));
 
-var validate = validator.compile(schema);
+const validate = validator.compile(schema);
 
 tape('schema should be valid', t => {
   t.ok(validator.validateSchema(schema));
@@ -21,17 +21,17 @@ tape('schema should be valid', t => {
 });
 
 tape('schema should validate correct marks', t => {
-  var marks = JSON.parse(fs.readFileSync(res + 'marks.json'));
-  for (var name in marks) {
+  const marks = JSON.parse(fs.readFileSync(res + 'marks.json'));
+  for (const name in marks) {
     t.ok(validate(marks[name]), name);
   }
   t.end();
 });
 
 tape('schema should invalidate incorrect marks', t => {
-  var marks = JSON.parse(fs.readFileSync(res + 'marks.json'));
-  for (var name in marks) {
-    var scene = marks[name];
+  const marks = JSON.parse(fs.readFileSync(res + 'marks.json'));
+  for (const name in marks) {
+    const scene = marks[name];
     switch (scene.marktype) {
       case 'rect': scene.marktype = 'fake'; break;
       case 'text': scene.marktype = 'arc'; break;
@@ -43,20 +43,20 @@ tape('schema should invalidate incorrect marks', t => {
 });
 
 tape('schema should validate scenegraph files', t => {
-  var files = [
+  const files = [
     'scenegraph-barley.json',
     'scenegraph-defs.json',
     'scenegraph-rect.json'
   ];
   files.forEach(f => {
-    var scene = JSON.parse(fs.readFileSync(res + f));
+    const scene = JSON.parse(fs.readFileSync(res + f));
     t.ok(validate(scene));
   });
   t.end();
 });
 
 tape('schema should invalidate degenerate scenegraphs', t => {
-  var list = [
+  const list = [
     {},
     {x: 0, y:1},
     {items: [{x:0, y:0}]},
@@ -71,7 +71,7 @@ tape('schema should invalidate degenerate scenegraphs', t => {
 });
 
 tape('schema should validate svg paths', t => {
-  var bad = [
+  const bad = [
     {marktype: 'path', items: [{path: 'lorem ipsum'}]},
     {marktype: 'path', items: [{path: 'L1,2'}]},
     {marktype: 'path', items: [{path: 'L1\n2'}]},
@@ -88,7 +88,7 @@ tape('schema should validate svg paths', t => {
     t.notOk(validate(scene), scene.items[0].path);
   });
 
-  var good = [
+  const good = [
     {marktype: 'path', items: [{path: ''}]},
     {marktype: 'path', items: [{path: 'M1,2'}]},
     {marktype: 'path', items: [{path: 'M1-2'}]},
@@ -109,7 +109,7 @@ tape('schema should validate svg paths', t => {
 });
 
 tape('schema should validate colors', t => {
-  var bad = [
+  const bad = [
     {marktype: 'rect', items: [{fill: '#ffff'}]},
     {marktype: 'rect', items: [{fill: 'rgb(256,0,0)'}]},
     {marktype: 'rect', items: [{fill: 'rgb(50%,50%,120%)'}]},
@@ -120,7 +120,7 @@ tape('schema should validate colors', t => {
     t.notOk(validate(scene));
   });
 
-  var good = [
+  const good = [
     {marktype: 'rect', items: [{fill: '#fff'}]},
     {marktype: 'rect', items: [{fill: '#abcdEf'}]},
     {marktype: 'rect', items: [{fill: 'steelblue'}]},

--- a/packages/vega-scenegraph/test/svg-handler-test.js
+++ b/packages/vega-scenegraph/test/svg-handler-test.js
@@ -6,12 +6,12 @@ var tape = require('tape'),
     jsdom = require('jsdom'),
     doc = (new jsdom.JSDOM()).window.document;
 
-var res = './test/resources/';
+const res = './test/resources/';
 
-var marks = JSON.parse(load('marks.json'));
-for (var name in marks) { vega.sceneFromJSON(marks[name]); }
+const marks = JSON.parse(load('marks.json'));
+for (const name in marks) { vega.sceneFromJSON(marks[name]); }
 
-var events = [
+const events = [
   'keydown',
   'keypress',
   'keyup',
@@ -42,7 +42,7 @@ function loadScene(file) {
 
 function render(scene, w, h) {
   global.document = doc;
-  var r = new Renderer()
+  const r = new Renderer()
     .initialize(doc.body, w, h)
     .render(scene);
   delete global.document;
@@ -50,7 +50,7 @@ function render(scene, w, h) {
 }
 
 function event(name, x, y) {
-  var evt = doc.createEvent('MouseEvents');
+  const evt = doc.createEvent('MouseEvents');
   evt.initEvent(name, false, true);
   evt.clientX = x || 0;
   evt.clientY = y || 0;
@@ -108,16 +108,16 @@ tape('SVGHandler should add/remove event callbacks', t => {
 });
 
 tape('SVGHandler should handle input events', t => {
-  var scene = loadScene('scenegraph-rect.json');
-  var handler = new Handler()
+  const scene = loadScene('scenegraph-rect.json');
+  const handler = new Handler()
     .initialize(render(scene, 400, 200))
     .scene(scene);
 
   t.equal(handler.scene(), scene);
 
-  var svg = handler.canvas();
-  var count = 0;
-  var increment = function() { count++; };
+  const svg = handler.canvas();
+  let count = 0;
+  const increment = function() { count++; };
 
   events.forEach(name => {
     handler.on(name, increment);

--- a/packages/vega-scenegraph/test/svg-renderer-test.js
+++ b/packages/vega-scenegraph/test/svg-renderer-test.js
@@ -7,10 +7,10 @@ var tape = require('tape'),
     jsdom = require('jsdom'),
     doc = (new jsdom.JSDOM()).window.document;
 
-var res = './test/resources/';
+const res = './test/resources/';
 
-var marks = JSON.parse(load('marks.json'));
-for (var name in marks) { vega.sceneFromJSON(marks[name]); }
+const marks = JSON.parse(load('marks.json'));
+for (const name in marks) { vega.sceneFromJSON(marks[name]); }
 
 function load(file) {
   return fs.readFileSync(res + file, 'utf8');
@@ -36,7 +36,7 @@ function compensate(svg) {
 
 function render(scene, w, h) {
   // clear document first
-  for (var i=doc.body.children.length; --i>=0;) {
+  for (let i=doc.body.children.length; --i>=0;) {
     doc.body.removeChild(doc.body.children[i]);
   }
 
@@ -52,7 +52,7 @@ function render(scene, w, h) {
 
 function renderAsync(scene, w, h, callback) {
   // clear document first
-  for (var i=doc.body.children.length; --i>=0;) {
+  for (let i=doc.body.children.length; --i>=0;) {
     doc.body.removeChild(doc.body.children[i]);
   }
 
@@ -68,19 +68,19 @@ function renderAsync(scene, w, h, callback) {
 
 // workaround for broken jsdom style parser
 function replaceFont(str, font) {
-  var tok = font.split(' ');
+  const tok = font.split(' ');
   return 'font: ' +
     tok.slice(2, -1).concat([tok[1], tok[0]]).join(' ') + ';';
 }
 
 tape('SVGRenderer should support argument free constructor', t => {
-  var r = new Renderer();
+  const r = new Renderer();
   t.equal(r.svg(), null);
   t.end();
 });
 
 tape('SVGRenderer should behave when dom element is not provided', t => {
-  var r = new Renderer().initialize(null, 100, 100, null);
+  const r = new Renderer().initialize(null, 100, 100, null);
   t.equal(r._svg, null);
   t.equal(r._root, null);
   t.equal(r.svg(), null);
@@ -93,29 +93,29 @@ tape('SVGRenderer should behave when dom element is not provided', t => {
 });
 
 tape('SVGRenderer should render scenegraph to svg', t => {
-  var scene = loadScene('scenegraph-rect.json');
-  var svg = render(scene, 400, 200);
-  var file = load('svg/scenegraph-rect.svg');
+  const scene = loadScene('scenegraph-rect.json');
+  const svg = render(scene, 400, 200);
+  const file = load('svg/scenegraph-rect.svg');
   t.equal(svg, file);
   t.end();
 });
 
 tape('SVGRenderer should support descriptions', t => {
-  var scene = loadScene('scenegraph-description.json');
-  var svg = render(scene, 400, 200);
-  var file = load('svg/scenegraph-description.svg');
+  const scene = loadScene('scenegraph-description.json');
+  const svg = render(scene, 400, 200);
+  const file = load('svg/scenegraph-description.svg');
   t.equal(svg, file);
   t.end();
 });
 
 tape('SVGRenderer should support clipping and gradients', t => {
-  var r = new Renderer()
+  const r = new Renderer()
     .initialize(doc.body, 102, 102);
 
   vega.resetSVGDefIds();
-  var scene = loadScene('scenegraph-defs.json');
+  let scene = loadScene('scenegraph-defs.json');
   var svg = compensate(r.render(scene).svg());
-  var file = load('svg/scenegraph-defs.svg');
+  let file = load('svg/scenegraph-defs.svg');
   t.equal(svg, file);
 
   svg = compensate(r.render(scene).svg());
@@ -132,9 +132,9 @@ tape('SVGRenderer should support clipping and gradients', t => {
 });
 
 tape('SVGRenderer should support axes, legends and sub-groups', t => {
-  var scene = loadScene('scenegraph-barley.json');
-  var svg = render(scene, 360, 740);
-  var file = load('svg/scenegraph-barley.svg');
+  const scene = loadScene('scenegraph-barley.json');
+  const svg = render(scene, 360, 740);
+  const file = load('svg/scenegraph-barley.svg');
   t.equal(svg, file);
   t.end();
 });
@@ -142,21 +142,21 @@ tape('SVGRenderer should support axes, legends and sub-groups', t => {
 tape('SVGRenderer should support full redraw', t => {
   vega.resetSVGDefIds();
 
-  var scene = loadScene('scenegraph-rect.json');
-  var r = new Renderer()
+  const scene = loadScene('scenegraph-rect.json');
+  const r = new Renderer()
     .initialize(doc.body, 400, 200)
     .background('white')
     .render(scene);
 
-  var mark = scene.items[0].items[0].items;
-  var rect = mark[1]; rect.fill = 'red'; rect.width *= 2;
+  const mark = scene.items[0].items[0].items;
+  const rect = mark[1]; rect.fill = 'red'; rect.width *= 2;
   mark.push({
     mark:mark, x:0, y:0, width:10, height:10, fill:'purple'
   });
   r.render(scene);
 
   var svg = compensate(r.svg());
-  var file = load('svg/scenegraph-full-redraw.svg');
+  let file = load('svg/scenegraph-full-redraw.svg');
   t.equal(svg, file);
 
   mark.pop();
@@ -171,25 +171,25 @@ tape('SVGRenderer should support full redraw', t => {
 tape('SVGRenderer should support enter-item redraw', t => {
   vega.resetSVGDefIds();
 
-  var scene = loadScene('scenegraph-rect.json');
-  var r = new Renderer()
+  const scene = loadScene('scenegraph-rect.json');
+  const r = new Renderer()
     .initialize(doc.body, 400, 200)
     .background('white')
     .render(scene);
 
-  var rects = scene.items[0].items[0];
-  var rect1 = {x:10, y:10, width:50, height:50, fill:'red'};
+  const rects = scene.items[0].items[0];
+  const rect1 = {x:10, y:10, width:50, height:50, fill:'red'};
   rect1.mark = rects;
   rect1.bounds = new Bounds().set(10, 10, 60, 60);
   rects.items.push(rect1);
 
-  var rect2 = {x:70, y:10, width:50, height:50, fill:'blue'};
+  const rect2 = {x:70, y:10, width:50, height:50, fill:'blue'};
   rect2.mark = rects;
   rect2.bounds = new Bounds().set(70, 10, 120, 60);
   rects.items.push(rect2);
 
   var svg = compensate(r.render(scene, [rect1, rect2]).svg());
-  var file = load('svg/scenegraph-enter-redraw.svg');
+  const file = load('svg/scenegraph-enter-redraw.svg');
   t.equal(svg, file);
   t.end();
 });
@@ -197,13 +197,13 @@ tape('SVGRenderer should support enter-item redraw', t => {
 tape('SVGRenderer should support exit-item redraw', function(t) {
   vega.resetSVGDefIds();
 
-  var scene = loadScene('scenegraph-rect.json');
-  var r = new Renderer()
+  const scene = loadScene('scenegraph-rect.json');
+  const r = new Renderer()
     .initialize(doc.body, 400, 200)
     .background('white')
     .render(scene);
 
-  var rect = scene.items[0].items[0].items.pop();
+  const rect = scene.items[0].items[0].items.pop();
   rect.exit = true;
   rect._svg.remove = rect._svg.remove || function() {
     this.parentNode.removeChild(this);
@@ -211,7 +211,7 @@ tape('SVGRenderer should support exit-item redraw', function(t) {
   r.render(scene, [rect]);
 
   var svg = compensate(r.svg());
-  var file = load('svg/scenegraph-exit-redraw.svg');
+  const file = load('svg/scenegraph-exit-redraw.svg');
   t.equal(svg, file);
   t.end();
 });
@@ -219,20 +219,20 @@ tape('SVGRenderer should support exit-item redraw', function(t) {
 tape('SVGRenderer should support single-item redraw', t => {
   vega.resetSVGDefIds();
 
-  var scene = loadScene('scenegraph-rect.json');
-  var r = new Renderer()
+  const scene = loadScene('scenegraph-rect.json');
+  const r = new Renderer()
     .initialize(doc.body, 400, 200)
     .background('white')
     .render(scene);
 
-  var rect = scene.items[0].items[0].items[1];
+  const rect = scene.items[0].items[0].items[1];
   rect.fill = 'red';
   rect.width *= 2;
   rect.bounds.x2 = 2*rect.bounds.x2 - rect.bounds.x1;
   r.render(scene, [rect]);
 
   var svg = compensate(r.svg());
-  var file = load('svg/scenegraph-single-redraw.svg');
+  const file = load('svg/scenegraph-single-redraw.svg');
   t.equal(svg, file);
   t.end();
 });
@@ -240,19 +240,19 @@ tape('SVGRenderer should support single-item redraw', t => {
 tape('SVGRenderer should support multi-item redraw', t => {
   vega.resetSVGDefIds();
 
-  var scene = vega.sceneFromJSON(vega.sceneToJSON(marks['line-1']));
-  var r = new Renderer()
+  const scene = vega.sceneFromJSON(vega.sceneToJSON(marks['line-1']));
+  const r = new Renderer()
     .initialize(doc.body, 400, 400)
     .background('white')
     .render(scene);
 
-  var line1 = scene.items[1]; line1.y = 5;                        // update
-  var line2 = scene.items.splice(2, 1)[0]; line2.status = 'exit'; // exit
-  var line3 = {x:400, y:200}; line3.mark = scene;                 // enter
+  const line1 = scene.items[1]; line1.y = 5;                        // update
+  const line2 = scene.items.splice(2, 1)[0]; line2.status = 'exit'; // exit
+  const line3 = {x:400, y:200}; line3.mark = scene;                 // enter
   scene.items.push(line3);
 
   var svg = compensate(r.render(scene, [line1, line2, line3]).svg());
-  var file = load('svg/scenegraph-line-redraw.svg');
+  const file = load('svg/scenegraph-line-redraw.svg');
   t.equal(svg, file);
   t.end();
 });
@@ -260,25 +260,25 @@ tape('SVGRenderer should support multi-item redraw', t => {
 tape('SVGRenderer should support enter-group redraw', t => {
   vega.resetSVGDefIds();
 
-  var scene = loadScene('scenegraph-barley.json');
-  var r = new Renderer()
+  const scene = loadScene('scenegraph-barley.json');
+  const r = new Renderer()
     .initialize(doc.body, 500, 600)
     .background('white')
     .render(scene);
 
-  var group = vega.sceneFromJSON(vega.sceneToJSON(scene.items[0]));
+  const group = vega.sceneFromJSON(vega.sceneToJSON(scene.items[0]));
   group.x = 200;
   group.mark = scene;
   scene.items.push(group);
 
   var svg = compensate(r.render(scene, [group]).svg());
-  var file = load('svg/scenegraph-enter-group-redraw.svg');
+  const file = load('svg/scenegraph-enter-group-redraw.svg');
   t.equal(svg, file);
   t.end();
 });
 
 tape('SVGRenderer should handle empty item sets', t => {
-  var types = [
+  const types = [
     'arc',
     'area',
     'group',
@@ -292,7 +292,7 @@ tape('SVGRenderer should handle empty item sets', t => {
   ];
   var scene, file, svg;
 
-  for (var i=0; i<types.length; ++i) {
+  for (let i=0; i<types.length; ++i) {
     scene = {marktype:types[i], items:[]};
     file = 'svg/marks-empty-' + types[i] + '.svg';
     svg = render(scene, 500, 500);
@@ -302,58 +302,58 @@ tape('SVGRenderer should handle empty item sets', t => {
 });
 
 tape('SVGRenderer should render arc mark', t => {
-  var svg = render(marks.arc, 500, 500);
-  var file = load('svg/marks-arc.svg');
+  const svg = render(marks.arc, 500, 500);
+  const file = load('svg/marks-arc.svg');
   t.equal(svg, file);
   t.end();
 });
 
 tape('SVGRenderer should render horizontal area mark', t => {
-  var svg = render(marks['area-h'], 500, 500);
-  var file = load('svg/marks-area-h.svg');
+  const svg = render(marks['area-h'], 500, 500);
+  const file = load('svg/marks-area-h.svg');
   t.equal(svg, file);
   t.end();
 });
 
 tape('SVGRenderer should render vertical area mark', t => {
-  var svg = render(marks['area-v'], 500, 500);
-  var file = load('svg/marks-area-v.svg');
+  const svg = render(marks['area-v'], 500, 500);
+  const file = load('svg/marks-area-v.svg');
   t.equal(svg, file);
   t.end();
 });
 
 tape('SVGRenderer should render area mark with breaks', t => {
-  var svg = render(marks['area-breaks'], 500, 500);
-  var file = load('svg/marks-area-breaks.svg');
+  const svg = render(marks['area-breaks'], 500, 500);
+  const file = load('svg/marks-area-breaks.svg');
   t.equal(svg, file);
   t.end();
 });
 
 tape('SVGRenderer should render trail mark', t => {
-  var svg = render(marks['trail'], 500, 500);
-  var file = load('svg/marks-area-trail.svg');
+  const svg = render(marks['trail'], 500, 500);
+  const file = load('svg/marks-area-trail.svg');
   t.equal(svg, file);
   t.end();
 });
 
 tape('SVGRenderer should render group mark', t => {
-  var svg = render(marks.group, 500, 500);
-  var file = load('svg/marks-group.svg');
+  const svg = render(marks.group, 500, 500);
+  const file = load('svg/marks-group.svg');
   t.equal(svg, file);
   t.end();
 });
 
 tape('SVGRenderer should render image mark', t => {
   renderAsync(marks.image, 500, 500, svg => {
-    var file = load('svg/marks-image.svg');
+    const file = load('svg/marks-image.svg');
     t.equal(svg, file);
     t.end();
   });
 });
 
 tape('SVGRenderer should render line mark', t => {
-  var svg = render(marks['line-1'], 500, 500);
-  var file = load('svg/marks-line-1.svg');
+  let svg = render(marks['line-1'], 500, 500);
+  let file = load('svg/marks-line-1.svg');
   t.equal(svg, file);
 
   svg = render(marks['line-2'], 500, 500);
@@ -363,43 +363,43 @@ tape('SVGRenderer should render line mark', t => {
 });
 
 tape('SVGRenderer should render line mark with breaks', t => {
-  var svg = render(marks['line-breaks'], 500, 500);
-  var file = load('svg/marks-line-breaks.svg');
+  const svg = render(marks['line-breaks'], 500, 500);
+  const file = load('svg/marks-line-breaks.svg');
   t.equal(svg, file);
   t.end();
 });
 
 tape('SVGRenderer should render path mark', t => {
-  var svg = render(marks.path, 500, 500);
-  var file = load('svg/marks-path.svg');
+  const svg = render(marks.path, 500, 500);
+  const file = load('svg/marks-path.svg');
   t.equal(svg, file);
   t.end();
 });
 
 tape('SVGRenderer should render rect mark', t => {
-  var svg = render(marks.rect, 500, 500);
-  var file = load('svg/marks-rect.svg');
+  const svg = render(marks.rect, 500, 500);
+  const file = load('svg/marks-rect.svg');
   t.equal(svg, file);
   t.end();
 });
 
 tape('SVGRenderer should render rule mark', t => {
-  var svg = render(marks.rule, 500, 500);
-  var file = load('svg/marks-rule.svg');
+  const svg = render(marks.rule, 500, 500);
+  const file = load('svg/marks-rule.svg');
   t.equal(svg, file);
   t.end();
 });
 
 tape('SVGRenderer should render symbol mark', t => {
-  var svg = render(marks.symbol, 500, 500);
-  var file = load('svg/marks-symbol.svg');
+  const svg = render(marks.symbol, 500, 500);
+  const file = load('svg/marks-symbol.svg');
   t.equal(svg, file);
   t.end();
 });
 
 tape('SVGRenderer should render text mark', t => {
-  var svg = render(marks.text, 500, 500);
-  var file = load('svg/marks-text.svg');
+  const svg = render(marks.text, 500, 500);
+  const file = load('svg/marks-text.svg');
   t.equal(svg, file);
   t.end();
 });

--- a/packages/vega-scenegraph/test/svg-string-renderer-test.js
+++ b/packages/vega-scenegraph/test/svg-string-renderer-test.js
@@ -5,11 +5,11 @@ var tape = require('tape'),
     Bounds = vega.Bounds,
     Renderer = vega.SVGStringRenderer;
 
-var res = './test/resources/';
-var GENERATE = require('./resources/generate-tests');
+const res = './test/resources/';
+const GENERATE = require('./resources/generate-tests');
 
-var marks = JSON.parse(load('marks.json'));
-for (var name in marks) { vega.sceneFromJSON(marks[name]); }
+const marks = JSON.parse(load('marks.json'));
+for (const name in marks) { vega.sceneFromJSON(marks[name]); }
 
 function generate(path, str) {
   if (GENERATE) fs.writeFileSync(res + path, str);
@@ -40,49 +40,49 @@ function renderAsync(scene, w, h, callback) {
 }
 
 tape('SVGStringRenderer should build empty group for item-less area mark', t => {
-  var r = new Renderer();
-  var str = r.mark(vega.markup(), {marktype: 'area', items:[]}) + '';
+  const r = new Renderer();
+  const str = r.mark(vega.markup(), {marktype: 'area', items:[]}) + '';
   generate('svg/marks-itemless-area.svg', str);
-  var file = load('svg/marks-itemless-area.svg');
+  const file = load('svg/marks-itemless-area.svg');
   t.equal(str, file);
   t.end();
 });
 
 tape('SVGStringRenderer should build empty group for item-less line mark', t => {
-  var r = new Renderer();
-  var str = r.mark(vega.markup(), {marktype: 'line', items:[]}) + '';
+  const r = new Renderer();
+  const str = r.mark(vega.markup(), {marktype: 'line', items:[]}) + '';
   generate('svg/marks-itemless-line.svg', str);
-  var file = load('svg/marks-itemless-line.svg');
+  const file = load('svg/marks-itemless-line.svg');
   t.equal(str, file);
   t.end();
 });
 
 tape('SVGStringRenderer should render scenegraph to SVG string', t => {
-  var scene = loadScene('scenegraph-rect.json');
-  var str = render(scene, 400, 200);
+  const scene = loadScene('scenegraph-rect.json');
+  const str = render(scene, 400, 200);
   generate('svg/scenegraph-rect.svg', str);
-  var file = load('svg/scenegraph-rect.svg');
+  const file = load('svg/scenegraph-rect.svg');
   t.equal(str, file);
   t.end();
 });
 
 tape('SVGStringRenderer should support descriptions', t => {
-  var scene = loadScene('scenegraph-description.json');
-  var str = render(scene, 400, 200);
+  const scene = loadScene('scenegraph-description.json');
+  const str = render(scene, 400, 200);
   generate('svg/scenegraph-description.svg', str);
-  var file = load('svg/scenegraph-description.svg');
+  const file = load('svg/scenegraph-description.svg');
   t.equal(str, file);
   t.end();
 });
 
 tape('SVGStringRenderer should support clipping and gradients', t => {
-  var scene = loadScene('scenegraph-defs.json');
-  var str = render(scene, 102, 102);
+  const scene = loadScene('scenegraph-defs.json');
+  let str = render(scene, 102, 102);
   generate('svg/scenegraph-defs.svg', str);
-  var file = load('svg/scenegraph-defs.svg');
+  let file = load('svg/scenegraph-defs.svg');
   t.equal(str, file);
 
-  var scene2 = loadScene('scenegraph-defs.json');
+  const scene2 = loadScene('scenegraph-defs.json');
   delete scene2.items[0].clip;
   scene2.items[0].fill = 'red';
   str = render(scene2, 102, 102);
@@ -94,10 +94,10 @@ tape('SVGStringRenderer should support clipping and gradients', t => {
 });
 
 tape('SVGStringRenderer should support axes, legends and sub-groups', t => {
-  var scene = loadScene('scenegraph-barley.json');
-  var str = render(scene, 360, 740);
+  const scene = loadScene('scenegraph-barley.json');
+  const str = render(scene, 360, 740);
   generate('svg/scenegraph-barley.svg', str);
-  var file = load('svg/scenegraph-barley.svg');
+  const file = load('svg/scenegraph-barley.svg');
   t.equal(str, file);
   t.end();
 });
@@ -105,22 +105,22 @@ tape('SVGStringRenderer should support axes, legends and sub-groups', t => {
 tape('SVGStringRenderer should support full redraw', t => {
   vega.resetSVGDefIds();
 
-  var scene = loadScene('scenegraph-rect.json');
-  var r = new Renderer()
+  const scene = loadScene('scenegraph-rect.json');
+  const r = new Renderer()
     .initialize(null, 400, 200)
     .background('white')
     .render(scene);
 
-  var mark = scene.items[0].items[0].items;
-  var rect = mark[1]; rect.fill = 'red'; rect.width *= 2;
+  const mark = scene.items[0].items[0].items;
+  const rect = mark[1]; rect.fill = 'red'; rect.width *= 2;
   mark.push({
     mark:mark, x:0, y:0, width:10, height:10, fill:'purple'
   });
   r.render(scene);
 
-  var str = r.svg();
+  let str = r.svg();
   generate('svg/scenegraph-full-redraw.svg', str);
-  var file = load('svg/scenegraph-full-redraw.svg');
+  let file = load('svg/scenegraph-full-redraw.svg');
   t.equal(str, file);
 
   mark.pop();
@@ -137,27 +137,27 @@ tape('SVGStringRenderer should support full redraw', t => {
 tape('SVGStringRenderer should support enter-item redraw', t => {
   vega.resetSVGDefIds();
 
-  var scene = loadScene('scenegraph-rect.json');
-  var r = new Renderer()
+  const scene = loadScene('scenegraph-rect.json');
+  const r = new Renderer()
     .initialize(null, 400, 200)
     .background('white')
     .render(scene);
 
-  var rects = scene.items[0].items[0];
+  const rects = scene.items[0].items[0];
 
-  var rect1 = {x:10, y:10, width:50, height:50, fill:'red'};
+  const rect1 = {x:10, y:10, width:50, height:50, fill:'red'};
   rect1.mark = rects;
   rect1.bounds = new Bounds().set(10, 10, 60, 60);
   rects.items.push(rect1);
 
-  var rect2 = {x:70, y:10, width:50, height:50, fill:'blue'};
+  const rect2 = {x:70, y:10, width:50, height:50, fill:'blue'};
   rect2.mark = rects;
   rect2.bounds = new Bounds().set(70, 10, 120, 60);
   rects.items.push(rect2);
 
-  var str = r.render(scene, [rect1, rect2]).svg();
+  const str = r.render(scene, [rect1, rect2]).svg();
   generate('svg/scenegraph-enter-redraw.svg', str);
-  var file = load('svg/scenegraph-enter-redraw.svg');
+  const file = load('svg/scenegraph-enter-redraw.svg');
   t.equal(str, file);
 
   t.end();
@@ -166,19 +166,19 @@ tape('SVGStringRenderer should support enter-item redraw', t => {
 tape('SVGStringRenderer should support exit-item redraw', t => {
   vega.resetSVGDefIds();
 
-  var scene = loadScene('scenegraph-rect.json');
-  var r = new Renderer()
+  const scene = loadScene('scenegraph-rect.json');
+  const r = new Renderer()
     .initialize(null, 400, 200)
     .background('white')
     .render(scene);
 
-  var rect = scene.items[0].items[0].items.pop();
+  const rect = scene.items[0].items[0].items.pop();
   rect.status = 'exit';
   r.render(scene, [rect]);
 
-  var str = r.svg();
+  const str = r.svg();
   generate('svg/scenegraph-exit-redraw.svg', str);
-  var file = load('svg/scenegraph-exit-redraw.svg');
+  const file = load('svg/scenegraph-exit-redraw.svg');
   t.equal(str, file);
 
   t.end();
@@ -187,20 +187,20 @@ tape('SVGStringRenderer should support exit-item redraw', t => {
 tape('SVGStringRenderer should support single-item redraw', t => {
   vega.resetSVGDefIds();
 
-  var scene = loadScene('scenegraph-rect.json');
-  var r = new Renderer()
+  const scene = loadScene('scenegraph-rect.json');
+  const r = new Renderer()
     .initialize(null, 400, 200)
     .background('white')
     .render(scene);
 
-  var rect = scene.items[0].items[0].items[1];
+  const rect = scene.items[0].items[0].items[1];
   rect.fill = 'red';
   rect.width *= 2;
   r.render(scene, [rect]);
 
-  var str = r.svg();
+  const str = r.svg();
   generate('svg/scenegraph-single-redraw.svg', str);
-  var file = load('svg/scenegraph-single-redraw.svg');
+  const file = load('svg/scenegraph-single-redraw.svg');
   t.equal(str, file);
 
   t.end();
@@ -209,20 +209,20 @@ tape('SVGStringRenderer should support single-item redraw', t => {
 tape('SVGStringRenderer should support multi-item redraw', t => {
   vega.resetSVGDefIds();
 
-  var scene = vega.sceneFromJSON(vega.sceneToJSON(marks['line-1']));
-  var r = new Renderer()
+  const scene = vega.sceneFromJSON(vega.sceneToJSON(marks['line-1']));
+  const r = new Renderer()
     .initialize(null, 400, 400)
     .background('white')
     .render(scene);
 
-  var line1 = scene.items[1]; line1.y = 5;                        // update
-  var line2 = scene.items.splice(2, 1)[0]; line2.status = 'exit'; // exit
-  var line3 = {x:400, y:200}; line3.mark = scene;                 // enter
+  const line1 = scene.items[1]; line1.y = 5;                        // update
+  const line2 = scene.items.splice(2, 1)[0]; line2.status = 'exit'; // exit
+  const line3 = {x:400, y:200}; line3.mark = scene;                 // enter
   scene.items.push(line3);
 
-  var str = r.render(scene, [line1, line2, line3]).svg();
+  const str = r.render(scene, [line1, line2, line3]).svg();
   generate('svg/scenegraph-line-redraw.svg', str);
-  var file = load('svg/scenegraph-line-redraw.svg');
+  const file = load('svg/scenegraph-line-redraw.svg');
   t.equal(str, file);
 
   t.end();
@@ -231,27 +231,27 @@ tape('SVGStringRenderer should support multi-item redraw', t => {
 tape('SVGStringRenderer should support enter-group redraw', t => {
   vega.resetSVGDefIds();
 
-  var scene = loadScene('scenegraph-barley.json');
-  var r = new Renderer()
+  const scene = loadScene('scenegraph-barley.json');
+  const r = new Renderer()
     .initialize(null, 500, 600)
     .background('white')
     .render(scene);
 
-  var group = vega.sceneFromJSON(vega.sceneToJSON(scene.items[0]));
+  const group = vega.sceneFromJSON(vega.sceneToJSON(scene.items[0]));
   group.x = 200;
   group.mark = scene;
   scene.items.push(group);
 
-  var str = r.render(scene, [group]).svg();
+  const str = r.render(scene, [group]).svg();
   generate('svg/scenegraph-enter-group-redraw.svg', str);
-  var file = load('svg/scenegraph-enter-group-redraw.svg');
+  const file = load('svg/scenegraph-enter-group-redraw.svg');
   t.equal(str, file);
 
   t.end();
 });
 
 tape('SVGStringRenderer should handle empty item sets', t => {
-  var types = [
+  const types = [
     'arc',
     'area',
     'group',
@@ -265,7 +265,7 @@ tape('SVGStringRenderer should handle empty item sets', t => {
   ];
   var scene, file, str;
 
-  for (var i=0; i<types.length; ++i) {
+  for (let i=0; i<types.length; ++i) {
     scene = {marktype:types[i], items:[]};
     file = 'svg/marks-empty-' + types[i] + '.svg';
     str = render(scene, 500, 500);
@@ -277,49 +277,49 @@ tape('SVGStringRenderer should handle empty item sets', t => {
 });
 
 tape('SVGStringRenderer should render arc mark', t => {
-  var svg = render(marks.arc, 500, 500);
+  const svg = render(marks.arc, 500, 500);
   generate('svg/marks-arc.svg', svg);
-  var file = load('svg/marks-arc.svg');
+  const file = load('svg/marks-arc.svg');
   t.equal(svg, file);
   t.end();
 });
 
 tape('SVGStringRenderer should render horizontal area mark', t => {
-  var svg = render(marks['area-h'], 500, 500);
+  const svg = render(marks['area-h'], 500, 500);
   generate('svg/marks-area-h.svg', svg);
-  var file = load('svg/marks-area-h.svg');
+  const file = load('svg/marks-area-h.svg');
   t.equal(svg, file);
   t.end();
 });
 
 tape('SVGStringRenderer should render vertical area mark', t => {
-  var svg = render(marks['area-v'], 500, 500);
+  const svg = render(marks['area-v'], 500, 500);
   generate('svg/marks-area-v.svg', svg);
-  var file = load('svg/marks-area-v.svg');
+  const file = load('svg/marks-area-v.svg');
   t.equal(svg, file);
   t.end();
 });
 
 tape('SVGStringRenderer should render area mark with breaks', t => {
-  var svg = render(marks['area-breaks'], 500, 500);
+  const svg = render(marks['area-breaks'], 500, 500);
   generate('svg/marks-area-breaks.svg', svg);
-  var file = load('svg/marks-area-breaks.svg');
+  const file = load('svg/marks-area-breaks.svg');
   t.equal(svg, file);
   t.end();
 });
 
 tape('SVGStringRenderer should render trail mark', t => {
-  var svg = render(marks['trail'], 500, 500);
+  const svg = render(marks['trail'], 500, 500);
   generate('svg/marks-area-trail.svg', svg);
-  var file = load('svg/marks-area-trail.svg');
+  const file = load('svg/marks-area-trail.svg');
   t.equal(svg, file);
   t.end();
 });
 
 tape('SVGStringRenderer should render group mark', t => {
-  var svg = render(marks.group, 500, 500);
+  const svg = render(marks.group, 500, 500);
   generate('svg/marks-group.svg', svg);
-  var file = load('svg/marks-group.svg');
+  const file = load('svg/marks-group.svg');
   t.equal(svg, file);
   t.end();
 });
@@ -327,16 +327,16 @@ tape('SVGStringRenderer should render group mark', t => {
 tape('SVGStringRenderer should render image mark', t => {
   renderAsync(marks.image, 500, 500, svg => {
     generate('svg/marks-image.svg', svg);
-    var file = load('svg/marks-image.svg');
+    const file = load('svg/marks-image.svg');
     t.equal(svg, file);
     t.end();
   });
 });
 
 tape('SVGStringRenderer should render line mark', t => {
-  var svg = render(marks['line-1'], 500, 500);
+  let svg = render(marks['line-1'], 500, 500);
   generate('svg/marks-line-1.svg', svg);
-  var file = load('svg/marks-line-1.svg');
+  let file = load('svg/marks-line-1.svg');
   t.equal(svg, file);
 
   svg = render(marks['line-2'], 500, 500);
@@ -348,58 +348,58 @@ tape('SVGStringRenderer should render line mark', t => {
 });
 
 tape('SVGStringRenderer should render line mark with breaks', t => {
-  var svg = render(marks['line-breaks'], 500, 500);
+  const svg = render(marks['line-breaks'], 500, 500);
   generate('svg/marks-line-breaks.svg', svg);
-  var file = load('svg/marks-line-breaks.svg');
+  const file = load('svg/marks-line-breaks.svg');
   t.equal(svg, file);
   t.end();
 });
 
 tape('SVGStringRenderer should render path mark', t => {
-  var svg = render(marks.path, 500, 500);
+  const svg = render(marks.path, 500, 500);
   generate('svg/marks-path.svg', svg);
-  var file = load('svg/marks-path.svg');
+  const file = load('svg/marks-path.svg');
   t.equal(svg, file);
   t.end();
 });
 
 tape('SVGStringRenderer should render rect mark', t => {
-  var svg = render(marks.rect, 500, 500);
+  const svg = render(marks.rect, 500, 500);
   generate('svg/marks-rect.svg', svg);
-  var file = load('svg/marks-rect.svg');
+  const file = load('svg/marks-rect.svg');
   t.equal(svg, file);
   t.end();
 });
 
 tape('SVGStringRenderer should render rule mark', t => {
-  var svg = render(marks.rule, 500, 500);
+  const svg = render(marks.rule, 500, 500);
   generate('svg/marks-rule.svg', svg);
-  var file = load('svg/marks-rule.svg');
+  const file = load('svg/marks-rule.svg');
   t.equal(svg, file);
   t.end();
 });
 
 tape('SVGStringRenderer should render symbol mark', t => {
-  var svg = render(marks.symbol, 500, 500);
+  const svg = render(marks.symbol, 500, 500);
   generate('svg/marks-symbol.svg', svg);
-  var file = load('svg/marks-symbol.svg');
+  const file = load('svg/marks-symbol.svg');
   t.equal(svg, file);
   t.end();
 });
 
 tape('SVGStringRenderer should render text mark', t => {
-  var svg = render(marks.text, 500, 500);
+  const svg = render(marks.text, 500, 500);
   generate('svg/marks-text.svg', svg);
-  var file = load('svg/marks-text.svg');
+  const file = load('svg/marks-text.svg');
   t.equal(svg, file);
   t.end();
 });
 
 tape('SVGStringRenderer should inject hyperlinks', t => {
-  var scene = loadScene('scenegraph-href.json');
+  const scene = loadScene('scenegraph-href.json');
   renderAsync(scene, 400, 200, svg => {
     generate('svg/scenegraph-href.svg', svg);
-    var file = load('svg/scenegraph-href.svg');
+    const file = load('svg/scenegraph-href.svg');
     t.equal(svg, file);
     t.end();
   });

--- a/packages/vega-schema/src/encode.js
+++ b/packages/vega-schema/src/encode.js
@@ -32,7 +32,7 @@ export function baseValueSchema(type, nullable) {
   var modType = type.type === 'number' ? 'number' : 'string',
       valueType = nullable ? oneOf(type, nullType) : type;
 
-  var valueRef = allOf(
+  const valueRef = allOf(
     ref(modType + 'Modifiers'),
     anyOf(
       oneOf(
@@ -51,7 +51,7 @@ export function baseValueSchema(type, nullable) {
 }
 
 export function valueSchema(type, nullable) {
-  var valueRef = baseValueSchema(type, nullable);
+  const valueRef = baseValueSchema(type, nullable);
   return oneOf(
     array(allOf(ruleRef, valueRef)),
     valueRef

--- a/packages/vega-schema/src/schema.js
+++ b/packages/vega-schema/src/schema.js
@@ -24,7 +24,7 @@ import title from './title';
 import transform from './transform';
 
 function extend(target, source) {
-  for (var key in source) {
+  for (const key in source) {
     target[key] = source[key];
   }
 }
@@ -35,7 +35,7 @@ function addModule(schema, module) {
 }
 
 export default function(definitions) {
-  var schema = {
+  const schema = {
     $schema: 'http://json-schema.org/draft-06/schema#',
     title: 'Vega Visualization Specification Language',
     defs: {},

--- a/packages/vega-schema/src/transform.js
+++ b/packages/vega-schema/src/transform.js
@@ -42,7 +42,7 @@ function transformSchema(name, def) {
 }
 
 function parameterSchema(param) {
-  var p = {};
+  let p = {};
 
   switch (param.type) {
     case 'projection':

--- a/packages/vega-statistics/test/bin-test.js
+++ b/packages/vega-statistics/test/bin-test.js
@@ -2,7 +2,7 @@ var tape = require('tape'),
     bin = require('../').bin;
 
 tape('bin generates boundaries for exact step size', t => {
-  var b = bin({extent:[1.3, 10.2], step:1, nice:false});
+  let b = bin({extent:[1.3, 10.2], step:1, nice:false});
   t.equal(b.start, 1.3);
   t.equal(b.stop, 10.2);
   t.equal(b.step, 1);
@@ -21,7 +21,7 @@ tape('bin generates boundaries for exact step size', t => {
 });
 
 tape('bin generates boundaries for zero-span extent', t => {
-  var b = bin({extent: [1, 1], maxbins: 1});
+  let b = bin({extent: [1, 1], maxbins: 1});
   t.equal(b.start, 1);
   t.equal(b.stop, 2);
   t.equal(b.step, 1);
@@ -45,7 +45,7 @@ tape('bin generates boundaries for zero-span extent', t => {
 });
 
 tape('bin generates boundaries for inferred step size', t => {
-  var b = bin({extent:[1.3, 10.2], maxbins:10, nice:false});
+  let b = bin({extent:[1.3, 10.2], maxbins:10, nice:false});
   t.equal(b.start, 1.3);
   t.equal(b.stop, 10.2);
   t.equal(b.step, 1);
@@ -69,7 +69,7 @@ tape('bin generates boundaries for inferred step size', t => {
 });
 
 tape('bin generates boundaries with minimum step size', t => {
-  var b = bin({extent:[0, 10], minstep:1, maxbins:100});
+  const b = bin({extent:[0, 10], minstep:1, maxbins:100});
   t.equal(b.start, 0);
   t.equal(b.stop, 10);
   t.equal(b.step, 1);
@@ -78,7 +78,7 @@ tape('bin generates boundaries with minimum step size', t => {
 });
 
 tape('bin generates boundaries for given span size', t => {
-  var b = bin({extent:[0, 100], span:10, maxbins:10, nice:false});
+  let b = bin({extent:[0, 100], span:10, maxbins:10, nice:false});
   t.equal(b.start, 0);
   t.equal(b.stop, 100);
   t.equal(b.step, 1);

--- a/packages/vega-statistics/test/bootstrapCI-test.js
+++ b/packages/vega-statistics/test/bootstrapCI-test.js
@@ -2,7 +2,7 @@ var tape = require('tape'),
     bootstrapCI = require('../').bootstrapCI;
 
 tape('bootstrapCI returns array of undefined for empty data', t => {
-  var ci = bootstrapCI([], 1000, 0.05);
+  const ci = bootstrapCI([], 1000, 0.05);
   t.deepEqual(ci, [undefined, undefined]);
   t.end();
 });

--- a/packages/vega-statistics/test/dotbin-test.js
+++ b/packages/vega-statistics/test/dotbin-test.js
@@ -2,7 +2,7 @@ var tape = require('tape'),
     dotbin = require('../').dotbin;
 
 tape('dotbin calculates dot plot bin positions', t => {
-  var data = [1, 1, 2, 3, 4, 5, 6];
+  const data = [1, 1, 2, 3, 4, 5, 6];
   t.deepEqual(
     Array.from(dotbin(data, 0.5)),
     data

--- a/packages/vega-statistics/test/integer-test.js
+++ b/packages/vega-statistics/test/integer-test.js
@@ -2,7 +2,7 @@ var tape = require('tape'),
     integer = require('../').randomInteger;
 
 tape('integer generates random values', t => {
-  var s = integer(10).sample();
+  let s = integer(10).sample();
   t.ok(0 <= s && s < 10);
   t.equal(s, ~~s);
 
@@ -14,7 +14,7 @@ tape('integer generates random values', t => {
 });
 
 tape('integer evaluates the pdf', t => {
-  var n1 = integer(0, 5);
+  const n1 = integer(0, 5);
   t.equal(n1.pdf(-1), 0.0);
   t.equal(n1.pdf(5), 0.0);
   t.equal(n1.pdf(0), 0.2);
@@ -26,7 +26,7 @@ tape('integer evaluates the pdf', t => {
 });
 
 tape('integer evaluates the cdf', t => {
-  var n1 = integer(0, 5);
+  const n1 = integer(0, 5);
   t.equal(n1.cdf(-1), 0.0);
   t.equal(n1.cdf(0), 0.2);
   t.equal(n1.cdf(1), 0.4);
@@ -38,7 +38,7 @@ tape('integer evaluates the cdf', t => {
 });
 
 tape('integer evaluates the inverse cdf', t => {
-  var n1 = integer(0, 5);
+  const n1 = integer(0, 5);
   // extreme values
   t.ok(Number.isNaN(n1.icdf(-1)));
   t.ok(Number.isNaN(n1.icdf(2)));

--- a/packages/vega-statistics/test/kde-test.js
+++ b/packages/vega-statistics/test/kde-test.js
@@ -11,9 +11,9 @@ function closeTo(t, a, b, delta) {
 }
 
 function check(t, u, s, values) {
-  var sum = values.reduce((a, b) => a + b, 0);
-  var avg = sum / values.length;
-  var dev = values.reduce((a, b) => a + (b-avg)*(b-avg), 0);
+  const sum = values.reduce((a, b) => a + b, 0);
+  const avg = sum / values.length;
+  let dev = values.reduce((a, b) => a + (b-avg)*(b-avg), 0);
   dev = dev / (values.length-1);
 
   // mean within 99.9% confidence interval
@@ -21,13 +21,13 @@ function check(t, u, s, values) {
 }
 
 function samples(dist, n) {
-  var a = Array(n);
+  const a = Array(n);
   while (--n >= 0) a[n] = dist.sample();
   return a;
 }
 
 tape('kde generates samples', t => {
-  var kde = stats.randomKDE(d3.range(0, 1000)
+  let kde = stats.randomKDE(d3.range(0, 1000)
     .map(gaussian.sample));
   check(t, 0, 1, samples(kde, 1000));
 
@@ -64,7 +64,7 @@ tape('kde does not support the inverse cdf', t => {
 });
 
 tape('kde auto-selects positive bandwidth values', t => {
-  var a = [377, 347, 347, 347, 347, 347];
+  const a = [377, 347, 347, 347, 347, 347];
   t.ok(stats.randomKDE(a).bandwidth() > 0);
   t.ok(stats.randomKDE(a.slice(1)).bandwidth() > 0);
   t.ok(stats.randomKDE([-1, -1, -1]).bandwidth() > 0);

--- a/packages/vega-statistics/test/mixture-test.js
+++ b/packages/vega-statistics/test/mixture-test.js
@@ -11,9 +11,9 @@ function closeTo(t, a, b, delta) {
 }
 
 function check(t, u, s, values) {
-  var sum = values.reduce((a, b) => a + b, 0);
-  var avg = sum / values.length;
-  var dev = values.reduce((a, b) => a + (b-avg)*(b-avg), 0);
+  const sum = values.reduce((a, b) => a + b, 0);
+  const avg = sum / values.length;
+  let dev = values.reduce((a, b) => a + (b-avg)*(b-avg), 0);
   dev = dev / (values.length-1);
 
   // mean within 99.9% confidence interval
@@ -21,17 +21,17 @@ function check(t, u, s, values) {
 }
 
 function samples(dist, n) {
-  var a = Array(n);
+  const a = Array(n);
   while (--n >= 0) a[n] = dist.sample();
   return a;
 }
 
 tape('mixture generates samples', t => {
-  var dists = [
+  const dists = [
     stats.randomNormal(),
     stats.randomNormal()
   ];
-  var mix = stats.randomMixture(dists);
+  let mix = stats.randomMixture(dists);
   check(t, 0, 1, samples(mix, 1000));
 
   mix = stats.randomMixture(dists, [2, 1]);
@@ -65,7 +65,7 @@ tape('mixture approximates the cdf', t => {
 });
 
 tape('mixture does not support the inverse cdf', t => {
-  var mix = stats.randomMixture([
+  const mix = stats.randomMixture([
     stats.randomNormal(),
     stats.randomUniform(-1, 1)
   ]);

--- a/packages/vega-statistics/test/normal-test.js
+++ b/packages/vega-statistics/test/normal-test.js
@@ -10,9 +10,9 @@ function closeTo(t, a, b, delta) {
 }
 
 function check(t, u, s, values) {
-  var sum = values.reduce((a, b) => a + b, 0);
-  var avg = sum / values.length;
-  var dev = values.reduce((a, b) => a + (b-avg)*(b-avg), 0);
+  const sum = values.reduce((a, b) => a + b, 0);
+  const avg = sum / values.length;
+  let dev = values.reduce((a, b) => a + (b-avg)*(b-avg), 0);
   dev = dev / (values.length-1);
 
   // mean within 99.9% confidence interval
@@ -20,7 +20,7 @@ function check(t, u, s, values) {
 }
 
 function samples(dist, n) {
-  var a = Array(n);
+  const a = Array(n);
   while (--n >= 0) a[n] = dist.sample();
   return a;
 }
@@ -33,7 +33,7 @@ tape('normal generates normal samples', t => {
 });
 
 tape('normal evaluates the pdf', t => {
-  var n1 = normal();
+  const n1 = normal();
   closeTo(t, 0.40, n1.pdf(0), 1e-2);
   closeTo(t, 0.24, n1.pdf(-1), 1e-2);
   t.equal(n1.pdf(5), n1.pdf(-5));
@@ -41,7 +41,7 @@ tape('normal evaluates the pdf', t => {
 });
 
 tape('normal approximates the cdf', t => {
-  var n1 = normal();
+  const n1 = normal();
   // extreme values
   t.equal(0, n1.cdf(-38));
   t.equal(1, n1.cdf(38));
@@ -54,7 +54,7 @@ tape('normal approximates the cdf', t => {
 });
 
 tape('normal approximates the inverse cdf', t => {
-  var n1 = normal();
+  const n1 = normal();
   // out of domain inputs
   t.ok(Number.isNaN(n1.icdf(-1)));
   t.ok(Number.isNaN(n1.icdf(2)));

--- a/packages/vega-statistics/test/quantiles-test.js
+++ b/packages/vega-statistics/test/quantiles-test.js
@@ -3,7 +3,7 @@ var tape = require('tape'),
 
 tape('quantiles calculates quantile values', t => {
   // unsorted
-  var a = [9, 7, 8, 1, 2, 3, 4, 5, 6];
+  const a = [9, 7, 8, 1, 2, 3, 4, 5, 6];
 
   // with number array
   t.deepEqual([3, 5, 7], quantiles(a, [0.25, 0.5, 0.75]));

--- a/packages/vega-statistics/test/quartiles-test.js
+++ b/packages/vega-statistics/test/quartiles-test.js
@@ -3,7 +3,7 @@ var tape = require('tape'),
 
 tape('quartiles calculates quartile values', t => {
   // unsorted
-  var a = [9, 7, 8, 1, 2, 3, 4, 5, 6];
+  const a = [9, 7, 8, 1, 2, 3, 4, 5, 6];
 
   // with number array
   t.deepEqual([3, 5, 7], quartiles(a));
@@ -16,7 +16,7 @@ tape('quartiles calculates quartile values', t => {
 
 tape('quartiles ignores invalid values', t => {
   // unsorted
-  var a = [9, 7, null, 8, 1, NaN, 2, 3, undefined, 4, 5, '', 6];
+  const a = [9, 7, null, 8, 1, NaN, 2, 3, undefined, 4, 5, '', 6];
 
   // with number array
   t.deepEqual([3, 5, 7], quartiles(a));

--- a/packages/vega-statistics/test/uniform-test.js
+++ b/packages/vega-statistics/test/uniform-test.js
@@ -2,7 +2,7 @@ var tape = require('tape'),
     uniform = require('../').randomUniform;
 
 tape('uniform generates random values', t => {
-  var s = uniform().sample();
+  let s = uniform().sample();
   t.ok(s >= 0 && s < 1);
 
   s = uniform(10).sample();
@@ -15,7 +15,7 @@ tape('uniform generates random values', t => {
 });
 
 tape('uniform evaluates the pdf', t => {
-  var n1 = uniform(-1, 1);
+  const n1 = uniform(-1, 1);
   t.equal(n1.pdf(-2), 0.0);
   t.equal(n1.pdf(2), 0.0);
   t.equal(n1.pdf(0), 0.5);
@@ -25,7 +25,7 @@ tape('uniform evaluates the pdf', t => {
 });
 
 tape('uniform evaluates the cdf', t => {
-  var n1 = uniform(-1, 1);
+  const n1 = uniform(-1, 1);
   // extreme values
   t.equal(n1.cdf(-2), 0);
   t.equal(n1.cdf(2), 1);
@@ -37,7 +37,7 @@ tape('uniform evaluates the cdf', t => {
 });
 
 tape('uniform evaluates the inverse cdf', t => {
-  var n1 = uniform(-1, 1);
+  const n1 = uniform(-1, 1);
   // extreme values
   t.ok(Number.isNaN(n1.icdf(-2)));
   t.ok(Number.isNaN(n1.icdf(2)));

--- a/packages/vega-time/test/bin-test.js
+++ b/packages/vega-time/test/bin-test.js
@@ -2,7 +2,7 @@ var tape = require('tape'),
     vega = require('../');
 
 tape('timeBin determines time unit bins', t => {
-  var extent = [new Date(2000, 0, 1), new Date(2001, 0, 1)];
+  const extent = [new Date(2000, 0, 1), new Date(2001, 0, 1)];
 
   t.deepEqual(
     vega.timeBin({extent: [new Date(2000, 0, 1), new Date(2010, 0, 1)], maxbins: 2}),

--- a/packages/vega-time/test/floor-test.js
+++ b/packages/vega-time/test/floor-test.js
@@ -2,7 +2,7 @@ var tape = require('tape'),
     vega = require('../'),
     {local, utc} = require('./util');
 
-var UNITS = [
+const UNITS = [
   'year',
   'quarter',
   'month',
@@ -45,7 +45,7 @@ function testFloor(t, data, f, g) {
 }
 
 tape('timeFloor generates local floor function', t => {
-  var data = [
+  const data = [
     {y: 2012, q: 0, m: 0, d: 1, w: 1, u: 0, doy: 1},
     {y: 2012, q: 1, m: 3, d: 2, w: 14, u: 1, doy: 93},
     {y: 2012, q: 2, m: 6, d: 3, w: 27, u: 2, doy: 185},
@@ -62,7 +62,7 @@ tape('timeFloor generates local floor function', t => {
 });
 
 tape('utcFloor generates utc floor function', t => {
-  var data = [
+  const data = [
     {y: 2012, q: 0, m: 0, d: 1, w: 1, u: 0, doy: 1},
     {y: 2012, q: 1, m: 3, d: 2, w: 14, u: 1, doy: 93},
     {y: 2012, q: 2, m: 6, d: 3, w: 27, u: 2, doy: 185},

--- a/packages/vega-time/test/interval-test.js
+++ b/packages/vega-time/test/interval-test.js
@@ -3,7 +3,7 @@ var tape = require('tape'),
     {local, utc} = require('./util');
 
 tape('timeInterval provides local intervals for time units', t => {
-  var ti;
+  let ti;
 
   ti = vega.timeInterval('year');
   t.equal(+local(2000), +ti(local(2000, 0, 1)));
@@ -47,14 +47,14 @@ tape('timeInterval provides local intervals for time units', t => {
   t.equal(+local(2000, 0, 1, 7, 30, 20), +ti(local(2000, 0, 1, 7, 30, 20, 45)));
 
   ti = vega.timeInterval('milliseconds');
-  var d = local(2000, 1, 2, 7, 15, 30, 120);
+  const d = local(2000, 1, 2, 7, 15, 30, 120);
   t.equal(+d, +ti(d));
 
   t.end();
 });
 
 tape('utcInterval provides utc intervals for time units', t => {
-  var ti;
+  let ti;
 
   ti = vega.utcInterval('year');
   t.equal(+utc(2000), +ti(utc(2000, 0, 1)));
@@ -98,7 +98,7 @@ tape('utcInterval provides utc intervals for time units', t => {
   t.equal(+utc(2000, 0, 1, 7, 30, 20), +ti(utc(2000, 0, 1, 7, 30, 20, 45)));
 
   ti = vega.utcInterval('milliseconds');
-  var d = utc(2000, 1, 2, 7, 15, 30, 120);
+  const d = utc(2000, 1, 2, 7, 15, 30, 120);
   t.equal(+d, +ti(d));
 
   t.end();

--- a/packages/vega-time/test/timeunit-specifier-test.js
+++ b/packages/vega-time/test/timeunit-specifier-test.js
@@ -32,7 +32,7 @@ tape('timeUnitSpecifier produces specifier for multiple time units', t => {
 });
 
 tape('timeUnitSpecifier supports configurable specifiers', t => {
-  var specs = {
+  const specs = {
     'year': '%y',
     'month': 'M%m',
     'year-month': '%y-%b',

--- a/packages/vega-transforms/src/Aggregate.js
+++ b/packages/vega-transforms/src/Aggregate.js
@@ -147,7 +147,7 @@ inherits(Aggregate, Transform, {
     // initialize group-by dimensions
     this._dims = array(_.groupby);
     this._dnames = this._dims.map(d => {
-      var dname = accessorName(d);
+      const dname = accessorName(d);
       inputVisit(d);
       outputs.push(dname);
       return dname;

--- a/packages/vega-transforms/src/Density.js
+++ b/packages/vega-transforms/src/Density.js
@@ -31,7 +31,7 @@ export default function Density(params) {
   Transform.call(this, null, params);
 }
 
-var distributions = [
+const distributions = [
   {
     'key': {'function': 'normal'},
     'params': [
@@ -63,7 +63,7 @@ var distributions = [
   }
 ];
 
-var mixture = {
+const mixture = {
   'key': {'function': 'mixture'},
   'params': [
     { 'name': 'distributions', 'type': 'param', 'array': true,

--- a/packages/vega-transforms/src/Filter.js
+++ b/packages/vega-transforms/src/Filter.js
@@ -32,7 +32,7 @@ inherits(Filter, Transform, {
     let isMod = true;
 
     pulse.visit(pulse.REM, t => {
-      var id = tupleid(t);
+      const id = tupleid(t);
       if (!cache.has(id)) rem.push(t);
       else cache.delete(id);
     });

--- a/packages/vega-transforms/src/Impute.js
+++ b/packages/vega-transforms/src/Impute.js
@@ -63,7 +63,7 @@ function getValue(_) {
 }
 
 function getField(_) {
-  var f = _.field;
+  const f = _.field;
   return t => t ? f(t) : NaN;
 }
 

--- a/packages/vega-transforms/test/aggregate-test.js
+++ b/packages/vega-transforms/test/aggregate-test.js
@@ -7,7 +7,7 @@ var tape = require('tape'),
     Aggregate = tx.aggregate;
 
 tape('Aggregate aggregates tuples', t => {
-  var data = [
+  const data = [
     {k:'a', v:1}, {k:'b', v:3},
     {k:'a', v:2}, {k:'b', v:4}
   ];
@@ -26,7 +26,7 @@ tape('Aggregate aggregates tuples', t => {
 
   // -- test adds
   df.pulse(col, changeset().insert(data)).run();
-  var d = out.value;
+  let d = out.value;
   t.equal(d.length, 2);
   t.equal(d[0].k, 'a');
   t.equal(d[0].count_v, 2);
@@ -90,7 +90,7 @@ tape('Aggregate aggregates tuples', t => {
 });
 
 tape('Aggregate handles count aggregates', t => {
-  var data = [
+  const data = [
     {foo:0, bar:1},
     {foo:2, bar:3},
     {foo:4, bar:5}
@@ -141,7 +141,7 @@ tape('Aggregate handles count aggregates', t => {
 });
 
 tape('Aggregate properly handles empty aggregation cells', t => {
-  var data = [
+  const data = [
     {k:'a', v:1}, {k:'b', v:3},
     {k:'a', v:2}, {k:'b', v:4}
   ];
@@ -170,7 +170,7 @@ tape('Aggregate properly handles empty aggregation cells', t => {
   // -- modify tuple
   df.pulse(col, changeset().modify(data[0], 'v', 2)).run();
 
-  var d = out.value;
+  const d = out.value;
   t.equal(d.length, 1);
   t.equal(d[0].k, 'a');
   t.equal(d[0].count_v, 2);
@@ -183,7 +183,7 @@ tape('Aggregate properly handles empty aggregation cells', t => {
 });
 
 tape('Aggregate handles distinct aggregates', t => {
-  var data = [
+  const data = [
     {foo:null},
     {foo:null},
     {foo:undefined},
@@ -226,7 +226,7 @@ tape('Aggregate handles distinct aggregates', t => {
 });
 
 tape('Aggregate handles cross-product', t => {
-  var data = [
+  const data = [
     {a: 0, b: 2},
     {a: 1, b: 3}
   ];
@@ -247,7 +247,7 @@ tape('Aggregate handles cross-product', t => {
 
   // -- test add
   df.pulse(col, changeset().insert(data)).run();
-  var d = out.value;
+  let d = out.value;
   t.equal(d.length, 4);
   t.equal(d[0].a, 0);
   t.equal(d[0].b, 2);
@@ -312,7 +312,7 @@ tape('Aggregate handles cross-product', t => {
 });
 
 tape('Aggregate handles empty/invalid data', t => {
-  var ops = [
+  const ops = [
     'count',
     'missing',
     'valid',
@@ -325,7 +325,7 @@ tape('Aggregate handles empty/invalid data', t => {
     'max',
     'median'
   ];
-  var res = [4, 3, 0, 0]; // higher indices 'undefined'
+  const res = [4, 3, 0, 0]; // higher indices 'undefined'
 
   var v = util.field('v'),
       df = new vega.Dataflow(),
@@ -344,7 +344,7 @@ tape('Aggregate handles empty/invalid data', t => {
       {v: NaN}, {v: null}, {v: undefined}, {v: ''}
     ])
   ).run();
-  var d = out.value[0];
+  const d = out.value[0];
 
   ops.forEach((op, i) => {
     t.equal(d[op], res[i], op);

--- a/packages/vega-transforms/test/bin-test.js
+++ b/packages/vega-transforms/test/bin-test.js
@@ -6,7 +6,7 @@ var tape = require('tape'),
     Bin = tx.bin,
     Collect = tx.collect;
 
-var TOLERANCE = 2e-14;
+const TOLERANCE = 2e-14;
 
 tape('Bin discretizes values', t => {
   var df = new vega.Dataflow(),
@@ -20,7 +20,7 @@ tape('Bin discretizes values', t => {
       });
 
   // stress test floating point math
-  var extents = [
+  const extents = [
     [0, 1e-50],
     [0, 0.1],
     [0, 0.5],
@@ -31,7 +31,7 @@ tape('Bin discretizes values', t => {
     [0, 20]
   ];
 
-  var divs = [5, 10, 20, 40];
+  const divs = [5, 10, 20, 40];
 
   extents.forEach(e => {
     divs.forEach(d => {
@@ -96,7 +96,7 @@ tape('Bin handles tail aggregation for last bin', t => {
 });
 
 tape('Bin supports point output', t => {
-  var data = [{v: 5.5}];
+  const data = [{v: 5.5}];
 
   var df = new vega.Dataflow(),
       c = df.add(Collect),

--- a/packages/vega-transforms/test/collect-test.js
+++ b/packages/vega-transforms/test/collect-test.js
@@ -5,7 +5,7 @@ var tape = require('tape'),
     changeset = vega.changeset;
 
 tape('Collect collects tuples', t => {
-  var data = [
+  const data = [
     {'id': 1, 'value': 'foo'},
     {'id': 3, 'value': 'bar'},
     {'id': 5, 'value': 'baz'}

--- a/packages/vega-transforms/test/dotbin-test.js
+++ b/packages/vega-transforms/test/dotbin-test.js
@@ -7,7 +7,7 @@ var tape = require('tape'),
     DotBin = transforms.dotbin;
 
 tape('DotBin assigns dot plot bin positions', t => {
-  var data = [
+  const data = [
     {key: 'a', value: 1},
     {key: 'a', value: 1},
     {key: 'a', value: 2},
@@ -34,7 +34,7 @@ tape('DotBin assigns dot plot bin positions', t => {
   t.equal(db.pulse.rem.length, 0);
   t.equal(db.pulse.mod.length, 0);
 
-  var d = c0.value;
+  let d = c0.value;
   t.deepEqual(d[0], {key: 'a', value: 1, x: 1.5});
   t.deepEqual(d[1], {key: 'a', value: 1, x: 1.5});
   t.deepEqual(d[2], {key: 'a', value: 2, x: 1.5});

--- a/packages/vega-transforms/test/extent-test.js
+++ b/packages/vega-transforms/test/extent-test.js
@@ -7,7 +7,7 @@ var tape = require('tape'),
     Extent = tx.extent;
 
 tape('Extent computes extents', t => {
-  var data = [
+  const data = [
     {'x': 0, 'y': 28}, {'x': 1, 'y': 43},
     {'x': 0, 'y': 55}, {'x': 1, 'y': 72}
   ];

--- a/packages/vega-transforms/test/facet-test.js
+++ b/packages/vega-transforms/test/facet-test.js
@@ -7,22 +7,22 @@ var tape = require('tape'),
     Facet = tx.facet;
 
 tape('Facet facets tuples', t => {
-  var data = [
+  const data = [
     {k:'a', v:5}, {k:'b', v:7}, {k:'c', v:9},
     {k:'a', v:1}, {k:'b', v:2}, {k:'c', v:3}
   ];
 
-  var subs = [];
+  const subs = [];
 
   function subflow(df, key) {
-    var col = df.add(Collect);
+    const col = df.add(Collect);
     subs.push({key: key, data: col});
     return col;
   }
 
   function subtest(len) {
     return function(s, i) {
-      var d = s.data.value;
+      const d = s.data.value;
       t.equal(d.length, len === undefined ? i + 1 : len);
       t.equal(d.every(t => t.k === s.key), true);
     };
@@ -112,22 +112,22 @@ tape('Facet facets tuples', t => {
 });
 
 tape('Facet handles key parameter change', t => {
-  var data = [
+  const data = [
     {k1:'a', k2:'a', v:5}, {k1:'b', k2:'c', v:7}, {k1:'c', k2:'c', v:9},
     {k1:'a', k2:'a', v:1}, {k1:'b', k2:'b', v:2}, {k1:'c', k2:'b', v:3}
   ];
 
-  var subs = [];
+  const subs = [];
 
   function subflow(df, key) {
-    var col = df.add(Collect);
+    const col = df.add(Collect);
     subs.push({key: key, data: col});
     return col;
   }
 
   function subtest(len) {
     return function(s, i) {
-      var d = s.data.value;
+      const d = s.data.value;
       t.equal(d.length, len === undefined ? i + 1 : len);
       t.equal(d.every(t => t.k2 === s.key), true);
     };

--- a/packages/vega-transforms/test/filter-test.js
+++ b/packages/vega-transforms/test/filter-test.js
@@ -7,10 +7,10 @@ var tape = require('tape'),
     Filter = tx.filter;
 
 tape('Filter filters tuples', t => {
-  var lt3 = util.accessor(d => d.id < 3, ['id']);
-  var baz = util.accessor(d => d.value === 'baz', ['value']);
+  const lt3 = util.accessor(d => d.id < 3, ['id']);
+  const baz = util.accessor(d => d.value === 'baz', ['value']);
 
-  var data = [
+  const data = [
     {'id': 1, 'value': 'foo'},
     {'id': 3, 'value': 'bar'},
     {'id': 5, 'value': 'baz'}

--- a/packages/vega-transforms/test/flatten-test.js
+++ b/packages/vega-transforms/test/flatten-test.js
@@ -7,7 +7,7 @@ var tape = require('tape'),
     Flatten = tx.flatten;
 
 tape('Flatten flattens arrays', t => {
-  var data = [
+  const data = [
     { k: 'a', v: [ 1, 2 ] },
     { k: 'b', v: [ 3, 4, 5 ] }
   ];
@@ -52,7 +52,7 @@ tape('Flatten flattens arrays', t => {
 });
 
 tape('Flatten flattens parallel arrays', t => {
-  var data = [
+  const data = [
     { k: 'a', a: [ 1, 2 ], b: [ 'A', 'B'] },
     { k: 'b', a: [ 3, 4, 5 ], b: [ 'C', 'D', 'E' ]}
   ];
@@ -98,7 +98,7 @@ tape('Flatten flattens parallel arrays', t => {
 
 
 tape('Flatten flattens and adds index field', t => {
-  var data = [
+  const data = [
     { k: 'a', v: [ 1, 2 ] },
     { k: 'b', v: [ 3, 4, 5 ] }
   ];

--- a/packages/vega-transforms/test/fold-test.js
+++ b/packages/vega-transforms/test/fold-test.js
@@ -7,7 +7,7 @@ var tape = require('tape'),
     Fold = tx.fold;
 
 tape('Fold folds tuples', t => {
-  var data = [
+  const data = [
     {a:'!', b:5, c:7},
     {a:'?', b:2, c:4}
   ];

--- a/packages/vega-transforms/test/formula-test.js
+++ b/packages/vega-transforms/test/formula-test.js
@@ -7,7 +7,7 @@ var tape = require('tape'),
     Collect = tx.collect;
 
 tape('Formula extends tuples', t => {
-  var data = [
+  const data = [
     {'id': 1, 'value': 'foo'},
     {'id': 3, 'value': 'bar'},
     {'id': 5, 'value': 'baz'}

--- a/packages/vega-transforms/test/impute-test.js
+++ b/packages/vega-transforms/test/impute-test.js
@@ -7,7 +7,7 @@ var tape = require('tape'),
     Impute = tx.impute;
 
 tape('Impute imputes missing tuples', t => {
-  var data = [
+  const data = [
     {'x': 0, 'y': 28, 'c':0},
     {'x': 0, 'y': 55, 'c':1},
     {'x': 1, 'y': 43, 'c':0}
@@ -30,7 +30,7 @@ tape('Impute imputes missing tuples', t => {
 
   df.pulse(co, changeset().insert(data)).run();
 
-  var p = im.pulse;
+  let p = im.pulse;
   t.equal(p.add.length, 4);
   t.equal(p.add[3].c, 1);
   t.equal(p.add[3].x, 1);
@@ -50,7 +50,7 @@ tape('Impute imputes missing tuples', t => {
 });
 
 tape('Impute imputes missing tuples for provided domain', t => {
-  var data = [
+  const data = [
     {c: 0, x: 0, y: 28},
     {c: 1, x: 0, y: 55},
     {c: 0, x: 1, y: 43},
@@ -79,9 +79,9 @@ tape('Impute imputes missing tuples for provided domain', t => {
 
   df.pulse(co, changeset().insert(data.slice(0, 3))).run();
 
-  var p = im.pulse;
+  const p = im.pulse;
   t.equal(p.add.length, 8);
-  for (var i=0; i<data.length; ++i) {
+  for (let i=0; i<data.length; ++i) {
     t.equal(p.add[i].c, data[i].c);
     t.equal(p.add[i].x, data[i].x);
     t.equal(p.add[i].y, data[i].y);
@@ -91,7 +91,7 @@ tape('Impute imputes missing tuples for provided domain', t => {
 });
 
 tape('Impute imputes missing tuples without groupby', t => {
-  var data = [
+  const data = [
     {x: 0, y: 28},
     {x: 1, y: 43},
     {x: 2, y: -1},
@@ -114,9 +114,9 @@ tape('Impute imputes missing tuples without groupby', t => {
 
   df.pulse(co, changeset().insert(data.slice(0, 2))).run();
 
-  var p = im.pulse;
+  const p = im.pulse;
   t.equal(p.add.length, 4);
-  for (var i=0; i<data.length; ++i) {
+  for (let i=0; i<data.length; ++i) {
     t.equal(p.add[i].c, data[i].c);
     t.equal(p.add[i].x, data[i].x);
     t.equal(p.add[i].y, data[i].y);

--- a/packages/vega-transforms/test/joinaggregate-test.js
+++ b/packages/vega-transforms/test/joinaggregate-test.js
@@ -7,7 +7,7 @@ var tape = require('tape'),
     JoinAggregate = tx.joinaggregate;
 
 tape('JoinAggregate extends tuples with aggregate values', t => {
-  var data = [
+  const data = [
     {k:'a', v:1}, {k:'b', v:3},
     {k:'a', v:2}, {k:'b', v:4}
   ];
@@ -26,7 +26,7 @@ tape('JoinAggregate extends tuples with aggregate values', t => {
 
   // -- test adds
   df.pulse(col, changeset().insert(data)).run();
-  var d = out.value;
+  let d = out.value;
 
   t.equal(d.length, 4);
   t.equal(d[0].k, 'a');
@@ -97,7 +97,7 @@ tape('JoinAggregate extends tuples with aggregate values', t => {
 });
 
 tape('JoinAggregate handles count aggregates', t => {
-  var data = [
+  let data = [
     {foo:0, bar:1},
     {foo:2, bar:3},
     {foo:4, bar:5}
@@ -180,7 +180,7 @@ tape('JoinAggregate handles count aggregates', t => {
 });
 
 tape('JoinAggregate handles distinct aggregates', t => {
-  var data = [
+  const data = [
     {foo:null},
     {foo:null},
     {foo:undefined},

--- a/packages/vega-transforms/test/kde-test.js
+++ b/packages/vega-transforms/test/kde-test.js
@@ -7,7 +7,7 @@ var tape = require('tape'),
     KDE = tx.kde;
 
 tape('KDE computes kernel density estimates', t => {
-  var data = [
+  const data = [
     {k:'a', v:1}, {k:'a', v:2}, {k:'a', v:2}, {k:'a', v:3},
     {k:'b', v:1}, {k:'b', v:1}, {k:'b', v:2}
   ];
@@ -27,7 +27,7 @@ tape('KDE computes kernel density estimates', t => {
 
   // -- test adds
   df.pulse(col, changeset().insert(data)).run();
-  var d = out.value;
+  const d = out.value;
   t.equal(d.length, 22);
   t.equal(d[10].k, 'a');
   t.equal(d[10].value, 3);
@@ -40,7 +40,7 @@ tape('KDE computes kernel density estimates', t => {
 });
 
 tape('KDE computes estimates with shared configurations', t => {
-  var data = [
+  const data = [
     {k:'a', v:1}, {k:'a', v:2}, {k:'a', v:2}, {k:'a', v:3},
     {k:'b', v:1}, {k:'b', v:1}, {k:'b', v:2}
   ];
@@ -60,7 +60,7 @@ tape('KDE computes estimates with shared configurations', t => {
 
   // -- test adds
   df.pulse(col, changeset().insert(data)).run();
-  var d = out.value;
+  const d = out.value;
   t.equal(d.length, 22);
   for (let i=0; i<11; ++i) {
     t.equal(d[i].value, d[i+11].value);
@@ -70,7 +70,7 @@ tape('KDE computes estimates with shared configurations', t => {
 });
 
 tape('KDE computes unnormalized kernel density estimates', t => {
-  var data = [
+  const data = [
     {k:'a', v:1}, {k:'a', v:2}, {k:'a', v:2}, {k:'a', v:3},
     {k:'b', v:1}, {k:'b', v:1}, {k:'b', v:2}
   ];
@@ -91,7 +91,7 @@ tape('KDE computes unnormalized kernel density estimates', t => {
 
   // -- test adds
   df.pulse(col, changeset().insert(data)).run();
-  var d = out.value;
+  const d = out.value;
   t.equal(d.length, 22);
   t.equal(d[10].k, 'a');
   t.equal(d[10].value, 3);

--- a/packages/vega-transforms/test/lookup-test.js
+++ b/packages/vega-transforms/test/lookup-test.js
@@ -8,13 +8,13 @@ var tape = require('tape'),
     TupleIndex = tx.tupleindex;
 
 tape('Lookup looks up matching tuples', t => {
-  var lut = [
+  const lut = [
     {'id': 1, 'value': 'foo'},
     {'id': 3, 'value': 'bar'},
     {'id': 5, 'value': 'baz'}
   ];
 
-  var data = [
+  const data = [
     {'id': 0, 'x': 5, 'y': 1},
     {'id': 1, 'x': 3, 'y': 5},
     {'id': 2, 'x': 1, 'y': 5},
@@ -42,7 +42,7 @@ tape('Lookup looks up matching tuples', t => {
 
   // add primary data
   df.pulse(c1, changeset().insert(data)).run();
-  var p = lu.pulse.add;
+  let p = lu.pulse.add;
   t.equal(p.length, 4);
   t.deepEqual(p.map(uv), ['baz', 'bar', 'foo', 'bar']);
   t.deepEqual(p.map(vv), ['foo', 'baz', 'baz', 'bar']);
@@ -58,13 +58,13 @@ tape('Lookup looks up matching tuples', t => {
 });
 
 tape('Lookup looks up matching values', t => {
-  var lut = [
+  const lut = [
     {'id': 1, 'value': 'foo'},
     {'id': 3, 'value': 'bar'},
     {'id': 5, 'value': 'baz'}
   ];
 
-  var data = [
+  const data = [
     {'id': 0, 'x': 5, 'y': 1},
     {'id': 1, 'x': 3, 'y': 5},
     {'id': 2, 'x': 1, 'y': 5},
@@ -91,7 +91,7 @@ tape('Lookup looks up matching values', t => {
 
   // add primary data
   df.pulse(c1, changeset().insert(data)).run();
-  var p = lu.pulse.add;
+  let p = lu.pulse.add;
   t.equal(p.length, 4);
   t.deepEqual(p.map(value), ['baz', 'bar', 'foo', 'bar']);
 

--- a/packages/vega-transforms/test/pivot-test.js
+++ b/packages/vega-transforms/test/pivot-test.js
@@ -7,7 +7,7 @@ var tape = require('tape'),
     Pivot = tx.pivot;
 
 tape('Pivot pivots values', t => {
-  var data = [
+  const data = [
     {a:'A', b:'u', c:1},
     {a:'A', b:'v', c:2},
     {a:'B', b:'u', c:3},
@@ -72,7 +72,7 @@ tape('Pivot pivots values', t => {
 });
 
 tape('Pivot pivots values within limit', t => {
-  var data = [
+  const data = [
     {a:'A', b:'u', c:1},
     {a:'A', b:'v', c:2},
     {a:'A', b:'w', c:3},
@@ -109,7 +109,7 @@ tape('Pivot pivots values within limit', t => {
 });
 
 tape('Pivot handles count aggregate', t => {
-  var data = [
+  const data = [
     {a:'A', b:'u', c:1},
     {a:'A', b:'v', c:null},
     {a:'B', b:'v', c:4},

--- a/packages/vega-transforms/test/prefacet-test.js
+++ b/packages/vega-transforms/test/prefacet-test.js
@@ -8,16 +8,16 @@ var tape = require('tape'),
     PreFacet = tx.prefacet;
 
 tape('PreFacet partitions pre-faceted tuple sets', t => {
-  var data = [
+  const data = [
     {'id': 'a', 'tuples': [{x:1},{x:2}]},
     {'id': 'b', 'tuples': [{x:3},{x:4}]},
     {'id': 'c', 'tuples': [{x:5},{x:6}]}
   ];
 
-  var subs = [];
+  const subs = [];
 
   function subflow(df, key) {
-    var col = df.add(Collect);
+    const col = df.add(Collect);
     subs.push({key: key, data: col});
     return col;
   }
@@ -100,7 +100,7 @@ tape('PreFacet partitions pre-faceted tuple sets', t => {
 });
 
 tape('PreFacet raises error if tuple sets are modified', t => {
-  var data = [
+  const data = [
     {'id': 'a', 'tuples': [{x:1},{x:2}]},
     {'id': 'b', 'tuples': [{x:3},{x:4}]},
     {'id': 'c', 'tuples': [{x:5},{x:6}]}

--- a/packages/vega-transforms/test/project-test.js
+++ b/packages/vega-transforms/test/project-test.js
@@ -7,7 +7,7 @@ var tape = require('tape'),
     Project = tx.project;
 
 tape('Project copies tuples', t => {
-  var data = [{'id': 0}, {'id': 1}];
+  const data = [{'id': 0}, {'id': 1}];
 
   var id = util.field('id'),
       df = new vega.Dataflow(),
@@ -70,7 +70,7 @@ tape('Project copies tuples', t => {
 });
 
 tape('Project projects tuples', t => {
-  var data = [{'id': 0, 'foo': 'a'}, {'id': 1, 'foo': 'b'}];
+  const data = [{'id': 0, 'foo': 'a'}, {'id': 1, 'foo': 'b'}];
 
   var id = util.field('id'),
       df = new vega.Dataflow(),
@@ -136,7 +136,7 @@ tape('Project projects tuples', t => {
 });
 
 tape('Project aliases tuples', t => {
-  var data = [{'id': 0, 'foo': 'a'}, {'id': 1, 'foo': 'b'}];
+  const data = [{'id': 0, 'foo': 'a'}, {'id': 1, 'foo': 'b'}];
 
   var id = util.field('id'),
       foo = util.field('foo'),
@@ -208,7 +208,7 @@ tape('Project aliases tuples', t => {
 });
 
 tape('Project projects tuples with nested properties', t => {
-  var data = [
+  const data = [
     {'id': 0, 'obj': {'foo': {'bar': 'a'}}},
     {'id': 1, 'obj': {'foo': {'bar': 'b'}}}
   ];

--- a/packages/vega-transforms/test/relay-test.js
+++ b/packages/vega-transforms/test/relay-test.js
@@ -7,7 +7,7 @@ var tape = require('tape'),
     Relay = tx.relay;
 
 tape('Relay propagates pulse', t => {
-  var data = [{'id': 0}, {'id': 1}];
+  const data = [{'id': 0}, {'id': 1}];
 
   var df = new vega.Dataflow(),
       c = df.add(Collect),
@@ -26,7 +26,7 @@ tape('Relay propagates pulse', t => {
 });
 
 tape('Relay relays derived tuples', t => {
-  var data = [{'id': 0}, {'id': 1}];
+  const data = [{'id': 0}, {'id': 1}];
 
   var id = util.field('id'),
       df = new vega.Dataflow(),

--- a/packages/vega-transforms/test/sample-test.js
+++ b/packages/vega-transforms/test/sample-test.js
@@ -25,8 +25,8 @@ tape('Sample samples tuples without backing source', t => {
 
   // -- modify tuple in and out sample, check propagation
   s.value.forEach(t => { map[tupleid(t)] = 1; });
-  var inTuple = s.value[0];
-  var outTuple = null;
+  const inTuple = s.value[0];
+  let outTuple = null;
 
   for (i=0; i<n; ++i) {
     tid = data[i];
@@ -41,7 +41,7 @@ tape('Sample samples tuples without backing source', t => {
 
   // -- remove half of sample, no backing source
   map = {};
-  var rems = s.value.slice(0, 10);
+  const rems = s.value.slice(0, 10);
   rems.forEach(t => { map[tupleid(t)] = 1; });
   df.pulse(s, changeset().remove(rems)).run();
   t.equal(s.value.length, ns - 10);
@@ -70,8 +70,8 @@ tape('Sample samples tuples with backing source', t => {
 
   // -- modify tuple in and out sample, check propagation
   s.value.forEach(t => { map[tupleid(t)] = 1; });
-  var inTuple = s.value[0];
-  var outTuple = null;
+  const inTuple = s.value[0];
+  let outTuple = null;
 
   for (i=0; i<n; ++i) {
     tid = data[i];

--- a/packages/vega-transforms/test/timeunit-test.js
+++ b/packages/vega-transforms/test/timeunit-test.js
@@ -7,7 +7,7 @@ var tape = require('tape'),
     Collect = tx.collect,
     TimeUnit = tx.timeunit;
 
-var UNITS = [
+const UNITS = [
   'year',
   'quarter',
   'month',
@@ -81,7 +81,7 @@ function testDates(t, data, unit, step, date) {
 }
 
 tape('TimeUnit truncates dates to time units', t => {
-  var data = [
+  const data = [
     {y: 2012, q: 0, m: 0, d: 1, w: 1, u: 0},
     {y: 2012, q: 1, m: 3, d: 2, w: 14, u: 1},
     {y: 2012, q: 2, m: 6, d: 3, w: 27, u: 2},
@@ -98,7 +98,7 @@ tape('TimeUnit truncates dates to time units', t => {
   df.pulse(c, changeset().insert(data));
 
   UNITS.forEach((u, i) => {
-    var a = u.split('-');
+    const a = u.split('-');
     df.update(units, a).run();
     t.equal(s.pulse.rem.length, 0);
     t.equal(s.pulse.add.length, i ? 0 : 4);
@@ -112,7 +112,7 @@ tape('TimeUnit truncates dates to time units', t => {
 });
 
 tape('TimeUnit truncates UTC dates to time units', t => {
-  var data = [
+  const data = [
     {y: 2012, q: 0, m: 0, d: 1, w: 1, u: 0},
     {y: 2012, q: 1, m: 3, d: 2, w: 14, u: 1},
     {y: 2012, q: 2, m: 6, d: 3, w: 27, u: 2},
@@ -129,7 +129,7 @@ tape('TimeUnit truncates UTC dates to time units', t => {
   df.pulse(c, changeset().insert(data));
 
   UNITS.forEach((u, i) => {
-    var a = u.split('-');
+    const a = u.split('-');
     df.update(units, a).run();
     t.equal(s.pulse.rem.length, 0);
     t.equal(s.pulse.add.length, i ? 0 : 4);
@@ -143,7 +143,7 @@ tape('TimeUnit truncates UTC dates to time units', t => {
 });
 
 tape('TimeUnit supports unit steps', t => {
-  var data = [
+  const data = [
     {y: 2012, q: 0, m: 0, d: 1, w: 1, u: 0},
     {y: 2012, q: 1, m: 3, d: 2, w: 14, u: 1},
     {y: 2012, q: 2, m: 6, d: 3, w: 27, u: 2},
@@ -176,7 +176,7 @@ tape('TimeUnit supports unit steps', t => {
 });
 
 tape('TimeUnit supports unit inference', t => {
-  var data = [
+  const data = [
     {y: 2012, q: 0, m: 0, d: 1, w: 1, u: 0},
     {y: 2012, q: 1, m: 3, d: 2, w: 14, u: 1},
     {y: 2012, q: 2, m: 6, d: 3, w: 27, u: 2},
@@ -226,7 +226,7 @@ tape('TimeUnit supports unit inference', t => {
 });
 
 tape('TimeUnit supports unit inference with extent', t => {
-  var data = [
+  const data = [
     {y: 2012, q: 0, m: 0, d: 1, w: 1, u: 0},
     {y: 2012, q: 1, m: 3, d: 2, w: 14, u: 1},
     {y: 2012, q: 2, m: 6, d: 3, w: 27, u: 2},
@@ -266,7 +266,7 @@ tape('TimeUnit supports unit inference with extent', t => {
 });
 
 tape('TimeUnit supports point output', t => {
-  var data = [{date: new Date(2012, 0, 1)}];
+  const data = [{date: new Date(2012, 0, 1)}];
 
   var df = new vega.Dataflow(),
       date = field('date'),

--- a/packages/vega-transforms/test/tupleindex-test.js
+++ b/packages/vega-transforms/test/tupleindex-test.js
@@ -7,7 +7,7 @@ var tape = require('tape'),
     TupleIndex = tx.tupleindex;
 
 tape('TupleIndex maintains an index of tuples', t => {
-  var data = [
+  const data = [
     {'id': 1, 'value': 'foo'},
     {'id': 3, 'value': 'bar'},
     {'id': 5, 'value': 'baz'}

--- a/packages/vega-transforms/test/values-test.js
+++ b/packages/vega-transforms/test/values-test.js
@@ -8,7 +8,7 @@ var tape = require('tape'),
     Values = tx.values;
 
 tape('Values extracts values', t => {
-  var data = [
+  const data = [
     {k:'a', v:1}, {k:'b', v:3},
     {k:'c', v:2}, {k:'d', v:4}
   ];
@@ -20,7 +20,7 @@ tape('Values extracts values', t => {
       val = df.add(Values, {field:key, sort:srt, pulse:col});
 
   df.pulse(col, changeset().insert(data)).run();
-  var values = val.value;
+  const values = val.value;
   t.deepEqual(values, ['a', 'b', 'c', 'd']);
 
   df.touch(val).run(); // no-op pulse

--- a/packages/vega-transforms/test/window-test.js
+++ b/packages/vega-transforms/test/window-test.js
@@ -7,13 +7,13 @@ var tape = require('tape'),
     Window = tx.window;
 
 function match(t, actual, expect) {
-  for (var k in expect) {
+  for (const k in expect) {
     t.equal(actual[k], expect[k]);
   }
 }
 
 tape('Window processes single partition', t => {
-  var data = [
+  const data = [
     {k:'a', v:1, key:0},
     {k:'b', v:3, key:1},
     {k:'a', v:2, key:2},
@@ -52,7 +52,7 @@ tape('Window processes single partition', t => {
 
   // -- test add
   df.pulse(col, changeset().insert(data)).run();
-  var d = out.value;
+  let d = out.value;
   t.equal(d.length, data.length);
   match(t, d[0], {
     k: 'a', v: 1, key: 0,
@@ -120,7 +120,7 @@ tape('Window processes single partition', t => {
 });
 
 tape('Window processes peers correctly', t => {
-  var data = [
+  const data = [
     {k:'a', v:1, key:0},
     {k:'b', v:3, key:1},
     {k:'a', v:2, key:2},
@@ -144,7 +144,7 @@ tape('Window processes peers correctly', t => {
 
   // -- test add
   df.pulse(col, changeset().insert(data)).run();
-  var d = out.value;
+  let d = out.value;
   t.equal(d.length, data.length);
   match(t, d[0], {k: 'a', v: 1, count: 1, sum: 1});
   match(t, d[1], {k: 'b', v: 3, count: 2, sum: 4});
@@ -164,7 +164,7 @@ tape('Window processes peers correctly', t => {
 });
 
 tape('Window processes multiple partitions', t => {
-  var data = [
+  const data = [
     {k:'a', v:1, key:0},
     {k:'b', v:3, key:1},
     {k:'a', v:2, key:2},
@@ -204,7 +204,7 @@ tape('Window processes multiple partitions', t => {
 
   // -- test add
   df.pulse(col, changeset().insert(data)).run();
-  var d = out.value.sort(util.compare('k', 'key'));
+  const d = out.value.sort(util.compare('k', 'key'));
   t.equal(d.length, data.length);
   match(t, d[0], {
     k: 'a', v: 1, key: 0,
@@ -246,7 +246,7 @@ tape('Window processes multiple partitions', t => {
 });
 
 tape('Window processes range frames', t => {
-  var data = [
+  const data = [
     {k:'a', v:1, key:0},
     {k:'b', v:3, key:1},
     {k:'a', v:2, key:2},
@@ -269,7 +269,7 @@ tape('Window processes range frames', t => {
 
   // -- test add
   df.pulse(col, changeset().insert(data)).run();
-  var d = out.value;
+  let d = out.value;
   t.equal(d.length, data.length);
   match(t, d[0], {
     k: 'a', v: 1, key: 0,
@@ -331,7 +331,7 @@ tape('Window processes range frames', t => {
 });
 
 tape('Window processes row frames', t => {
-  var data = [
+  const data = [
     {k:'a', v:1, key:0},
     {k:'b', v:3, key:1},
     {k:'a', v:2, key:2},
@@ -354,7 +354,7 @@ tape('Window processes row frames', t => {
 
   // -- test add
   df.pulse(col, changeset().insert(data)).run();
-  var d = out.value;
+  const d = out.value;
   t.equal(d.length, data.length);
   match(t, d[0], {
     k: 'a', v: 1, key: 0,
@@ -381,7 +381,7 @@ tape('Window processes row frames', t => {
 });
 
 tape('Window processes unsorted values', t => {
-  var data = [
+  const data = [
     {key:0}, {key:1}, {key:2}, {key:3}, {key:4}
   ];
 
@@ -394,7 +394,7 @@ tape('Window processes unsorted values', t => {
       out = df.add(Collect, {pulse: agg});
 
   df.pulse(col, changeset().insert(data)).run();
-  var d = out.value;
+  const d = out.value;
   t.equal(d.length, data.length);
   match(t, d[0], {key: 0, rank: 1, dense_rank: 1});
   match(t, d[1], {key: 1, rank: 2, dense_rank: 2});
@@ -406,7 +406,7 @@ tape('Window processes unsorted values', t => {
 });
 
 tape('Window processes fill operations', t => {
-  var data = [
+  const data = [
     {u: 'a',  v:1, x: null,      key:0},
     {u: null, v:3, x: true,      key:1},
     {u: null,      x: false,     key:2},
@@ -434,7 +434,7 @@ tape('Window processes fill operations', t => {
 
   // -- test add
   df.pulse(col, changeset().insert(data)).run();
-  var d = out.value;
+  const d = out.value;
   t.equal(d.length, data.length);
   match(t, d[0], {
     u: 'a', v: 1, x: null, key: 0,
@@ -457,7 +457,7 @@ tape('Window processes fill operations', t => {
 });
 
 tape('Window handles next_value with overwrite', t => {
-  var data = [
+  const data = [
     {u: 'a',  v:1, x: null,      key:0},
     {u: null, v:3, x: true,      key:1},
     {u: null,      x: false,     key:2},
@@ -481,7 +481,7 @@ tape('Window handles next_value with overwrite', t => {
 
   // -- test add
   df.pulse(col, changeset().insert(data)).run();
-  var d = out.value;
+  const d = out.value;
   t.equal(d.length, data.length);
   match(t, d[0], {key: 0, u: 'a', v: 1, x: true});
   match(t, d[1], {key: 1, u: 'b', v: 3, x: true});
@@ -492,7 +492,7 @@ tape('Window handles next_value with overwrite', t => {
 });
 
 tape('Window handles prev_value with overwrite', t => {
-  var data = [
+  const data = [
     {u: 'a',  v:1, x: null,      key:0},
     {u: null, v:3, x: true,      key:1},
     {u: null,      x: false,     key:2},
@@ -516,7 +516,7 @@ tape('Window handles prev_value with overwrite', t => {
 
   // -- test add
   df.pulse(col, changeset().insert(data)).run();
-  var d = out.value;
+  const d = out.value;
   t.equal(d.length, data.length);
   match(t, d[0], {key: 0, u: 'a', v: 1, x: null});
   match(t, d[1], {key: 1, u: 'a', v: 3, x: true});
@@ -527,7 +527,7 @@ tape('Window handles prev_value with overwrite', t => {
 });
 
 tape('Window fill operations handle partition state', t => {
-  var data = [
+  const data = [
     {u: 'a',  v: null, key:0, idx:0},
     {u: null, v: 'b',  key:1, idx:0}
   ];
@@ -551,7 +551,7 @@ tape('Window fill operations handle partition state', t => {
 
   // -- test add
   df.pulse(col, changeset().insert(data)).run();
-  var d = out.value;
+  const d = out.value;
   t.equal(d.length, data.length);
   match(t, d[0], {
     u: 'a', v: null, key: 0, idx: 0,

--- a/packages/vega-util/test/array-test.js
+++ b/packages/vega-util/test/array-test.js
@@ -9,7 +9,7 @@ tape('array wraps values in an array', t => {
   t.deepEqual(vega.array(), []);
 
   // should return an unmodified array argument
-  var value = [1, 2, 3];
+  const value = [1, 2, 3];
   t.equal(vega.array(value), value);
 
   // should return an array for non-array argument

--- a/packages/vega-util/test/compare-test.js
+++ b/packages/vega-util/test/compare-test.js
@@ -2,7 +2,7 @@ var tape = require('tape'),
     vega = require('../');
 
 tape('compare compares numbers', t => {
-  var c = vega.compare('x');
+  const c = vega.compare('x');
   t.equal(c({x:1}, {x:0}), 1);
   t.equal(c({x:0}, {x:1}), -1);
   t.equal(c({x:1}, {x:1}), 0);
@@ -18,7 +18,7 @@ tape('compare compares numbers', t => {
 });
 
 tape('compare compares strings', t => {
-  var c = vega.compare('x');
+  const c = vega.compare('x');
   t.equal(c({x:'b'}, {x:'a'}), 1);
   t.equal(c({x:'a'}, {x:'b'}), -1);
   t.equal(c({x:'b'}, {x:'b'}), 0);
@@ -34,7 +34,7 @@ tape('compare compares strings', t => {
 });
 
 tape('compare compares dates', t => {
-  var c = vega.compare('x');
+  const c = vega.compare('x');
   t.equal(c({x:new Date(1)}, {x:new Date(0)}), 1);
   t.equal(c({x:new Date(0)}, {x:new Date(1)}), -1);
   t.equal(c({x:new Date(1)}, {x:new Date(1)}), 0);
@@ -51,7 +51,7 @@ tape('compare compares dates', t => {
 });
 
 tape('compare compares null, undefined and NaN', t => {
-  var c = vega.compare('x');
+  const c = vega.compare('x');
   // null and undefined are treated as equivalent
   t.equal(c({x:null}, {x:undefined}), 0);
   t.equal(c({x:undefined}, {x:null}), 0);
@@ -68,7 +68,7 @@ tape('compare compares null, undefined and NaN', t => {
 });
 
 tape('compare supports descending order', t => {
-  var c = vega.compare('x', 'descending');
+  const c = vega.compare('x', 'descending');
   t.equal(c({x:1}, {x:0}), -1);
   t.equal(c({x:0}, {x:1}), 1);
   t.equal(c({x:1}, {x:1}), -0);
@@ -77,7 +77,7 @@ tape('compare supports descending order', t => {
 });
 
 tape('compare supports nested comparison', t => {
-  var c = vega.compare(['x', 'y'], ['descending', 'ascending']);
+  const c = vega.compare(['x', 'y'], ['descending', 'ascending']);
   t.equal(c({x:1,y:0}, {x:0,y:1}), -1);
   t.equal(c({x:0,y:1}, {x:1,y:0}), 1);
   t.equal(c({x:0,y:0}, {x:0,y:1}), -1);

--- a/packages/vega-util/test/extend-test.js
+++ b/packages/vega-util/test/extend-test.js
@@ -11,7 +11,7 @@ tape('extend extends objects with other object properties', t => {
   object1.o1_2 = 'vo1_2';
   object1.override_1 = 'x';
   parent.p1_1 = 'vp1_1';
-  var o = vega.extend({c1: 'vc1', p2_2: 'x', o1_1: 'y'}, object1, object2);
+  const o = vega.extend({c1: 'vc1', p2_2: 'x', o1_1: 'y'}, object1, object2);
 
   // should inherit all direct properties
   t.equal(o['o1_1'], 'vo1_1');

--- a/packages/vega-util/test/fastmap-test.js
+++ b/packages/vega-util/test/fastmap-test.js
@@ -2,7 +2,7 @@ var tape = require('tape'),
     vega = require('../');
 
 tape('fastmap maps keys to values', t => {
-  var m = vega.fastmap();
+  const m = vega.fastmap();
 
   m.set('foo', 1);
   m.set('bar', 2);
@@ -49,7 +49,7 @@ tape('fastmap maps keys to values', t => {
 });
 
 tape('fastmap accepts object as argument', t => {
-  var m = vega.fastmap({a:1, b:2});
+  const m = vega.fastmap({a:1, b:2});
   t.equal(m.size, 2);
   t.equal(m.empty, 0);
   t.equal(m.has('a'), true);
@@ -60,7 +60,7 @@ tape('fastmap accepts object as argument', t => {
 });
 
 tape('fastmap supports external clean test', t => {
-  var m = vega.fastmap({a:1, b:2, c:1});
+  const m = vega.fastmap({a:1, b:2, c:1});
 
   m.test(value => value === 1);
   m.clean();

--- a/packages/vega-util/test/field-test.js
+++ b/packages/vega-util/test/field-test.js
@@ -2,7 +2,7 @@ var tape = require('tape'),
     vega = require('../');
 
 tape('field creates a field accessor', t => {
-  var f = vega.field('x');
+  let f = vega.field('x');
   t.equal(typeof f, 'function');
   t.equal(vega.accessorName(f), 'x');
   t.deepEqual(vega.accessorFields(f), ['x']);

--- a/packages/vega-util/test/lruCache-test.js
+++ b/packages/vega-util/test/lruCache-test.js
@@ -2,7 +2,7 @@ var tape = require('tape'),
     vega = require('../');
 
 tape('lruCache should cache items', t => {
-  var cache = vega.lruCache();
+  const cache = vega.lruCache();
 
   // test adding an entry
   cache.set('a', 'foo');
@@ -41,7 +41,7 @@ tape('lruCache should cache items', t => {
 });
 
 tape('lruCache should evict least recently used items', t => {
-  var cache = vega.lruCache(2);
+  const cache = vega.lruCache(2);
 
   cache.set('a', 1); // a in curr cache
   cache.set('b', 2); // a,b in curr cache

--- a/packages/vega-util/test/stringValue-test.js
+++ b/packages/vega-util/test/stringValue-test.js
@@ -21,11 +21,11 @@ tape('stringValue maps values', t => {
   t.equal(vega.stringValue([['1', 3], '2']), '[["1",3],"2"]');
 
   // should stringify objects
-  var x = {a: {b: {c: 1}}};
+  const x = {a: {b: {c: 1}}};
   t.equal(JSON.stringify(x), vega.stringValue(x));
 
   // should handle quotes in strings
-  var tests = ["'hello'", '"hello"'];
+  let tests = ["'hello'", '"hello"'];
   tests.forEach(s => {
     t.equal(s, eval(vega.stringValue(s)));
   });

--- a/packages/vega-util/test/transform-test.js
+++ b/packages/vega-util/test/transform-test.js
@@ -7,35 +7,35 @@ function equal(a1, a2) {
 }
 
 tape('panLinear pans a domain linearly', t => {
-  var domain = [0, 1];
+  const domain = [0, 1];
   t.ok(equal(vega.panLinear(domain, -1), [1, 2]));
   t.ok(equal(vega.panLinear(domain, +1), [-1, 0]));
   t.end();
 });
 
 tape('panLog pans a domain logarithmically', t => {
-  var domain = [1, 10];
+  const domain = [1, 10];
   t.ok(equal(vega.panLog(domain, -1), [10, 100]));
   t.ok(equal(vega.panLog(domain, +1), [0.1, 1]));
   t.end();
 });
 
 tape('panPow pans a domain along a power scale', t => {
-  var domain = [4, 16];
+  const domain = [4, 16];
   t.ok(equal(vega.panPow(domain, -1, 0.5), [16, 36]));
   t.ok(equal(vega.panPow(domain, +1, 0.5), [0, 4]));
   t.end();
 });
 
 tape('panSymlog pans a domain along a symlog scale', t => {
-  var domain = [0, 1];
+  const domain = [0, 1];
   t.ok(equal(vega.panSymlog(domain, -1, 1), [1, 3]));
   t.ok(equal(vega.panSymlog(domain, +1, 1), [-1, 0]));
   t.end();
 });
 
 tape('zoomLinear zooms a domain linearly', t => {
-  var domain = [0, 1];
+  const domain = [0, 1];
   t.ok(equal(vega.zoomLinear(domain, null, 2.0), [-0.5, 1.5]));
   t.ok(equal(vega.zoomLinear(domain, null, 0.5), [0.25, 0.75]));
   t.ok(equal(vega.zoomLinear(domain, 0.5,  2.0), [-0.5, 1.5]));

--- a/packages/vega-util/test/visit-array-test.js
+++ b/packages/vega-util/test/visit-array-test.js
@@ -4,7 +4,7 @@ var tape = require('tape'),
 tape('visitArray should visit arrays', t => {
   // check visited item count
   function run(array, filter) {
-    var count = 0;
+    let count = 0;
     vega.visitArray(array, filter, () => { ++count; });
     return count;
   }

--- a/packages/vega-view-transforms/src/Overlap.js
+++ b/packages/vega-view-transforms/src/Overlap.js
@@ -55,7 +55,7 @@ const hasOverlap = (items, pad) => {
 };
 
 const hasBounds = item => {
-  var b = item.bounds;
+  const b = item.bounds;
   return b.width() > 1 && b.height() > 1;
 };
 

--- a/packages/vega-view-transforms/src/Render.js
+++ b/packages/vega-view-transforms/src/Render.js
@@ -17,7 +17,7 @@ inherits(Render, Transform, {
 
     // set z-index dirty flag as needed
     if (pulse.fields && pulse.fields['zindex']) {
-      var item = pulse.source && pulse.source[0];
+      const item = pulse.source && pulse.source[0];
       if (item) item.mark.zdirty = true;
     }
   }

--- a/packages/vega-view-transforms/src/layout/axis.js
+++ b/packages/vega-view-transforms/src/layout/axis.js
@@ -8,7 +8,7 @@ export function isYAxis(mark) {
 }
 
 function axisIndices(datum) {
-  var index = +datum.grid;
+  let index = +datum.grid;
   return [
     datum.ticks  ? index++ : -1, // ticks index
     datum.labels ? index++ : -1, // labels index

--- a/packages/vega-view-transforms/src/layout/grid.js
+++ b/packages/vega-view-transforms/src/layout/grid.js
@@ -17,7 +17,7 @@ function gridLayoutGroups(group) {
       n = groups.length,
       i = 0, mark, items;
 
-  var views = {
+  const views = {
     marks:      [],
     rowheaders: [],
     rowfooters: [],
@@ -56,14 +56,14 @@ function bboxFlush(item) {
 }
 
 function bboxFull(item) {
-  var b = item.bounds.clone();
+  const b = item.bounds.clone();
   return b.empty()
     ? b.set(0, 0, 0, 0)
     : b.translate(-(item.x || 0), -(item.y || 0));
 }
 
 function get(opt, key, d) {
-  var v = isObject(opt) ? opt[key] : opt;
+  const v = isObject(opt) ? opt[key] : opt;
   return v != null ? v : (d !== undefined ? d : 0);
 }
 

--- a/packages/vega-view-transforms/src/layout/legend.js
+++ b/packages/vega-view-transforms/src/layout/legend.js
@@ -15,7 +15,7 @@ function lookup(config, orient) {
 
 // if legends specify offset directly, use the maximum specified value
 function offsets(legends, value) {
-  var max = -Infinity;
+  let max = -Infinity;
   legends.forEach(item => {
     if (item.offset != null) max = Math.max(max, item.offset);
   });
@@ -206,7 +206,7 @@ function translate(view, item, dx, dy) {
 
 function legendEntryLayout(entries) {
   // get max widths for each column
-  var widths = entries.reduce((w, g) => {
+  const widths = entries.reduce((w, g) => {
     w[g.column] = Math.max(g.bounds.x2 - g.x, w[g.column] || 0);
     return w;
   }, {});

--- a/packages/vega-view-transforms/test/overlap-test.js
+++ b/packages/vega-view-transforms/test/overlap-test.js
@@ -6,7 +6,7 @@ var tape = require('tape'),
     Overlap = tx.overlap;
 
 function items() {
-  var mark = {bounds: new Bounds(0, 0, 20, 10)};
+  const mark = {bounds: new Bounds(0, 0, 20, 10)};
   return [
     {opacity: 1, mark: mark, bounds: new Bounds().set( 0, 0,  3, 10)},
     {opacity: 1, mark: mark, bounds: new Bounds().set( 5, 0, 20, 10)},

--- a/packages/vega-view/src/View.js
+++ b/packages/vega-view/src/View.js
@@ -128,7 +128,7 @@ function findOperatorHandler(op, handler) {
 }
 
 function addOperatorListener(view, name, op, handler) {
-  var h = findOperatorHandler(op, handler);
+  let h = findOperatorHandler(op, handler);
   if (!h) {
     h = trap(view, () => handler(name, op.value));
     h.handler = handler;
@@ -138,7 +138,7 @@ function addOperatorListener(view, name, op, handler) {
 }
 
 function removeOperatorListener(view, op, handler) {
-  var h = findOperatorHandler(op, handler);
+  const h = findOperatorHandler(op, handler);
   if (h) op._targets.remove(h);
   return view;
 }
@@ -201,7 +201,7 @@ inherits(View, Dataflow, {
   },
 
   signal(name, value, options) {
-    var op = lookupSignal(this, name);
+    const op = lookupSignal(this, name);
     return arguments.length === 1
       ? op.value
       : this.update(op, value, options);
@@ -277,7 +277,7 @@ inherits(View, Dataflow, {
   // -- EVENT HANDLING ----
 
   addEventListener(type, handler, options) {
-    var callback = handler;
+    let callback = handler;
     if (!(options && options.trap === false)) {
       // wrap callback in error handler
       callback = trap(this, handler);
@@ -304,7 +304,7 @@ inherits(View, Dataflow, {
   },
 
   addResizeListener(handler) {
-    var l = this._resizeListeners;
+    const l = this._resizeListeners;
     if (l.indexOf(handler) < 0) {
       // add handler if it isn't already registered
       // note: error trapping handled elsewhere, so

--- a/packages/vega-view/src/data.js
+++ b/packages/vega-view/src/data.js
@@ -19,7 +19,7 @@ export function change(name, changes) {
   if (!isChangeSet(changes)) {
     error('Second argument to changes must be a changeset.');
   }
-  var dataset = dataref(this, name);
+  const dataset = dataref(this, name);
   dataset.modified = true;
   return this.pulse(dataset.input, changes);
 }

--- a/packages/vega-view/src/element.js
+++ b/packages/vega-view/src/element.js
@@ -1,6 +1,6 @@
 export default function(tag, attr, text) {
-  var el = document.createElement(tag);
-  for (var key in attr) el.setAttribute(key, attr[key]);
+  const el = document.createElement(tag);
+  for (const key in attr) el.setAttribute(key, attr[key]);
   if (text != null) el.textContent = text;
   return el;
 }

--- a/packages/vega-view/src/events-extend.js
+++ b/packages/vega-view/src/events-extend.js
@@ -48,7 +48,7 @@ export default function(view, event, item) {
 }
 
 function extension(view, item, point) {
-  var itemGroup = item
+  const itemGroup = item
     ? item.mark.marktype === 'group' ? item : item.mark.group
     : null;
 
@@ -64,7 +64,7 @@ function extension(view, item, point) {
     if (!item) return point;
     if (isString(item)) item = group(item);
 
-    var p = point.slice();
+    const p = point.slice();
     while (item) {
       p[0] -= item.x || 0;
       p[1] -= item.y || 0;

--- a/packages/vega-view/src/initialize-handler.js
+++ b/packages/vega-view/src/initialize-handler.js
@@ -3,7 +3,7 @@ import trap from './trap';
 
 export default function(view, prevHandler, el, constructor) {
   // instantiate scenegraph handler
-  var handler = new constructor(view.loader(), trap(view, view.tooltip()))
+  const handler = new constructor(view.loader(), trap(view, view.tooltip()))
     .scene(view.scenegraph().root)
     .initialize(el, offset(view), view);
 

--- a/packages/vega-view/src/render-to-image-url.js
+++ b/packages/vega-view/src/render-to-image-url.js
@@ -23,6 +23,6 @@ export default async function(type, scaleFactor) {
 }
 
 function toBlobURL(data, mime) {
-  var blob = new Blob([data], {type: mime});
+  const blob = new Blob([data], {type: mime});
   return window.URL.createObjectURL(blob);
 }

--- a/packages/vega-view/src/size.js
+++ b/packages/vega-view/src/size.js
@@ -46,7 +46,7 @@ export function initializeResize(view) {
   );
 
   // respond to padding signal
-  var resizePadding = view.add(null, resetSize, {pad: p});
+  const resizePadding = view.add(null, resetSize, {pad: p});
 
   // set rank to run immediately after source signal
   view._resizeWidth.rank = w.rank + 1;
@@ -56,7 +56,7 @@ export function initializeResize(view) {
 
 export function resizeView(viewWidth, viewHeight, width, height, origin, auto) {
   this.runAfter(view => {
-    var rerun = 0;
+    let rerun = 0;
 
     // reset autosize flag
     view._autosize = 0;

--- a/packages/vega-view/src/tooltip.js
+++ b/packages/vega-view/src/tooltip.js
@@ -1,7 +1,7 @@
 import {isArray, isDate, isObject} from 'vega-util';
 
 export default function(handler, event, item, value) {
-  var el = handler.element();
+  const el = handler.element();
   if (el) el.setAttribute('title', formatTooltip(value));
 }
 
@@ -14,7 +14,7 @@ function formatTooltip(value) {
 
 function formatObject(obj) {
   return Object.keys(obj).map(key => {
-    var v = obj[key];
+    const v = obj[key];
     return key + ': ' + (isArray(v) ? formatArray(v) : formatValue(v));
   }).join('\n');
 }

--- a/packages/vega-wordcloud/src/Wordcloud.js
+++ b/packages/vega-wordcloud/src/Wordcloud.js
@@ -4,9 +4,9 @@ import {constant, error, extent, inherits, isFunction} from 'vega-util';
 import {scale} from 'vega-scale';
 import {random} from 'vega-statistics';
 
-var Output = ['x', 'y', 'font', 'fontSize', 'fontStyle', 'fontWeight', 'angle'];
+const Output = ['x', 'y', 'font', 'fontSize', 'fontStyle', 'fontWeight', 'angle'];
 
-var Params = ['text', 'font', 'rotate', 'fontSize', 'fontStyle', 'fontWeight'];
+const Params = ['text', 'font', 'rotate', 'fontSize', 'fontStyle', 'fontWeight'];
 
 export default function Wordcloud(params) {
   Transform.call(this, cloud(), params);
@@ -37,7 +37,7 @@ inherits(Wordcloud, Transform, {
     }
 
     function modp(param) {
-      var p = _[param];
+      const p = _[param];
       return isFunction(p) && pulse.modified(p.fields);
     }
 

--- a/packages/vega-wordcloud/test/wordcloud-test.js
+++ b/packages/vega-wordcloud/test/wordcloud-test.js
@@ -5,7 +5,7 @@ var tape = require('tape'),
     Wordcloud = require('../').wordcloud;
 
 tape('Wordcloud generates wordcloud layout', t => {
-  var data = [
+  const data = [
     {text: 'foo', size: 49, index: 0},
     {text: 'bar', size: 36, index: 1},
     {text: 'baz', size: 25, index: 2},
@@ -26,7 +26,7 @@ tape('Wordcloud generates wordcloud layout', t => {
         pulse: c0
       });
 
-  var angles = [0, 30, 60, 90];
+  const angles = [0, 30, 60, 90];
   rot.set(t => angles[t.index]);
 
   df.pulse(c0, vega.changeset().insert(data)).run();

--- a/packages/vega/test/scene-test.js
+++ b/packages/vega/test/scene-test.js
@@ -42,7 +42,7 @@ tape('Vega generates scenegraphs for specifications', t => {
 
         if (OUTPUT_FAILURES && !isEqual) {
           pair.forEach((scene, i) => {
-            var prefix = vega.pad(index, 2, '0', 'left');
+            const prefix = vega.pad(index, 2, '0', 'left');
             fs.writeFileSync(
               `${prefix}-scene-${i?'expect':'actual'}-${name}.json`,
               JSON.stringify(scene, 0, 2)

--- a/packages/vega/test/schema-test.js
+++ b/packages/vega/test/schema-test.js
@@ -6,14 +6,14 @@ var tape = require('tape'),
     validSpecs = require('./specs-valid.json'),
     invalidSpecs = require('./specs-invalid.json');
 
-var validator = new ajv({
+const validator = new ajv({
     allErrors: true,
     verbose: true,
     extendRefs: 'fail'
   })
   .addMetaSchema(require('ajv/lib/refs/json-schema-draft-06.json'));
 
-var validate = validator.compile(schema);
+const validate = validator.compile(schema);
 
 tape('JSON schema is valid', t => {
   t.ok(validator.validateSchema(schema));
@@ -21,7 +21,7 @@ tape('JSON schema is valid', t => {
 });
 
 tape('JSON schema recognizes valid specifications', t => {
-  var dir = process.cwd() + '/test/specs-valid/';
+  const dir = process.cwd() + '/test/specs-valid/';
   validSpecs.forEach(file => {
     var spec = JSON.parse(fs.readFileSync(dir + file + '.vg.json')),
         valid = validate(spec);
@@ -33,9 +33,9 @@ tape('JSON schema recognizes valid specifications', t => {
 });
 
 tape('JSON schema recognizes invalid specifications', t => {
-  var dir = process.cwd() + '/test/specs-invalid/';
+  const dir = process.cwd() + '/test/specs-invalid/';
   invalidSpecs.forEach(file => {
-    var specs = JSON.parse(fs.readFileSync(dir + file + '.json'));
+    const specs = JSON.parse(fs.readFileSync(dir + file + '.json'));
     specs.forEach((spec, index) => {
       t.notOk(validate(spec),
         'invalid schema (' + index + '): ' + file);


### PR DESCRIPTION
**'Let' and 'const' are block-scope variable declarations that can replace 'var' declarations in many cases.**

`const` declares blocked-scoped variables that cannot be re-assigned. `let` declares block-scoped variables that can be changed. They are available since ES6 and are preferred over function-scope, modifiable `var` declarations, because they make it easier to reason about the code.

When there are several variables declared in a statement, this codemod does not change the declaration to prevent formatting breakages and linter issues.

✅ This codemod is semantically safe. It only changes variables that are used within block-scope, and only marks variables as `const` if they are not modified.