### PR TITLE
Update documentation in typings.

### DIFF
--- a/packages/vega-typings/package.json
+++ b/packages/vega-typings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vega-typings",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "description": "Typings for Vega.",
   "types": "types",
   "repository": "vega/vega",

--- a/packages/vega-typings/package.json
+++ b/packages/vega-typings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vega-typings",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "Typings for Vega.",
   "types": "types",
   "repository": "vega/vega",

--- a/packages/vega-typings/types/spec/bind.d.ts
+++ b/packages/vega-typings/types/spec/bind.d.ts
@@ -1,5 +1,5 @@
 export type Element = string;
-export interface BaseBinding {
+export interface BindBase {
   /**
    * An optional CSS selector string indicating the parent element to which
    * the input element should be added. By default, all input elements are
@@ -18,7 +18,7 @@ export interface BaseBinding {
    */
   name?: string;
 }
-export interface InputBinding extends BaseBinding {
+export interface BindInput extends BindBase {
   /**
    * The type of input element to use.
    * The valid values are `"checkbox"`, `"radio"`, `"range"`, `"select"`,
@@ -35,10 +35,10 @@ export interface InputBinding extends BaseBinding {
    */
   autocomplete?: string;
 }
-export interface BindCheckbox extends BaseBinding {
+export interface BindCheckbox extends BindBase {
   input: 'checkbox';
 }
-export interface BindRadioSelect extends BaseBinding {
+export interface BindRadioSelect extends BindBase {
   input: 'radio' | 'select';
   /**
    * An array of options to select from.
@@ -51,7 +51,7 @@ export interface BindRadioSelect extends BaseBinding {
    */
   labels?: string[];
 }
-export interface BindRange extends BaseBinding {
+export interface BindRange extends BindBase {
   input: 'range';
   /**
    * Sets the minimum slider value. Defaults to the smaller of the signal value and `0`.
@@ -67,7 +67,7 @@ export interface BindRange extends BaseBinding {
    */
   step?: number;
 }
-export interface DirectBinding {
+export interface BindDirect {
   /**
    * An input element that exposes a _value_ property and supports the
    * [EventTarget](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget)
@@ -89,4 +89,4 @@ export interface DirectBinding {
    */
   debounce?: number;
 }
-export type Binding = BindCheckbox | BindRadioSelect | BindRange | InputBinding | DirectBinding;
+export type Binding = BindCheckbox | BindRadioSelect | BindRange | BindInput | BindDirect;

--- a/packages/vega-typings/types/spec/bind.d.ts
+++ b/packages/vega-typings/types/spec/bind.d.ts
@@ -1,13 +1,38 @@
 export type Element = string;
 export interface BaseBinding {
-  type?: string;
+  /**
+   * An optional CSS selector string indicating the parent element to which
+   * the input element should be added. By default, all input elements are
+   * added within the parent container of the Vega view.
+   */
   element?: Element;
+  /**
+   * If defined, delays event handling until the specified milliseconds have
+   * elapsed since the last event was fired.
+   */
   debounce?: number;
+  /**
+   * By default, the signal name is used to label input elements.
+   * This `name` property can be used instead to specify a custom
+   * label for the bound signal.
+   */
   name?: string;
 }
 export interface InputBinding extends BaseBinding {
+  /**
+   * The type of input element to use.
+   * The valid values are `"checkbox"`, `"radio"`, `"range"`, `"select"`,
+   * and any other legal [HTML form input type](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input).
+   */
   input?: string;
+  /**
+   * Text that appears in the form control when it has no value set.
+   */
   placeholder?: string;
+  /**
+   * A hint for form autofill.
+   * See the [HTML autocomplete attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete) for additional information.
+   */
   autocomplete?: string;
 }
 export interface BindCheckbox extends BaseBinding {
@@ -15,18 +40,53 @@ export interface BindCheckbox extends BaseBinding {
 }
 export interface BindRadioSelect extends BaseBinding {
   input: 'radio' | 'select';
+  /**
+   * An array of options to select from.
+   */
   options: any[];
+  /**
+   * An array of label strings to represent the `options` values. If
+   * unspecified, the `options` value will be coerced to a string and
+   * used as the label.
+   */
   labels?: string[];
 }
 export interface BindRange extends BaseBinding {
   input: 'range';
+  /**
+   * Sets the minimum slider value. Defaults to the smaller of the signal value and `0`.
+   */
   min?: number;
+  /**
+   * Sets the maximum slider value. Defaults to the larger of the signal value and `100`.
+   */
   max?: number;
+  /**
+   * Sets the minimum slider increment. If undefined, the step size will be
+   * automatically determined based on the `min` and `max` values.
+   */
   step?: number;
 }
 export interface DirectBinding {
+  /**
+   * An input element that exposes a _value_ property and supports the
+   * [EventTarget](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget)
+   * interface, or a CSS selector string to such an element. When the element
+   * updates and dispatches an event, the _value_ property will be used as the
+   * new, bound signal value. When the signal updates independent of the
+   * element, the _value_ property will be set to the signal value and a new
+   * event will be dispatched on the element.
+   */
   element: Element | EventTarget;
+  /**
+   * The event (default `"input"`) to listen for to track changes on the
+   * external element.
+   */
   event?: string;
+  /**
+   * If defined, delays event handling until the specified milliseconds have
+   * elapsed since the last event was fired.
+   */
   debounce?: number;
 }
 export type Binding = BindCheckbox | BindRadioSelect | BindRange | InputBinding | DirectBinding;

--- a/packages/vega-typings/types/spec/projection.d.ts
+++ b/packages/vega-typings/types/spec/projection.d.ts
@@ -83,25 +83,85 @@ export interface BaseProjection {
    * GeoJSON data to which the projection should attempt to automatically fit the `translate` and `scale` parameters. If object-valued, this parameter should be a GeoJSON Feature or FeatureCollection. If array-valued, each array member may be a GeoJSON Feature, FeatureCollection, or a sub-array of GeoJSON Features.
    */
   fit?: Fit | Fit[] | SignalRef;
+
   /*
    * Used in conjunction with fit, provides the pixel area to which the projection should be automatically fit.
    */
   extent?: Vector2<Vector2<number | SignalRef>> | SignalRef;
+
   /*
    * Used in conjunction with fit, provides the width and height in pixels of the area to which the projection should be automatically fit.
    */
   size?: Vector2<number | SignalRef> | SignalRef;
 
   // TODO: use a union tagged by the projection type to determine which of the following is applicable
-  /* The following properties are all supported for specific types of projections. Consult the d3-geo-projection library for more information: https://github.com/d3/d3-geo-projection */
+  // The following properties are all supported for specific types of projections. Consult the d3-geo-projection library for more information: https://github.com/d3/d3-geo-projection.
+
+  /**
+   * The coefficient parameter for the `hammer` projection.
+   *
+   * __Default value:__ `2`
+   */
   coefficient?: number | SignalRef;
+
+  /**
+   * For the `satellite` projection, the distance from the center of the
+   * sphere to the point of view, as a proportion of the sphere’s radius.
+   * The recommended maximum clip angle for a given `distance` is
+   * acos(1 / distance) converted to degrees. If tilt is also
+   * applied, then more conservative clipping may be necessary.
+   *
+   * __Default value:__ `2.0`
+   */
   distance?: number | SignalRef;
+
+  /**
+   * The fraction parameter for the `bottomley` projection.
+   *
+   * __Default value:__ `0.5`, corresponding to a sin(ψ) where ψ = π/6.
+   */
   fraction?: number | SignalRef;
+
+  /**
+   * The number of lobes in projections that support multi-lobe views:
+   * `berghaus`, `gingery`, or `healpix`.
+   * The default value varies based on the projection type.
+   */
   lobes?: number | SignalRef;
+
+  /**
+   * The default parallel parameter for projections that support it:
+   * `armadillo`, `bonne`, `craig`, `cylindricalEqualArea`,
+   * `cylindricalStereographic`, `hammerRetroazimuthal`, `loximuthal`,
+   * or `rectangularPolyconic`.
+   * The default value varies based on the projection type.
+   */
   parallel?: number | SignalRef;
+
+  /**
+   * The default radius parameter for the `airy` or `gingery` projection.
+   * The default value varies based on the projection type.
+   */
   radius?: number | SignalRef;
+
+  /**
+   * The ratio parameter for the `hill`, `hufnagel`, or `wagner` projections.
+   * The default value varies based on the projection type.
+   */
   ratio?: number | SignalRef;
+
+  /**
+   * The spacing parameter for the `lagrange` projection.
+   *
+   * __Default value:__ `0.5`
+   */
   spacing?: number | SignalRef;
+
+  /**
+   * The tilt angle (in degrees) for the `satellite` projection.
+   *
+   * __Default value:__ `0`.
+   */
   tilt?: number | SignalRef;
 
   /*

--- a/packages/vega-typings/types/spec/projection.d.ts
+++ b/packages/vega-typings/types/spec/projection.d.ts
@@ -89,7 +89,7 @@ export interface BaseProjection {
    */
   extent?: Vector2<Vector2<number | SignalRef>> | SignalRef;
 
-  /*
+  /**
    * Used in conjunction with fit, provides the width and height in pixels of the area to which the projection should be automatically fit.
    */
   size?: Vector2<number | SignalRef> | SignalRef;
@@ -130,7 +130,7 @@ export interface BaseProjection {
   lobes?: number | SignalRef;
 
   /**
-   * The default parallel parameter for projections that support it:
+   * The parallel parameter for projections that support it:
    * `armadillo`, `bonne`, `craig`, `cylindricalEqualArea`,
    * `cylindricalStereographic`, `hammerRetroazimuthal`, `loximuthal`,
    * or `rectangularPolyconic`.
@@ -139,7 +139,7 @@ export interface BaseProjection {
   parallel?: number | SignalRef;
 
   /**
-   * The default radius parameter for the `airy` or `gingery` projection.
+   * The radius parameter for the `airy` or `gingery` projection.
    * The default value varies based on the projection type.
    */
   radius?: number | SignalRef;
@@ -164,12 +164,12 @@ export interface BaseProjection {
    */
   tilt?: number | SignalRef;
 
-  /*
+  /**
    * Sets whether or not the x-dimension is reflected (negated) in the output.
    */
   reflectX?: boolean | SignalRef;
 
-  /*
+  /**
    * Sets whether or not the y-dimension is reflected (negated) in the output.
    */
   reflectY?: boolean | SignalRef;


### PR DESCRIPTION
**vega-typings**

- Update typing comments for bindings and projections to fill-in missing Vega-Lite documentation.