### PR TITLE
add expr functions for extensional selection predicates

### DIFF
--- a/packages/vega-functions/src/codegen.js
+++ b/packages/vega-functions/src/codegen.js
@@ -9,8 +9,10 @@ import {
 } from 'vega-dataflow';
 
 import {
+  selectionIdTest,
   selectionResolve,
   selectionTest,
+  selectionTuples,
   selectionVisitor
 } from 'vega-selections';
 
@@ -336,4 +338,6 @@ expressionFunction('treeAncestors', treeAncestors, dataVisitor);
 
 // register Vega-Lite selection functions
 expressionFunction('vlSelectionTest', selectionTest, selectionVisitor);
+expressionFunction('vlSelectionIdTest', selectionIdTest, selectionVisitor);
 expressionFunction('vlSelectionResolve', selectionResolve, selectionVisitor);
+expressionFunction('vlSelectionTuples', selectionTuples);

--- a/packages/vega-selections/index.js
+++ b/packages/vega-selections/index.js
@@ -1,3 +1,4 @@
-export {selectionTest} from './src/selectionTest';
+export {selectionTest, selectionIdTest} from './src/selectionTest';
+export {selectionTuples} from './src/selectionTuples';
 export {selectionResolve} from './src/selectionResolve';
 export {selectionVisitor} from './src/selectionVisitor';

--- a/packages/vega-selections/src/selectionTest.js
+++ b/packages/vega-selections/src/selectionTest.js
@@ -1,7 +1,9 @@
+import {bisector} from 'd3-array';
 import {Intersect} from './constants';
 import {field, inrange, isArray, isDate, toNumber} from 'vega-util';
 
-var TYPE_ENUM = 'E',
+const SELECTION_ID = '_vgsid_',
+    TYPE_ENUM = 'E',
     TYPE_RANGE_INC = 'R',
     TYPE_RANGE_EXC = 'R-E',
     TYPE_RANGE_LE = 'R-LE',
@@ -101,4 +103,28 @@ export function selectionTest(name, datum, op) {
   // if not intersecting, then we saw no matches
   // if no active selections, return false
   return n && intersect;
+}
+
+const selectionId = field(SELECTION_ID),
+  bisect = bisector(selectionId),
+  bisectLeft = bisect.left,
+  bisectRight = bisect.right;
+
+export function selectionIdTest(name, datum, op) {
+  const data = this.context.data[name],
+      entries = data ? data.values.value : [],
+      unitIdx = data ? data[UNIT_INDEX] && data[UNIT_INDEX].value : undefined,
+      intersect = op === Intersect,
+      value = selectionId(datum),
+      index = bisectLeft(entries, value);
+
+  if (index === entries.length) return false;
+  if (selectionId(entries[index]) !== value) return false;
+
+  if (unitIdx && intersect) {
+    if (unitIdx.size === 1) return true;
+    if (bisectRight(entries, value) - index < unitIdx.size) return false;
+  }
+
+  return true;
 }

--- a/packages/vega-selections/src/selectionTuples.js
+++ b/packages/vega-selections/src/selectionTuples.js
@@ -1,0 +1,14 @@
+import {extend, field} from 'vega-util';
+
+/**
+ * Maps an array of scene graph items to an array of selection tuples.
+ * @param {string} name  - The name of the dataset representing the selection.
+ * @param {string} unit  - The name of the unit view.
+ *
+ * @returns {array} An array of selection entries for the given unit.
+ */
+export function selectionTuples(array, base) {
+  return array.map(x => extend({
+    values: base.fields.map(f => (f.getter || (f.getter = field(f.field)))(x.datum))
+  }, base));
+}


