### PR TITLE
fix: do not run hasSignal on data

### DIFF
--- a/packages/vega-parser/src/parsers/data.js
+++ b/packages/vega-parser/src/parsers/data.js
@@ -1,7 +1,7 @@
 import parseTransform from './transform';
 import parseTrigger from './trigger';
 import {Collect, Load, Relay, Sieve} from '../transforms';
-import {hasSignal, ref} from '../util';
+import {hasSignal, isSignal, ref} from '../util';
 import {array} from 'vega-util';
 
 export default function parseData(data, scope) {
@@ -34,8 +34,8 @@ function analyze(data, scope, ops) {
 
   if (data.values) {
     // hard-wired input data set
-    if (hasSignal(data.values) || hasSignal(data.format)) {
-      // if either values or format has signal, use dynamic loader
+    if (isSignal(data.values) || hasSignal(data.format)) {
+      // if either values is signal or format has signal, use dynamic loader
       output.push(load(scope, data));
       output.push(source = collect());
     } else {


### PR DESCRIPTION
data could be deeply nested, large, or have nulls

After this change, this code runs (before we get an error `TypeError: Cannot read property 'type' of null`, see https://observablehq.com/@vega/vega-lite-and-apache-arrow-no-plugin).

```ts
const url =
    "https://gist.githubusercontent.com/domoritz/0f53a5abde95564c36dfaac623a7a922/raw/cce3719b853e25d5dfff97a270283ba83af3c0e6/flights-10k.arrow";

const data = await Arrow.Table.from(fetch(url));

vegaEmbed("#vis", {
    width: 500,
    data: { values: data },
    mark: "point",
    encoding: {
        x: { field: "AIR_TIME", type: "quantitative" },
        y: { field: "ARR_DELAY", type: "quantitative" },
    },
});
```