### PR TITLE
feat: consistently name the exports from Vega and vega-expression and vega-event-selector

### DIFF
--- a/packages/vega-event-selector/index.d.ts
+++ b/packages/vega-event-selector/index.d.ts
@@ -1,1 +1,3 @@
 export function selector(selectorName: string, source: string): any[];
+
+export const parseSelector = selector;

--- a/packages/vega-event-selector/index.js
+++ b/packages/vega-event-selector/index.js
@@ -1,1 +1,4 @@
-export {default as selector} from './src/event-selector';
+export {
+    default as selector,
+    default as parseSelector
+} from './src/event-selector';

--- a/packages/vega-expression/index.d.ts
+++ b/packages/vega-expression/index.d.ts
@@ -1,5 +1,9 @@
+import { Node } from "estree";
+
 /** Parse a JavaScript *expression* string and return the resulting abstract syntax tree in the ESTree format */
-export function parse(expression: string): any;
+export function parse(expression: string):  Node.Expression | Node.SequenceExpression;
+
+export const parseExpression = parse;
 
 interface CodegenOptions {
   /** A hash of allowed top-level constant values */
@@ -38,6 +42,8 @@ export function codegen(
   /** A hash of all properties referenced outside a provided allowed list */
   globals: string[];
 };
+
+export const codegenExpression = codegen;
 
 /** An object defining default constant values for the Vega expression language */
 export const constants: { [cn: string]: string };

--- a/packages/vega-expression/index.js
+++ b/packages/vega-expression/index.js
@@ -14,7 +14,13 @@ export {
   default as ASTNode
 } from './src/ast';
 
-export { default as parse} from './src/parser';
-export { default as codegen } from './src/codegen';
+export {
+  default as parse,
+  default as parseExpression
+} from './src/parser';
+export {
+  default as codegen,
+  default as codegenExpression
+} from './src/codegen';
 export { default as functions } from './src/functions';
 export { default as constants } from './src/constants';

--- a/packages/vega-expression/package.json
+++ b/packages/vega-expression/package.json
@@ -23,6 +23,7 @@
     "prepublishOnly": "yarn test && yarn build"
   },
   "dependencies": {
-    "vega-util": "^1.16.0"
+    "vega-util": "^1.16.0",
+    "@types/estree": "^0.0.47"
   }
 }

--- a/packages/vega/index.js
+++ b/packages/vega/index.js
@@ -89,10 +89,10 @@ export {
 } from 'vega-runtime';
 
 export {
-  codegen as codegenExpression,
-  parse as parseExpression
+  codegenExpression,
+  parseExpression
 } from 'vega-expression';
 
 export {
-  selector as parseSelector
+  parseSelector
 } from 'vega-event-selector';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1841,6 +1841,11 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
 
+"@types/estree@^0.0.47":
+  version "0.0.47"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.47.tgz#d7a51db20f0650efec24cd04994f523d93172ed4"
+  integrity sha512-c5ciR06jK8u9BstrmJyO97m+klJrrhCf9u3rLu3DEAJBirxRqSCvDQoYKmxuYwQI5SZChAWu+tq9oVlGRuzPAg==
+
 "@types/minimatch@^3.0.3":
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.4.tgz#f0ec25dbf2f0e4b18647313ac031134ca5b24b21"


### PR DESCRIPTION
This change allow consumers to externalize vega-expression and vega-event-selector when they already have Vega