### PR TITLE
fix: add "method" to LabelTransform

### DIFF
--- a/packages/vega-typings/types/spec/transform.d.ts
+++ b/packages/vega-typings/types/spec/transform.d.ts
@@ -506,6 +506,7 @@ export interface LabelTransform {
   lineAnchor?: 'begin' | 'end' | SignalRef;
   avoidBaseMark?: boolean | SignalRef;
   avoidMarks?: string[];
+  method?: 'naive' | 'reduced-search' | 'floodfill';
   as?: Vector7<string | SignalRef> | SignalRef;
 }
 


### PR DESCRIPTION
We allow users to specify `method` in label transform when labeling area. So, I added `method` to `LabelTransform`