### PR DESCRIPTION
This PR adds two new expression functions to support extensional predicates for Vega-Lite selections. This is (currently) most useful to support interval selections over cartographic projections (vega/vega-lite#6953). 

<details>
  <summary>An example output Vega spec for Vega-Lite geo-interval selections</summary>
  
```json
{
  "$schema": "https://vega.github.io/schema/vega/v5.json",
  "background": "white",
  "padding": 5,
  "width": 500,
  "height": 300,
  "style": "cell",
  "data": [
    {
      "name": "brush_store",
      "transform": [
        {"type": "formula", "expr": "datum.values[0]", "as": "_vgsid_"},
        {"type": "collect", "sort": {"field": "_vgsid_"}}
      ]
    },
    {
      "name": "source_0",
      "url": "data/us-10m.json",
      "format": {"type": "topojson", "feature": "states"},
      "transform": [{"type": "identifier", "as": "_vgsid_"}]
    },
    {
      "name": "source_1",
      "url": "data/airports.csv",
      "format": {"type": "csv", "delimiter": ","},
      "transform": [
        {"type": "identifier", "as": "_vgsid_"},
        {
          "type": "geojson",
          "fields": ["longitude", "latitude"],
          "signal": "layer_1_geojson_0"
        },
        {
          "type": "geopoint",
          "projection": "projection",
          "fields": ["longitude", "latitude"],
          "as": ["layer_1_x", "layer_1_y"]
        }
      ]
    }
  ],
  "projections": [
    {
      "name": "projection",
      "size": {"signal": "[width, height]"},
      "fit": {"signal": "[data('source_0'), layer_1_geojson_0]"},
      "type": "albersUsa"
    }
  ],
  "signals": [
    {
      "name": "unit",
      "value": {},
      "on": [
        {"events": "mousemove", "update": "isTuple(group()) ? group() : unit"}
      ]
    },
    {
      "name": "brush",
      "update": "vlSelectionResolve(\"brush_store\", \"union\")"
    },
    {
      "name": "brush_x",
      "value": [],
      "on": [
        {
          "events": {
            "source": "scope",
            "type": "mousedown",
            "filter": [
              "!event.item || event.item.mark.name !== \"brush_brush\""
            ]
          },
          "update": "[x(unit), x(unit)]"
        },
        {
          "events": {
            "source": "window",
            "type": "mousemove",
            "consume": true,
            "between": [
              {
                "source": "scope",
                "type": "mousedown",
                "filter": [
                  "!event.item || event.item.mark.name !== \"brush_brush\""
                ]
              },
              {"source": "window", "type": "mouseup"}
            ]
          },
          "update": "[brush_x[0], clamp(x(unit), 0, width)]"
        },
        {
          "events": [{"source": "scope", "type": "dblclick"}],
          "update": "[0, 0]"
        },
        {
          "events": {"signal": "brush_translate_delta"},
          "update": "clampRange(panLinear(brush_translate_anchor.extent_x, brush_translate_delta.x / span(brush_translate_anchor.extent_x)), 0, width)"
        },
        {
          "events": {"signal": "brush_zoom_delta"},
          "update": "clampRange(zoomLinear(brush_x, brush_zoom_anchor.x, brush_zoom_delta), 0, width)"
        }
      ]
    },
    {
      "name": "brush_y",
      "value": [],
      "on": [
        {
          "events": {
            "source": "scope",
            "type": "mousedown",
            "filter": [
              "!event.item || event.item.mark.name !== \"brush_brush\""
            ]
          },
          "update": "[y(unit), y(unit)]"
        },
        {
          "events": {
            "source": "window",
            "type": "mousemove",
            "consume": true,
            "between": [
              {
                "source": "scope",
                "type": "mousedown",
                "filter": [
                  "!event.item || event.item.mark.name !== \"brush_brush\""
                ]
              },
              {"source": "window", "type": "mouseup"}
            ]
          },
          "update": "[brush_y[0], clamp(y(unit), 0, height)]"
        },
        {
          "events": [{"source": "scope", "type": "dblclick"}],
          "update": "[0, 0]"
        },
        {
          "events": {"signal": "brush_translate_delta"},
          "update": "clampRange(panLinear(brush_translate_anchor.extent_y, brush_translate_delta.y / span(brush_translate_anchor.extent_y)), 0, height)"
        },
        {
          "events": {"signal": "brush_zoom_delta"},
          "update": "clampRange(zoomLinear(brush_y, brush_zoom_anchor.y, brush_zoom_delta), 0, height)"
        }
      ]
    },
    {
      "name": "brush_tuple",
      "update": "vlSelectionTuples(intersect([[brush_x[0], brush_y[0]],[brush_x[1], brush_y[1]]], {markname: \"layer_1_marks\"}, unit.mark), {unit: \"layer_1\", fields: [brush_tuple_fields[0]]})"
    },
    {
      "name": "brush_tuple_fields",
      "value": [
        {"type": "E", "field": "_vgsid_"},
        {"field": "longitude", "channel": "x", "type": "E"},
        {"field": "latitude", "channel": "y", "type": "E"}
      ]
    },
    {
      "name": "brush_translate_anchor",
      "value": {},
      "on": [
        {
          "events": [
            {"source": "scope", "type": "mousedown", "markname": "brush_brush"}
          ],
          "update": "{x: x(unit), y: y(unit), extent_x: slice(brush_x), extent_y: slice(brush_y)}"
        }
      ]
    },
    {
      "name": "brush_translate_delta",
      "value": {},
      "on": [
        {
          "events": [
            {
              "source": "window",
              "type": "mousemove",
              "consume": true,
              "between": [
                {
                  "source": "scope",
                  "type": "mousedown",
                  "markname": "brush_brush"
                },
                {"source": "window", "type": "mouseup"}
              ]
            }
          ],
          "update": "{x: brush_translate_anchor.x - x(unit), y: brush_translate_anchor.y - y(unit)}"
        }
      ]
    },
    {
      "name": "brush_zoom_anchor",
      "on": [
        {
          "events": [
            {
              "source": "scope",
              "type": "wheel",
              "consume": true,
              "markname": "brush_brush"
            }
          ],
          "update": "{x: x(unit), y: y(unit)}"
        }
      ]
    },
    {
      "name": "brush_zoom_delta",
      "on": [
        {
          "events": [
            {
              "source": "scope",
              "type": "wheel",
              "consume": true,
              "markname": "brush_brush"
            }
          ],
          "force": true,
          "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
        }
      ]
    },
    {
      "name": "brush_modify",
      "on": [
        {
          "events": {"signal": "brush_tuple"},
          "update": "modify(\"brush_store\", brush_tuple, true)"
        }
      ]
    }
  ],
  "marks": [
    {
      "name": "brush_brush_bg",
      "type": "rect",
      "clip": true,
      "encode": {
        "enter": {"fill": {"value": "#333"}, "fillOpacity": {"value": 0.125}},
        "update": {
          "x": [
            {
              "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"layer_1\"",
              "signal": "brush_x[0]"
            },
            {"value": 0}
          ],
          "y": [
            {
              "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"layer_1\"",
              "signal": "brush_y[0]"
            },
            {"value": 0}
          ],
          "x2": [
            {
              "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"layer_1\"",
              "signal": "brush_x[1]"
            },
            {"value": 0}
          ],
          "y2": [
            {
              "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"layer_1\"",
              "signal": "brush_y[1]"
            },
            {"value": 0}
          ]
        }
      }
    },
    {
      "name": "layer_0_marks",
      "type": "shape",
      "style": ["geoshape"],
      "interactive": false,
      "from": {"data": "source_0"},
      "encode": {
        "update": {
          "fill": {"value": "lightgray"},
          "stroke": {"value": "white"},
          "ariaRoleDescription": {"value": "geoshape"}
        }
      },
      "transform": [{"type": "geoshape", "projection": "projection"}]
    },
    {
      "name": "layer_1_marks",
      "type": "symbol",
      "style": ["circle"],
      "interactive": true,
      "from": {"data": "source_1"},
      "encode": {
        "update": {
          "opacity": {"value": 0.7},
          "fill": [
            {
              "test": "!(length(data(\"brush_store\"))) || (vlSelectionIdTest(\"brush_store\", datum))",
              "value": "red"
            },
            {"value": "steelblue"}
          ],
          "ariaRoleDescription": {"value": "circle"},
          "description": {
            "signal": "\"longitude: \" + (format(datum[\"longitude\"], \"\")) + \"; latitude: \" + (format(datum[\"latitude\"], \"\"))"
          },
          "x": {"field": "layer_1_x"},
          "y": {"field": "layer_1_y"},
          "size": {"value": 10},
          "shape": {"value": "circle"}
        }
      }
    },
    {
      "name": "brush_brush",
      "type": "rect",
      "clip": true,
      "encode": {
        "enter": {"fill": {"value": "transparent"}},
        "update": {
          "x": [
            {
              "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"layer_1\"",
              "signal": "brush_x[0]"
            },
            {"value": 0}
          ],
          "y": [
            {
              "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"layer_1\"",
              "signal": "brush_y[0]"
            },
            {"value": 0}
          ],
          "x2": [
            {
              "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"layer_1\"",
              "signal": "brush_x[1]"
            },
            {"value": 0}
          ],
          "y2": [
            {
              "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"layer_1\"",
              "signal": "brush_y[1]"
            },
            {"value": 0}
          ],
          "stroke": [
            {
              "test": "brush_x[0] !== brush_x[1] && brush_y[0] !== brush_y[1]",
              "value": "white"
            },
            {"value": null}
          ]
        }
      }
    }
  ]
}
```
</details>

For the spec above, I'll call out the specific places these new functions are being used:

1. To map from an array of scenegraph elements (picked via the `intersect` function) to selection tuples:
```json 
    {
      "name": "brush_tuple",
      "update": "vlSelectionTuples(intersect([[brush_x[0], brush_y[0]],[brush_x[1], brush_y[1]]], {markname: \"layer_1_marks\"}, unit.mark), {unit: \"layer_1\", fields: [brush_tuple_fields[0]]})"
    }
```
2. Selection tuples are then sorted by their IDs:
```json
"data": [
    {
      "name": "brush_store",
      "transform": [
        {"type": "formula", "expr": "datum.values[0]", "as": "_vgsid_"},
        {"type": "collect", "sort": {"field": "_vgsid_"}}
      ]
```
3. And finally, we use `vlSelectionIdTest` to do a binary search over this dataset:
```json
{
      "name": "layer_1_marks",
      "type": "symbol",
      "style": ["circle"],
      "interactive": true,
      "from": {"data": "source_1"},
      "encode": {
        "update": {
          "opacity": {"value": 0.7},
          "fill": [
            {
              "test": "!(length(data(\"brush_store\"))) || (vlSelectionIdTest(\"brush_store\", datum))",
              "value": "red"
            },
            {"value": "steelblue"}
          ]
```