### PR TITLE
feat(vega-projection): allow "fit" to auto rotate

### DIFF
--- a/packages/vega-geo/src/Projection.js
+++ b/packages/vega-geo/src/Projection.js
@@ -2,6 +2,7 @@ import {Feature, FeatureCollection} from './constants';
 import {Transform} from 'vega-dataflow';
 import {projection, projectionProperties} from 'vega-projection';
 import {array, error, inherits, isFunction} from 'vega-util';
+import {geoCentroid} from 'd3-geo';
 
 /**
  * Maintains a cartographic projection.
@@ -37,8 +38,15 @@ inherits(Projection, Transform, {
 
 function fit(proj, _) {
   var data = collectGeoJSON(_.fit);
-  _.extent ? proj.fitExtent(_.extent, data)
-    : _.size ? proj.fitSize(_.size, data) : 0;
+  if (_.rotate == null) {
+    // -rotation to move the centroid to the center of the map
+    var rotation = geoCentroid(data).map(i => -i);
+
+    if (!Number.isNaN(rotation[0])) proj.rotate(rotation);
+  }
+
+  if (_.extent) proj.fitExtent(_.extent, data);
+  else if (_.size) proj.fitSize(_.size, data);
 }
 
 function create(type) {

--- a/packages/vega-geo/test/projection-test.js
+++ b/packages/vega-geo/test/projection-test.js
@@ -4,7 +4,60 @@ var tape = require('tape'),
     Graticule = geo.graticule,
     Projection = geo.projection;
 
-tape('Projection transform fits parameters to GeoJSON data', t => {
+var earthquakes = {
+  type: 'FeatureCollection',
+  features: [
+    {
+      type: 'Feature',
+      geometry: {type: 'Point', coordinates: [-118.6671667, 34.4945, 26.49]}
+    },
+    {
+      type: 'Feature',
+      geometry: {type: 'Point', coordinates: [-118.0873333, 34.12, 9.72]}
+    }
+  ]
+};
+
+tape('Projection transform auto fits parameters to GeoJSON data', t => {
+  var df = new vega.Dataflow(),
+      pr = df.add(Projection, {
+        type: 'orthographic',
+        fit: earthquakes
+      });
+
+  df.run();
+
+  var proj = pr.value;
+  t.equal(Math.round(proj.scale()), 250);
+  t.equal(Math.round(proj.translate()[0]), 480);
+  t.equal(Math.round(proj.translate()[1]), 250);
+  t.equal(+proj.rotate()[0].toFixed(2), 118.38);
+  t.equal(+proj.rotate()[1].toFixed(2), -34.31);
+
+  t.end();
+});
+
+tape('Projection transform allows overriding rotation when auto fitting parameters to GeoJSON data', t => {
+  var df = new vega.Dataflow(),
+      pr = df.add(Projection, {
+        type: 'orthographic',
+        fit: earthquakes,
+        rotate: [0, 0]
+      });
+
+  df.run();
+
+  var proj = pr.value;
+  t.equal(Math.round(proj.scale()), 250);
+  t.equal(Math.round(proj.translate()[0]), 480);
+  t.equal(Math.round(proj.translate()[1]), 250);
+  t.equal(+proj.rotate()[0].toFixed(2), 0);
+  t.equal(+proj.rotate()[1].toFixed(2), 0);
+
+  t.end();
+});
+
+tape('Projection transform auto fits parameters with graticlue and sphere GeoJSON data', t => {
   var df = new vega.Dataflow(),
       gr = df.add(Graticule),
       pr = df.add(Projection, {
@@ -16,14 +69,16 @@ tape('Projection transform fits parameters to GeoJSON data', t => {
   df.run();
 
   var proj = pr.value;
-  t.equal(proj.scale(), 250);
+  t.equal(Math.round(proj.scale()), 250);
   t.equal(Math.round(proj.translate()[0]), 250);
   t.equal(Math.round(proj.translate()[1]), 250);
+  t.equal(+proj.rotate()[0].toFixed(2), 14.15);
+  t.equal(+proj.rotate()[1].toFixed(2), -90);
 
   t.end();
 });
 
-tape('Projection transform handles fit input with null data', t => {
+tape('Projection transform auto fits parameters with null data', t => {
   var df = new vega.Dataflow(),
       gr = df.add(Graticule),
       pr = df.add(Projection, {
@@ -35,9 +90,11 @@ tape('Projection transform handles fit input with null data', t => {
   df.run();
 
   var proj = pr.value;
-  t.equal(proj.scale(), 250);
+  t.equal(Math.round(proj.scale()), 250);
   t.equal(Math.round(proj.translate()[0]), 250);
   t.equal(Math.round(proj.translate()[1]), 250);
+  t.equal(+proj.rotate()[0].toFixed(2), 14.15);
+  t.equal(+proj.rotate()[1].toFixed(2), -90);
 
   t.end();
 });

--- a/packages/vega-typings/types/spec/projection.d.ts
+++ b/packages/vega-typings/types/spec/projection.d.ts
@@ -58,7 +58,7 @@ export interface BaseProjection {
   /**
    * The projection's three-axis rotation to the specified angles, which must be a two- or three-element array of numbers [`lambda`, `phi`, `gamma`] specifying the rotation angles in degrees about each spherical axis. (These correspond to yaw, pitch and roll.)
    *
-   * __Default value:__ `[0, 0, 0]`
+   * __Default value:__ `[0, 0, 0]` or the spherical centroid as determined by `fit` if `fit` is set.
    */
   rotate?: Vector2<number | SignalRef> | Vector3<number | SignalRef> | SignalRef;
 
@@ -80,7 +80,7 @@ export interface BaseProjection {
   precision?: number | SignalRef;
 
   /*
-   * GeoJSON data to which the projection should attempt to automatically fit the `translate` and `scale` parameters. If object-valued, this parameter should be a GeoJSON Feature or FeatureCollection. If array-valued, each array member may be a GeoJSON Feature, FeatureCollection, or a sub-array of GeoJSON Features.
+   * GeoJSON data to which the projection should attempt to automatically fit the `translate`, `scale`, and `rotate` parameters. If object-valued, this parameter should be a GeoJSON Feature or FeatureCollection. If array-valued, each array member may be a GeoJSON Feature, FeatureCollection, or a sub-array of GeoJSON Features.
    */
   fit?: Fit | Fit[] | SignalRef;
   /*


### PR DESCRIPTION
While `fit` controls the projection `scale` and `translate` parameters it makes sense to also control the `rotate` parameter unless it has been overridden. This change uses `d3.geoCentroid` to rotate that to the center of the map.