### PR TITLE
Add signal binding to external input element.

### DIFF
--- a/packages/vega-schema/src/bind.js
+++ b/packages/vega-schema/src/bind.js
@@ -39,7 +39,12 @@ const bind = oneOf(
     element: elementRef,
     debounce: numberType,
     name: stringType
-  }, true)
+  }, true),
+  object({
+    _element_: elementRef,
+    event: stringType,
+    debounce: numberType
+  })
 );
 
 export default {

--- a/packages/vega-typings/types/spec/bind.d.ts
+++ b/packages/vega-typings/types/spec/bind.d.ts
@@ -24,4 +24,9 @@ export interface BindRange extends BaseBinding {
   max?: number;
   step?: number;
 }
-export type Binding = BindCheckbox | BindRadioSelect | BindRange | InputBinding;
+export interface DirectBinding {
+  element: Element | EventTarget;
+  event?: string;
+  debounce?: number;
+}
+export type Binding = BindCheckbox | BindRadioSelect | BindRange | InputBinding | DirectBinding;

--- a/packages/vega-view/src/bind.js
+++ b/packages/vega-view/src/bind.js
@@ -31,7 +31,7 @@ export default function(view, el, binding) {
       active: false,
       set: null,
       update: value => {
-        if (value !== view.signal(param.signal)) {
+        if (value != view.signal(param.signal)) {
           view.runAsync(null, () => {
             bind.source = true;
             view.signal(param.signal, value);
@@ -44,7 +44,9 @@ export default function(view, el, binding) {
     }
   }
 
-  generate(bind, el, param, view.signal(param.signal));
+  (param.input == null && param.element ? target : generate)(
+    bind, el, param, view.signal(param.signal)
+  );
 
   if (!bind.active) {
     view.on(view._signals[param.signal], null, () => {
@@ -56,6 +58,29 @@ export default function(view, el, binding) {
   }
 
   return bind;
+}
+
+/**
+ * Bind the signal to an existing EventTarget.
+ */
+function target(bind, node, param, value) {
+  // initialize state
+  if (value !== undefined) {
+    node.value = value;
+  }
+
+  // listen for changes on the element
+  node.addEventListener('input', () => bind.update(node.value));
+
+  // propagate change to element
+  bind.set = value => {
+    node.value = value;
+    node.dispatchEvent(event(param.event || 'input'));
+  };
+}
+
+function event(type) {
+  return typeof Event !== 'undefined' ? new Event(type) : { type };
 }
 
 /**

--- a/packages/vega-view/src/initialize.js
+++ b/packages/vega-view/src/initialize.js
@@ -30,12 +30,12 @@ export default function(el, elBind) {
 
   // initialize signal bindings
   if (el && config !== 'none') {
-    elBind = elBind ? (view._elBind = lookup(view, elBind))
+    elBind = elBind ? (view._elBind = lookup(view, elBind, true))
       : el.appendChild(element('form', {'class': 'vega-bindings'}));
 
     view._bind.forEach(_ => {
       if (_.param.element && config !== 'container') {
-        _.element = lookup(view, _.param.element);
+        _.element = lookup(view, _.param.element, !!_.param.input);
       }
     });
 
@@ -47,7 +47,7 @@ export default function(el, elBind) {
   return view;
 }
 
-function lookup(view, el) {
+function lookup(view, el, clear) {
   if (typeof el === 'string') {
     if (typeof document !== 'undefined') {
       el = document.querySelector(el);
@@ -60,7 +60,7 @@ function lookup(view, el) {
       return null;
     }
   }
-  if (el) {
+  if (el && clear) {
     try {
       el.innerHTML = '';
     } catch (e) {

--- a/packages/vega/test/web/bind-external.html
+++ b/packages/vega/test/web/bind-external.html
@@ -1,0 +1,100 @@
+<!DOCTYPE HTML>
+<html>
+  <head>
+    <title>Vega Bind External Element Test</title>
+    <script src="../../build/vega.min.js"></script>
+    <style>
+      body { margin: 10px; font: 14px Helvetica Neue; }
+      canvas, svg { border: 1px solid #ccc; }
+    </style>
+  </head>
+  <body>
+    <div>
+      Bar Width: <input id="slider" type="range" min="1" value="10" max="50"></input>
+    </div>
+    <div id="view"></div>
+    <script>
+const spec = {
+  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "width": 400,
+  "height": 200,
+  "padding": 5,
+
+  "signals": [
+    {
+      "name": "barWidth",
+      "value": 18,
+      "bind": {"element": "#slider"}
+    }
+  ],
+
+  "data": [
+    {
+      "name": "table",
+      "values": [
+        {"u": 1,  "v": 28}, {"u": 2,  "v": 55},
+        {"u": 3,  "v": 43}, {"u": 4,  "v": 91},
+        {"u": 5,  "v": 81}, {"u": 6,  "v": 53},
+        {"u": 7,  "v": 19}, {"u": 8,  "v": 87},
+        {"u": 9,  "v": 52}, {"u": 10, "v": 48},
+        {"u": 11, "v": 24}, {"u": 12, "v": 49},
+        {"u": 13, "v": 87}, {"u": 14, "v": 66},
+        {"u": 15, "v": 17}, {"u": 16, "v": 27},
+        {"u": 17, "v": 68}, {"u": 18, "v": 16},
+        {"u": 19, "v": 49}, {"u": 20, "v": 15}
+      ]
+    }
+  ],
+
+  "scales": [
+    {
+      "name": "xscale",
+      "type": "band",
+      "range": "width",
+      "padding": 0.05,
+      "round": true,
+      "domain": {"data": "table", "field": "u"}
+    },
+    {
+      "name": "yscale",
+      "type": "linear",
+      "range": "height",
+      "domain": {"data": "table", "field": "v"},
+      "zero": true,
+      "nice": true
+    }
+  ],
+
+  "axes": [
+    {"orient": "bottom", "scale": "xscale", "zindex": 1},
+    {"orient": "left", "scale": "yscale", "zindex": 1}
+  ],
+
+  "marks": [
+    {
+      "type": "rect",
+      "from": {"data": "table"},
+      "encode": {
+        "enter": {
+          "y": {"scale": "yscale", "field": "v"},
+          "y2": {"scale": "yscale", "value": 0}
+        },
+        "update": {
+          "fill": {"value": "steelblue"},
+          "xc": {"scale": "xscale", "field": "u", "band": 0.5},
+          "width": {"signal": "barWidth"}
+        },
+        "hover": {
+          "fill": {"value": "red"}
+        }
+      }
+    }
+  ]
+};
+
+const runtimeSpec = vega.parse(spec);
+const view = new vega.View(runtimeSpec, {container: '#view', hover: true});
+view.runAsync();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
When binding signals to input elements, Vega typically generates its own HTML input elements within a given container. This PR add supports for binding _directly_ to an existing input element by specifying the `element` property of a binding but _not_ the `input` type. This `element` entry must expose a `value` property and support the [`EventTarget` interface](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget) (or be a CSS selector for such an element).

This approach should support binding to an Observable cell containing an input element, for example using signal syntax such as: `bind: { element: viewof inputCell }`.

**vega**
- Add web test for external element binding.

**vega-schema**
- Add signal binding to external input element.

**vega-typings**
- Add signal binding to external input element.

**vega-view**
- Add signal binding to external input element.