### PR TITLE
refactor: import only default from JSON files for webpack 5

### DIFF
--- a/packages/vega/index.js
+++ b/packages/vega/index.js
@@ -1,6 +1,6 @@
 // -- Transforms -----
 
-import package from './package.json';
+import pkg from './package.json';
 import {extend} from 'vega-util';
 import {transforms} from 'vega-dataflow';
 import * as tx from 'vega-transforms';
@@ -22,7 +22,7 @@ extend(
 
 // -- Exports -----
 
-export const version = package.version;
+export const version = pkg.version;
 
 export * from 'vega-statistics';
 

--- a/packages/vega/index.js
+++ b/packages/vega/index.js
@@ -1,5 +1,6 @@
 // -- Transforms -----
 
+import package from './package.json';
 import {extend} from 'vega-util';
 import {transforms} from 'vega-dataflow';
 import * as tx from 'vega-transforms';
@@ -21,9 +22,7 @@ extend(
 
 // -- Exports -----
 
-export {
-  version
-} from './package.json';
+export const version = package.version;
 
 export * from 'vega-statistics';
 


### PR DESCRIPTION
Webpack no longer supports using named exports from JSON modules (https://webpack.js.org/migrate/5/#cleanup-the-code)

It looks like a similar update was made in vega-lite here https://github.com/vega/vega-lite/pull/7029