### PR TITLE
Support event functions in interpreter.

### DIFF
--- a/packages/vega-interpreter/package.json
+++ b/packages/vega-interpreter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vega-interpreter",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "CSP-compliant interpreter for Vega expressions.",
   "keywords": [
     "vega",

--- a/packages/vega-interpreter/src/interpret.js
+++ b/packages/vega-interpreter/src/interpret.js
@@ -3,6 +3,8 @@ import Ops from './ops-binary';
 import Unary from './ops-unary';
 import Functions from './functions';
 
+const EventFunctions = ['view', 'item', 'group', 'xy', 'x', 'y'];
+
 const Visitors = {
   Literal: ($, n) => n.value,
 
@@ -66,10 +68,14 @@ const Visitors = {
 export default function(ast, fn, params, datum, event, item) {
   const $ = n => Visitors[n.type]($, n);
   $.memberDepth = 0;
-  $.fn = fn;
+  $.fn = Object.create(fn);
   $.params = params;
   $.datum = datum;
   $.event = event;
   $.item = item;
+
+  // route event functions to annotated vega event context
+  EventFunctions.forEach(f => $.fn[f] = (...args) => event.vega[f](...args));
+
   return $(ast);
 }


### PR DESCRIPTION
**vega-interpreter**

- Register event functions (`x`, `y`, `xy`, _etc_) with interpreter.