### PR TITLE
Use ES6 Spread Syntax (...)

### DIFF
--- a/packages/vega-functions/src/functions/merge.js
+++ b/packages/vega-functions/src/functions/merge.js
@@ -3,5 +3,5 @@ import {extend} from 'vega-util';
 export default function() {
   const args = [].slice.call(arguments);
   args.unshift({});
-  return extend.apply(null, args);
+  return extend(...args);
 }

--- a/packages/vega-runtime/src/expression.js
+++ b/packages/vega-runtime/src/expression.js
@@ -6,7 +6,7 @@ function expression(ctx, args, code) {
   if (code[code.length-1] !== ';') {
     code = 'return(' + code + ');';
   }
-  const fn = Function.apply(null, args.concat(code));
+  const fn = Function(...args.concat(code));
   return ctx && ctx.functions ? fn.bind(ctx.functions) : fn;
 }
 

--- a/packages/vega-scenegraph/src/Handler.js
+++ b/packages/vega-scenegraph/src/Handler.js
@@ -115,9 +115,9 @@ Handler.prototype = {
   handlers(type) {
     const h = this._handlers, a = [];
     if (type) {
-      a.push.apply(a, h[this.eventName(type)]);
+      a.push(...h[this.eventName(type)]);
     } else {
-      for (const k in h) { a.push.apply(a, h[k]); }
+      for (const k in h) { a.push(...h[k]); }
     }
     return a;
   },

--- a/packages/vega-selections/src/selectionResolve.js
+++ b/packages/vega-selections/src/selectionResolve.js
@@ -54,7 +54,7 @@ export function selectionResolve(name, op, isMulti) {
   entries = Object.keys(multiRes);
   if (isMulti && entries.length) {
     resolved[VlMulti] = op === Union
-      ? {[Or]: entries.reduce((acc, k) => (acc.push.apply(acc, multiRes[k]), acc), [])}
+      ? {[Or]: entries.reduce((acc, k) => (acc.push(...multiRes[k]), acc), [])}
       : {[And]: entries.map(k => ({[Or]: multiRes[k]}))};
   }
 


### PR DESCRIPTION
**The spread syntax (`...`) allows iterables like array expressions to be expanded in place where arguments are expected.** It can used in place of `.apply`. For example `Math.min.apply(Math, args)` can be replaced with `Math.min(...args)`.