### PR TITLE
fix xmlns namespace

### DIFF
--- a/packages/vega-scenegraph/src/SVGRenderer.js
+++ b/packages/vega-scenegraph/src/SVGRenderer.js
@@ -44,7 +44,9 @@ inherits(SVGRenderer, Renderer, {
 
     if (el) {
       this._svg = domChild(el, 0, 'svg', ns);
-      setAttributes(this._svg, metadata);
+      this._svg.setAttributeNS(ns, 'xmlns', metadata['xmlns']);
+      this._svg.setAttributeNS(ns, 'xmlns:xlink', metadata['xmlns:xlink']);
+      this._svg.setAttribute('version', metadata['version']);
       this._svg.setAttribute('class', 'marks');
       domClear(el, 1);
 


### PR DESCRIPTION
For context, please see:

https://talk.observablehq.com/t/svg-export-from-a-vega-lite-api-chart-error-on-opening-the-file/4398/7

I didn’t touch SVGStringRenderer.js or image.js, which also reference this metadata without regard to namespaces; it might be good to fix those too, but if they’re just strictly for serialization, it might not matter.

Fixes vega/vega-lite-api#213.