### PR TITLE
chore: use ecmaVersion 2020 in eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,7 +8,7 @@ module.exports = {
     node: true
   },
   parserOptions: {
-    ecmaVersion: 2018,
+    ecmaVersion: 2020,
     sourceType: 'module'
   },
   rules: {


### PR DESCRIPTION
Needed to support nullish coalescing: https://eslint.org/blog/2020/06/eslint-v7.2.0-released. 