### PR TITLE
feat: Reference spec source in DataFlow nodes

### DIFF
--- a/packages/vega-parser/src/DataScope.js
+++ b/packages/vega-parser/src/DataScope.js
@@ -63,7 +63,7 @@ function addSortField(scope, p, sort) {
   }
 }
 
-function cache(scope, ds, name, optype, field, counts, index) {
+function cache(scope, ds, name, optype, field, counts, index, src) {
   const cache = ds[name] || (ds[name] = {}),
         sort = sortKey(counts);
 
@@ -78,10 +78,10 @@ function cache(scope, ds, name, optype, field, counts, index) {
 
   if (!v) {
     const params = counts
-      ? {field: keyFieldRef, pulse: ds.countsRef(scope, field, counts)}
+      ? {field: keyFieldRef, pulse: ds.countsRef(scope, field, counts, src)}
       : {field: scope.fieldRef(field), pulse: ref(ds.output)};
     if (sort) params.sort = scope.sortRef(counts);
-    op = scope.add(entry(optype, undefined, params));
+    op = scope.add(entry(optype, undefined, params, undefined, src));
     if (index) ds.index[field] = op;
     v = ref(op);
     if (k != null) cache[k] = v;
@@ -90,7 +90,7 @@ function cache(scope, ds, name, optype, field, counts, index) {
 }
 
 DataScope.prototype = {
-  countsRef(scope, field, sort) {
+  countsRef(scope, field, sort, src) {
     const ds = this,
           cache = ds.counts || (ds.counts = {}),
           k = fieldKey(field);
@@ -108,8 +108,8 @@ DataScope.prototype = {
         pulse: ref(ds.output)
       };
       if (sort && sort.field) addSortField(scope, p, sort);
-      a = scope.add(Aggregate(p));
-      v = scope.add(Collect({pulse: ref(a)}));
+      a = scope.add(Aggregate(p, undefined, undefined, src));
+      v = scope.add(Collect({pulse: ref(a)}, undefined, undefined, src));
       v = {agg: a, ref: ref(v)};
       if (k != null) cache[k] = v;
     } else if (sort && sort.field) {
@@ -123,16 +123,16 @@ DataScope.prototype = {
     return ref(this.values);
   },
 
-  extentRef(scope, field) {
-    return cache(scope, this, 'extent', 'extent', field, false);
+  extentRef(scope, field, src) {
+    return cache(scope, this, 'extent', 'extent', field, false, undefined, src);
   },
 
-  domainRef(scope, field) {
-    return cache(scope, this, 'domain', 'values', field, false);
+  domainRef(scope, field, src) {
+    return cache(scope, this, 'domain', 'values', field, false, undefined, src);
   },
 
-  valuesRef(scope, field, sort) {
-    return cache(scope, this, 'vals', 'values', field, sort || true);
+  valuesRef(scope, field, sort, src) {
+    return cache(scope, this, 'vals', 'values', field, sort || true, undefined, src);
   },
 
   lookupRef(scope, field) {

--- a/packages/vega-parser/src/DataScope.js
+++ b/packages/vega-parser/src/DataScope.js
@@ -43,7 +43,7 @@ function fieldKey(field) {
   return isString(field) ? field : null;
 }
 
-function addSortField(scope, p, sort) {
+function addSortField(scope, p, sort, src) {
   const as = aggrField(sort.op, sort.field);
   let s;
 
@@ -58,7 +58,7 @@ function addSortField(scope, p, sort) {
   }
   if (sort.op) {
     p.ops.push((s=sort.op.signal) ? scope.signalRef(s) : sort.op);
-    p.fields.push(scope.fieldRef(sort.field));
+    p.fields.push(scope.fieldRef(sort.field, undefined, src));
     p.as.push(as);
   }
 }
@@ -79,8 +79,8 @@ function cache(scope, ds, name, optype, field, counts, index, src) {
   if (!v) {
     const params = counts
       ? {field: keyFieldRef, pulse: ds.countsRef(scope, field, counts, src)}
-      : {field: scope.fieldRef(field), pulse: ref(ds.output)};
-    if (sort) params.sort = scope.sortRef(counts);
+      : {field: scope.fieldRef(field, undefined, src), pulse: ref(ds.output)};
+    if (sort) params.sort = scope.sortRef(counts, src);
     op = scope.add(entry(optype, undefined, params, undefined, src));
     if (index) ds.index[field] = op;
     v = ref(op);
@@ -104,16 +104,16 @@ DataScope.prototype = {
 
     if (!v) {
       p = {
-        groupby: scope.fieldRef(field, 'key'),
+        groupby: scope.fieldRef(field, 'key', src),
         pulse: ref(ds.output)
       };
-      if (sort && sort.field) addSortField(scope, p, sort);
+      if (sort && sort.field) addSortField(scope, p, sort, src);
       a = scope.add(Aggregate(p, undefined, undefined, src));
       v = scope.add(Collect({pulse: ref(a)}, undefined, undefined, src));
       v = {agg: a, ref: ref(v)};
       if (k != null) cache[k] = v;
     } else if (sort && sort.field) {
-      addSortField(scope, v.agg.params, sort);
+      addSortField(scope, v.agg.params, sort, src);
     }
 
     return v.ref;

--- a/packages/vega-parser/src/Scope.js
+++ b/packages/vega-parser/src/Scope.js
@@ -287,11 +287,11 @@ Scope.prototype = Subscope.prototype = {
     return hasOwnProperty(this.signals, name);
   },
 
-  addSignal(name, value) {
+  addSignal(name, value, src) {
     if (this.hasOwnSignal(name)) {
       error('Duplicate signal name: ' + stringValue(name));
     }
-    const op = value instanceof Entry ? value : this.add(operator(value));
+    const op = value instanceof Entry ? value : this.add(operator(value, undefined, src));
     return this.signals[name] = op;
   },
 

--- a/packages/vega-parser/src/Scope.js
+++ b/packages/vega-parser/src/Scope.js
@@ -72,8 +72,8 @@ function Subscope(scope) {
 }
 
 Scope.prototype = Subscope.prototype = {
-  parse(spec) {
-    return parseScope(spec, this);
+  parse(spec, src) {
+    return parseScope(spec, this, src);
   },
 
   fork() {
@@ -112,9 +112,9 @@ Scope.prototype = Subscope.prototype = {
     return op;
   },
 
-  proxy(op) {
+  proxy(op, src) {
     const vref = op instanceof Entry ? ref(op) : op;
-    return this.add(Proxy({value: vref}));
+    return this.add(Proxy({value: vref}, undefined, undefined, src));
   },
 
   addStream(stream) {
@@ -169,10 +169,10 @@ Scope.prototype = Subscope.prototype = {
 
   // ----
 
-  pushState(encode, parent, lookup) {
-    this._encode.push(ref(this.add(Sieve({pulse: encode}))));
+  pushState(encode, parent, lookup, src) {
+    this._encode.push(ref(this.add(Sieve({pulse: encode}, undefined, undefined, src))));
     this._parent.push(parent);
-    this._lookup.push(lookup ? ref(this.proxy(lookup)) : null);
+    this._lookup.push(lookup ? ref(this.proxy(lookup, src)) : null);
     this._markpath.push(-1);
   },
 
@@ -306,7 +306,7 @@ Scope.prototype = Subscope.prototype = {
     if (this.signals[s]) {
       return ref(this.signals[s]);
     } else if (!hasOwnProperty(this.lambdas, s)) {
-      this.lambdas[s] = this.add(operator(null));
+      this.lambdas[s] = this.add(operator(null, undefined, s));
     }
     return ref(this.lambdas[s]);
   },
@@ -353,8 +353,8 @@ Scope.prototype = Subscope.prototype = {
     this.scales[name] = this.add(transform);
   },
 
-  addScale(name, params) {
-    this.addScaleProj(name, Scale(params));
+  addScale(name, params, src) {
+    this.addScaleProj(name, Scale(params, undefined, undefined, src));
   },
 
   addProjection(name, params) {

--- a/packages/vega-parser/src/parsers/axis.js
+++ b/packages/vega-parser/src/parsers/axis.js
@@ -43,7 +43,7 @@ export default function(spec, scope) {
     minstep: scope.property(spec.tickMinStep),
     formatType: scope.property(spec.formatType),
     formatSpecifier: scope.property(spec.format)
-  })));
+  }, undefined, undefined, spec)));
 
   // generate axis marks
   const children = [];

--- a/packages/vega-parser/src/parsers/axis.js
+++ b/packages/vega-parser/src/parsers/axis.js
@@ -32,7 +32,7 @@ export default function(spec, scope) {
     domain: !!_('domain'),
     title:  spec.title != null
   };
-  const dataRef = ref(scope.add(Collect({}, [datum])));
+  const dataRef = ref(scope.add(Collect({}, [datum], undefined, spec)));
 
   // data source for axis ticks
   const ticksRef = ref(scope.add(AxisTicks({

--- a/packages/vega-parser/src/parsers/axis.js
+++ b/packages/vega-parser/src/parsers/axis.js
@@ -90,7 +90,8 @@ export default function(spec, scope) {
       interactive,
       style
     }),
-    scope
+    scope,
+    spec
   );
 }
 

--- a/packages/vega-parser/src/parsers/data.js
+++ b/packages/vega-parser/src/parsers/data.js
@@ -4,7 +4,7 @@ import {Collect, Load, Relay, Sieve} from '../transforms';
 import {hasSignal, isSignal, ref} from '../util';
 import {array} from 'vega-util';
 
-export default function parseData(data, scope, src) {
+export default function parseData(data, scope) {
   const transforms = [];
 
   if (data.transform) {
@@ -19,13 +19,13 @@ export default function parseData(data, scope, src) {
     });
   }
 
-  scope.addDataPipeline(data.name, analyze(data, scope, transforms, src));
+  scope.addDataPipeline(data.name, analyze(data, scope, transforms));
 }
 
 /**
  * Analyze a data pipeline, add needed operators.
  */
-function analyze(data, scope, ops, src) {
+function analyze(data, scope, ops) {
   const output = [];
   let source = null,
       modify = false,
@@ -36,7 +36,7 @@ function analyze(data, scope, ops, src) {
     // hard-wired input data set
     if (isSignal(data.values) || hasSignal(data.format)) {
       // if either values is signal or format has signal, use dynamic loader
-      output.push(load(scope, data, src));
+      output.push(load(scope, data));
       output.push(source = collect());
     } else {
       // otherwise, ingest upon dataflow init
@@ -49,7 +49,7 @@ function analyze(data, scope, ops, src) {
     // load data from external source
     if (hasSignal(data.url) || hasSignal(data.format)) {
       // if either url or format has signal, use dynamic loader
-      output.push(load(scope, data, src));
+      output.push(load(scope, data));
       output.push(source = collect());
     } else {
       // otherwise, request load upon dataflow init
@@ -87,7 +87,7 @@ function analyze(data, scope, ops, src) {
     output[0] = Relay({
       derive: modify,
       pulse: n ? upstream : upstream[0]
-    }, undefined, undefined, src);
+    }, undefined, undefined, data);
     if (modify || n) {
       // collect derived and multi-pulse tuples
       output.splice(1, 0, collect());
@@ -95,7 +95,7 @@ function analyze(data, scope, ops, src) {
   }
 
   if (!source) output.push(collect());
-  output.push(Sieve({}, undefined, undefined, src));
+  output.push(Sieve({}, undefined, undefined, data));
   return output;
 }
 
@@ -105,11 +105,11 @@ function collect(values) {
   return s;
 }
 
-function load(scope, data, src) {
+function load(scope, data) {
   return Load({
     url:    data.url ? scope.property(data.url) : undefined,
     async:  data.async ? scope.property(data.async) : undefined,
     values: data.values ? scope.property(data.values) : undefined,
     format: scope.objectProperty(data.format)
-  }, undefined, undefined, src);
+  }, undefined, undefined, data);
 }

--- a/packages/vega-parser/src/parsers/data.js
+++ b/packages/vega-parser/src/parsers/data.js
@@ -4,7 +4,7 @@ import {Collect, Load, Relay, Sieve} from '../transforms';
 import {hasSignal, isSignal, ref} from '../util';
 import {array} from 'vega-util';
 
-export default function parseData(data, scope) {
+export default function parseData(data, scope, src) {
   const transforms = [];
 
   if (data.transform) {
@@ -19,13 +19,13 @@ export default function parseData(data, scope) {
     });
   }
 
-  scope.addDataPipeline(data.name, analyze(data, scope, transforms));
+  scope.addDataPipeline(data.name, analyze(data, scope, transforms, src));
 }
 
 /**
  * Analyze a data pipeline, add needed operators.
  */
-function analyze(data, scope, ops) {
+function analyze(data, scope, ops, src) {
   const output = [];
   let source = null,
       modify = false,
@@ -95,7 +95,7 @@ function analyze(data, scope, ops) {
   }
 
   if (!source) output.push(collect());
-  output.push(Sieve({}));
+  output.push(Sieve({}, undefined, undefined, src));
   return output;
 }
 

--- a/packages/vega-parser/src/parsers/data.js
+++ b/packages/vega-parser/src/parsers/data.js
@@ -36,7 +36,7 @@ function analyze(data, scope, ops, src) {
     // hard-wired input data set
     if (isSignal(data.values) || hasSignal(data.format)) {
       // if either values is signal or format has signal, use dynamic loader
-      output.push(load(scope, data));
+      output.push(load(scope, data, src));
       output.push(source = collect());
     } else {
       // otherwise, ingest upon dataflow init
@@ -49,7 +49,7 @@ function analyze(data, scope, ops, src) {
     // load data from external source
     if (hasSignal(data.url) || hasSignal(data.format)) {
       // if either url or format has signal, use dynamic loader
-      output.push(load(scope, data));
+      output.push(load(scope, data, src));
       output.push(source = collect());
     } else {
       // otherwise, request load upon dataflow init
@@ -87,7 +87,7 @@ function analyze(data, scope, ops, src) {
     output[0] = Relay({
       derive: modify,
       pulse: n ? upstream : upstream[0]
-    });
+    }, undefined, undefined, src);
     if (modify || n) {
       // collect derived and multi-pulse tuples
       output.splice(1, 0, collect());
@@ -105,11 +105,11 @@ function collect(values) {
   return s;
 }
 
-function load(scope, data) {
+function load(scope, data, src) {
   return Load({
     url:    data.url ? scope.property(data.url) : undefined,
     async:  data.async ? scope.property(data.async) : undefined,
     values: data.values ? scope.property(data.values) : undefined,
     format: scope.objectProperty(data.format)
-  });
+  }, undefined, undefined, src);
 }

--- a/packages/vega-parser/src/parsers/legend.js
+++ b/packages/vega-parser/src/parsers/legend.js
@@ -63,7 +63,7 @@ export default function(spec, scope) {
     minstep: scope.property(spec.tickMinStep),
     formatType: scope.property(spec.formatType),
     formatSpecifier: scope.property(spec.format)
-  })));
+  }, undefined, undefined, spec)));
 
   // continuous gradient legend
   if (type === Gradient) {
@@ -127,7 +127,8 @@ export default function(spec, scope) {
       interactive,
       style
     }),
-    scope
+    scope,
+    spec
   );
 }
 

--- a/packages/vega-parser/src/parsers/mark.js
+++ b/packages/vega-parser/src/parsers/mark.js
@@ -15,7 +15,7 @@ import {fieldRef, isSignal, ref} from '../util';
 import {error} from 'vega-util';
 import {Bound, Collect, DataJoin, Encode, Mark, Overlap, Render, Sieve, SortItems, ViewLayout} from '../transforms';
 
-export default function(spec, scope) {
+export default function(spec, scope, src) {
   const role = getRole(spec),
         group = spec.type === GroupMark,
         facet = spec.from && spec.from.facet,
@@ -50,7 +50,7 @@ export default function(spec, scope) {
     parent:      scope.signals.parent ? scope.signalRef('parent') : null,
     index:       scope.markpath(),
     pulse:       ref(op)
-  }));
+  }, undefined, undefined, src));
   const markRef = ref(op);
 
   // add visual encoders

--- a/packages/vega-parser/src/parsers/mark.js
+++ b/packages/vega-parser/src/parsers/mark.js
@@ -15,7 +15,7 @@ import {fieldRef, isSignal, ref} from '../util';
 import {error} from 'vega-util';
 import {Bound, Collect, DataJoin, Encode, Mark, Overlap, Render, Sieve, SortItems, ViewLayout} from '../transforms';
 
-export default function(spec, scope) {
+export default function(spec, scope, src) {
   const role = getRole(spec),
         group = spec.type === GroupMark,
         facet = spec.from && spec.from.facet,
@@ -27,18 +27,18 @@ export default function(spec, scope) {
   const nested = role === MarkRole || layout || facet;
 
   // resolve input data
-  const input = parseData(spec.from, group, scope, spec);
+  const input = parseData(spec.from, group, scope, src);
 
   // data join to map tuples to visual items
   op = scope.add(DataJoin({
     key:   input.key || (spec.key ? fieldRef(spec.key) : undefined),
     pulse: input.pulse,
     clean: !group
-  }, undefined, undefined, spec));
+  }, undefined, undefined, src));
   const joinRef = ref(op);
 
   // collect visual items
-  op = store = scope.add(Collect({pulse: joinRef}, undefined, undefined, spec));
+  op = store = scope.add(Collect({pulse: joinRef}, undefined, undefined, src));
 
   // connect visual items to scenegraph
   op = scope.add(Mark({
@@ -50,14 +50,14 @@ export default function(spec, scope) {
     parent:      scope.signals.parent ? scope.signalRef('parent') : null,
     index:       scope.markpath(),
     pulse:       ref(op)
-  }, undefined, undefined, spec));
+  }, undefined, undefined, src));
   const markRef = ref(op);
 
   // add visual encoders
   op = enc = scope.add(Encode(parseEncode(
     spec.encode, spec.type, role, spec.style, scope,
     {mod: false, pulse: markRef}
-  ), undefined, undefined, spec));
+  ), undefined, undefined, src));
 
   // monitor parent marks to propagate changes
   op.params.parent = scope.encode();
@@ -79,9 +79,9 @@ export default function(spec, scope) {
   // if item sort specified, perform post-encoding
   if (spec.sort) {
     op = scope.add(SortItems({
-      sort:  scope.compareRef(spec.sort, spec),
+      sort:  scope.compareRef(spec.sort, src),
       pulse: ref(op)
-    }, undefined, undefined, spec));
+    }, undefined, undefined, src));
   }
 
   const encodeRef = ref(op);
@@ -93,12 +93,12 @@ export default function(spec, scope) {
       legends:  scope.legends,
       mark:     markRef,
       pulse:    encodeRef
-    }, undefined, undefined, spec));
+    }, undefined, undefined, src));
     layoutRef = ref(layout);
   }
 
   // compute bounding boxes
-  const bound = scope.add(Bound({mark: markRef, pulse: layoutRef || encodeRef}, undefined, undefined, spec));
+  const bound = scope.add(Bound({mark: markRef, pulse: layoutRef || encodeRef}, undefined, undefined, src));
   boundRef = ref(bound);
 
   // if group mark, recurse to parse nested content
@@ -106,7 +106,7 @@ export default function(spec, scope) {
     // juggle layout & bounds to ensure they run *after* any faceting transforms
     if (nested) { ops = scope.operators; ops.pop(); if (layout) ops.pop(); }
 
-    scope.pushState(encodeRef, layoutRef || boundRef, joinRef, spec);
+    scope.pushState(encodeRef, layoutRef || boundRef, joinRef, src);
     facet ? parseFacet(spec, scope, input)          // explicit facet
         : nested ? parseSubflow(spec, scope, input) // standard mark group
         : scope.parse(spec); // guide group, we can avoid nested scopes
@@ -117,12 +117,12 @@ export default function(spec, scope) {
 
   // if requested, add overlap removal transform
   if (overlap) {
-    boundRef = parseOverlap(overlap, boundRef, scope, spec);
+    boundRef = parseOverlap(overlap, boundRef, scope, src);
   }
 
   // render / sieve items
-  const render = scope.add(Render({pulse: boundRef}, undefined, undefined, spec)),
-        sieve = scope.add(Sieve({pulse: ref(render)}, undefined, scope.parent(), spec));
+  const render = scope.add(Render({pulse: boundRef}, undefined, undefined, src)),
+        sieve = scope.add(Sieve({pulse: ref(render)}, undefined, scope.parent(), src));
 
   // if mark is named, make accessible as reactive geometry
   // add trigger updates if defined

--- a/packages/vega-parser/src/parsers/mark.js
+++ b/packages/vega-parser/src/parsers/mark.js
@@ -34,11 +34,11 @@ export default function(spec, scope, src) {
     key:   input.key || (spec.key ? fieldRef(spec.key) : undefined),
     pulse: input.pulse,
     clean: !group
-  }));
+  }, undefined, undefined, src));
   const joinRef = ref(op);
 
   // collect visual items
-  op = store = scope.add(Collect({pulse: joinRef}));
+  op = store = scope.add(Collect({pulse: joinRef}, undefined, undefined, src));
 
   // connect visual items to scenegraph
   op = scope.add(Mark({

--- a/packages/vega-parser/src/parsers/mark.js
+++ b/packages/vega-parser/src/parsers/mark.js
@@ -79,7 +79,7 @@ export default function(spec, scope) {
   // if item sort specified, perform post-encoding
   if (spec.sort) {
     op = scope.add(SortItems({
-      sort:  scope.compareRef(spec.sort),
+      sort:  scope.compareRef(spec.sort, spec),
       pulse: ref(op)
     }, undefined, undefined, spec));
   }
@@ -117,7 +117,7 @@ export default function(spec, scope) {
 
   // if requested, add overlap removal transform
   if (overlap) {
-    boundRef = parseOverlap(overlap, boundRef, scope);
+    boundRef = parseOverlap(overlap, boundRef, scope, spec);
   }
 
   // render / sieve items
@@ -138,7 +138,7 @@ export default function(spec, scope) {
   }
 }
 
-function parseOverlap(overlap, source, scope) {
+function parseOverlap(overlap, source, scope, src) {
   const method = overlap.method,
         bound = overlap.bound,
         sep = overlap.separation;
@@ -150,7 +150,7 @@ function parseOverlap(overlap, source, scope) {
   };
 
   if (overlap.order) {
-    params.sort = scope.compareRef({field: overlap.order});
+    params.sort = scope.compareRef({field: overlap.order}, src);
   }
 
   if (bound) {
@@ -160,5 +160,5 @@ function parseOverlap(overlap, source, scope) {
     params.boundOrient = bound.orient;
   }
 
-  return ref(scope.add(Overlap(params)));
+  return ref(scope.add(Overlap(params, undefined, undefined, src)));
 }

--- a/packages/vega-parser/src/parsers/marks/data.js
+++ b/packages/vega-parser/src/parsers/marks/data.js
@@ -3,12 +3,12 @@ import {Collect} from '../../transforms';
 import {ref} from '../../util';
 import {array, error, extend} from 'vega-util';
 
-export default function(from, group, scope) {
+export default function(from, group, scope, src) {
   let facet, key, op, dataRef, parent;
 
   // if no source data, generate singleton datum
   if (!from) {
-    dataRef = ref(scope.add(Collect(null, [{}])));
+    dataRef = ref(scope.add(Collect(null, [{}], undefined, src)));
   }
 
   // if faceted, process facet specification
@@ -25,14 +25,14 @@ export default function(from, group, scope) {
           type:    'aggregate',
           groupby: array(facet.groupby)
         }, facet.aggregate), scope);
-        op.params.key = scope.keyRef(facet.groupby);
+        op.params.key = scope.keyRef(facet.groupby, undefined, src);
         op.params.pulse = getDataRef(facet, scope);
         dataRef = parent = ref(scope.add(op));
       } else {
         parent = ref(scope.getData(from.data).aggregate);
       }
 
-      key = scope.keyRef(facet.groupby, true);
+      key = scope.keyRef(facet.groupby, true, src);
     }
   }
 

--- a/packages/vega-parser/src/parsers/marks/facet.js
+++ b/packages/vega-parser/src/parsers/marks/facet.js
@@ -21,13 +21,13 @@ export default function(spec, scope, group) {
     op = scope.add(PreFacet({
       field: scope.fieldRef(facet.field),
       pulse: data
-    }));
+    }, undefined, undefined, spec));
   } else if (facet.groupby) {
     op = scope.add(Facet({
       key:   scope.keyRef(facet.groupby),
-      group: ref(scope.proxy(group.parent)),
+      group: ref(scope.proxy(group.parent, spec)),
       pulse: data
-    }));
+    }, undefined, undefined, spec));
   } else {
     error('Facet must specify groupby or field: ' + stringValue(facet));
   }
@@ -35,7 +35,7 @@ export default function(spec, scope, group) {
   // initialize facet subscope
   const subscope = scope.fork(),
         source = subscope.add(Collect()),
-        values = subscope.add(Sieve({pulse: ref(source)}));
+        values = subscope.add(Sieve({pulse: ref(source)}, undefined, undefined, spec));
   subscope.addData(name, new DataScope(subscope, source, source, values));
   subscope.addSignal('parent', null, spec);
 

--- a/packages/vega-parser/src/parsers/marks/facet.js
+++ b/packages/vega-parser/src/parsers/marks/facet.js
@@ -37,7 +37,7 @@ export default function(spec, scope, group) {
         source = subscope.add(Collect()),
         values = subscope.add(Sieve({pulse: ref(source)}));
   subscope.addData(name, new DataScope(subscope, source, source, values));
-  subscope.addSignal('parent', null);
+  subscope.addSignal('parent', null, spec);
 
   // parse faceted subflow
   op.params.subflow = {

--- a/packages/vega-parser/src/parsers/marks/facet.js
+++ b/packages/vega-parser/src/parsers/marks/facet.js
@@ -19,12 +19,12 @@ export default function(spec, scope, group) {
 
   if (facet.field) {
     op = scope.add(PreFacet({
-      field: scope.fieldRef(facet.field),
+      field: scope.fieldRef(facet.field, undefined, spec),
       pulse: data
     }, undefined, undefined, spec));
   } else if (facet.groupby) {
     op = scope.add(Facet({
-      key:   scope.keyRef(facet.groupby),
+      key:   scope.keyRef(facet.groupby, undefined, spec),
       group: ref(scope.proxy(group.parent, spec)),
       pulse: data
     }, undefined, undefined, spec));
@@ -34,7 +34,7 @@ export default function(spec, scope, group) {
 
   // initialize facet subscope
   const subscope = scope.fork(),
-        source = subscope.add(Collect()),
+        source = subscope.add(Collect(undefined, undefined, undefined, spec)),
         values = subscope.add(Sieve({pulse: ref(source)}, undefined, undefined, spec));
   subscope.addData(name, new DataScope(subscope, source, source, values));
   subscope.addSignal('parent', null, spec);

--- a/packages/vega-parser/src/parsers/marks/subflow.js
+++ b/packages/vega-parser/src/parsers/marks/subflow.js
@@ -1,10 +1,10 @@
 import {PreFacet, Sieve} from '../../transforms';
 
 export default function(spec, scope, input) {
-  const op = scope.add(PreFacet({pulse: input.pulse})),
+  const op = scope.add(PreFacet({pulse: input.pulse}, undefined, undefined, spec)),
         subscope = scope.fork();
 
-  subscope.add(Sieve());
+  subscope.add(Sieve(undefined, undefined, undefined, spec));
   subscope.addSignal('parent', null);
 
   // parse group mark subflow

--- a/packages/vega-parser/src/parsers/projection.js
+++ b/packages/vega-parser/src/parsers/projection.js
@@ -6,21 +6,21 @@ export default function(proj, scope) {
 
   for (const name in proj) {
     if (name === 'name') continue;
-    params[name] = parseParameter(proj[name], name, scope);
+    params[name] = parseParameter(proj[name], name, scope, proj);
   }
 
   // apply projection defaults from config
   for (const name in config) {
     if (params[name] == null) {
-      params[name] = parseParameter(config[name], name, scope);
+      params[name] = parseParameter(config[name], name, scope, proj);
     }
   }
 
-  scope.addProjection(proj.name, params);
+  scope.addProjection(proj.name, params, proj);
 }
 
-function parseParameter(_, name, scope) {
-  return isArray(_) ? _.map(_ => parseParameter(_, name, scope))
+function parseParameter(_, name, scope, src) {
+  return isArray(_) ? _.map(_ => parseParameter(_, name, scope, src))
     : !isObject(_) ? _
     : _.signal ? scope.signalRef(_.signal)
     : name === 'fit' ? _

--- a/packages/vega-parser/src/parsers/scale.js
+++ b/packages/vega-parser/src/parsers/scale.js
@@ -145,7 +145,7 @@ function ordinalMultipleDomain(domain, scope, fields, src) {
     a = sort.op || 'count';
     v = sort.field ? aggrField(a, sort.field) : 'count';
     p.ops = [MULTIDOMAIN_SORT_OPS[a]];
-    p.fields = [scope.fieldRef(v)];
+    p.fields = [scope.fieldRef(v, undefined, src)];
     p.as = [v];
   }
   a = scope.add(Aggregate(p, undefined, undefined, src));
@@ -156,9 +156,9 @@ function ordinalMultipleDomain(domain, scope, fields, src) {
   // extract values for combined domain
   v = scope.add(Values({
     field: keyFieldRef,
-    sort:  scope.sortRef(sort),
+    sort:  scope.sortRef(sort, src),
     pulse: ref(c)
-  }));
+  }, undefined, undefined, src));
 
   return ref(v);
 }

--- a/packages/vega-parser/src/parsers/scope.js
+++ b/packages/vega-parser/src/parsers/scope.js
@@ -23,7 +23,7 @@ export default function(spec, scope, preprocessed) {
   scales.forEach(_ => initScale(_, scope));
 
   // parse data sources
-  array(spec.data).forEach(_ => parseData(_, scope, _));
+  array(spec.data).forEach(_ => parseData(_, scope));
 
   // parse scale definitions
   scales.forEach(_ => parseScale(_, scope));

--- a/packages/vega-parser/src/parsers/scope.js
+++ b/packages/vega-parser/src/parsers/scope.js
@@ -23,7 +23,7 @@ export default function(spec, scope, preprocessed) {
   scales.forEach(_ => initScale(_, scope));
 
   // parse data sources
-  array(spec.data).forEach(_ => parseData(_, scope, spec));
+  array(spec.data).forEach(_ => parseData(_, scope, _));
 
   // parse scale definitions
   scales.forEach(_ => parseScale(_, scope));
@@ -35,7 +35,7 @@ export default function(spec, scope, preprocessed) {
   array(spec.axes).forEach(_ => parseAxis(_, scope));
 
   // parse mark definitions
-  array(spec.marks).forEach(_ => parseMark(_, scope, spec));
+  array(spec.marks).forEach(_ => parseMark(_, scope, _));
 
   // parse legend definitions
   array(spec.legends).forEach(_ => parseLegend(_, scope));

--- a/packages/vega-parser/src/parsers/scope.js
+++ b/packages/vega-parser/src/parsers/scope.js
@@ -23,7 +23,7 @@ export default function(spec, scope, preprocessed) {
   scales.forEach(_ => initScale(_, scope));
 
   // parse data sources
-  array(spec.data).forEach(_ => parseData(_, scope));
+  array(spec.data).forEach(_ => parseData(_, scope, spec));
 
   // parse scale definitions
   scales.forEach(_ => parseScale(_, scope));
@@ -35,7 +35,7 @@ export default function(spec, scope, preprocessed) {
   array(spec.axes).forEach(_ => parseAxis(_, scope));
 
   // parse mark definitions
-  array(spec.marks).forEach(_ => parseMark(_, scope));
+  array(spec.marks).forEach(_ => parseMark(_, scope, spec));
 
   // parse legend definitions
   array(spec.legends).forEach(_ => parseLegend(_, scope));

--- a/packages/vega-parser/src/parsers/signal.js
+++ b/packages/vega-parser/src/parsers/signal.js
@@ -19,7 +19,7 @@ export default function(signal, scope) {
     });
   } else {
     // define a new signal in the current scope
-    const op = scope.addSignal(name, signal.value);
+    const op = scope.addSignal(name, signal.value, signal);
     if (signal.react === false) op.react = false;
     if (signal.bind) scope.addBinding(name, signal.bind);
   }

--- a/packages/vega-parser/src/parsers/title.js
+++ b/packages/vega-parser/src/parsers/title.js
@@ -49,7 +49,8 @@ export default function(spec, scope) {
       interactive,
       style
     }),
-    scope
+    scope,
+    spec
   );
 }
 

--- a/packages/vega-parser/src/parsers/transform.js
+++ b/packages/vega-parser/src/parsers/transform.js
@@ -11,8 +11,8 @@ export default function(spec, scope) {
   const def = definition(spec.type);
   if (!def) error('Unrecognized transform type: ' + stringValue(spec.type));
 
-  const t = entry(def.type.toLowerCase(), null, parseParameters(def, spec, scope));
-  if (spec.signal) scope.addSignal(spec.signal, scope.proxy(t), spec);
+  const t = entry(def.type.toLowerCase(), null, parseParameters(def, spec, scope), undefined, spec);
+  if (spec.signal) scope.addSignal(spec.signal, scope.proxy(t, spec), spec);
   t.metadata = def.metadata || {};
 
   return t;

--- a/packages/vega-parser/src/parsers/transform.js
+++ b/packages/vega-parser/src/parsers/transform.js
@@ -54,29 +54,29 @@ function parseParameter(def, spec, scope) {
   }
 
   return def.array && !isSignal(value)
-    ? value.map(v => parameterValue(def, v, scope))
-    : parameterValue(def, value, scope);
+    ? value.map(v => parameterValue(def, v, scope, spec))
+    : parameterValue(def, value, scope, spec);
 }
 
 /**
  * Parse a single parameter value.
  */
-function parameterValue(def, value, scope) {
+function parameterValue(def, value, scope, src) {
   const type = def.type;
 
   if (isSignal(value)) {
     return isExpr(type) ? error('Expression references can not be signals.')
-         : isField(type) ? scope.fieldRef(value)
-         : isCompare(type) ? scope.compareRef(value)
+         : isField(type) ? scope.fieldRef(value, undefined, src)
+         : isCompare(type) ? scope.compareRef(value, src)
          : scope.signalRef(value.signal);
   } else {
     const expr = def.expr || isField(type);
-    return expr && outerExpr(value) ? scope.exprRef(value.expr, value.as)
+    return expr && outerExpr(value) ? scope.exprRef(value.expr, value.as, src)
          : expr && outerField(value) ? fieldRef(value.field, value.as)
          : isExpr(type) ? parseExpression(value, scope)
          : isData(type) ? ref(scope.getData(value).values)
          : isField(type) ? fieldRef(value)
-         : isCompare(type) ? scope.compareRef(value)
+         : isCompare(type) ? scope.compareRef(value, src)
          : value;
   }
 }
@@ -101,16 +101,16 @@ function parseSubParameters(def, spec, scope) {
     if (!isArray(value)) { // signals not allowed!
       error('Expected an array of sub-parameters. Instead: ' + stringValue(value));
     }
-    return value.map(v => parseSubParameter(def, v, scope));
+    return value.map(v => parseSubParameter(def, v, scope, spec));
   } else {
-    return parseSubParameter(def, value, scope);
+    return parseSubParameter(def, value, scope, spec);
   }
 }
 
 /**
  * Parse a sub-parameter object.
  */
-function parseSubParameter(def, value, scope) {
+function parseSubParameter(def, value, scope, src) {
   const n =def.params.length;
   let pdef;
 
@@ -127,7 +127,7 @@ function parseSubParameter(def, value, scope) {
 
   // parse params, create Params transform, return ref
   const params = extend(parseParameters(pdef, value, scope), pdef.key);
-  return ref(scope.add(Params(params)));
+  return ref(scope.add(Params(params, undefined, undefined, src)));
 }
 
 // -- Utilities -----

--- a/packages/vega-parser/src/parsers/transform.js
+++ b/packages/vega-parser/src/parsers/transform.js
@@ -12,7 +12,7 @@ export default function(spec, scope) {
   if (!def) error('Unrecognized transform type: ' + stringValue(spec.type));
 
   const t = entry(def.type.toLowerCase(), null, parseParameters(def, spec, scope));
-  if (spec.signal) scope.addSignal(spec.signal, scope.proxy(t));
+  if (spec.signal) scope.addSignal(spec.signal, scope.proxy(t), spec);
   t.metadata = def.metadata || {};
 
   return t;

--- a/packages/vega-parser/src/parsers/view.js
+++ b/packages/vega-parser/src/parsers/view.js
@@ -29,7 +29,7 @@ export default function parseView(spec, scope) {
   const config = scope.config;
 
   // add scenegraph root
-  const root = ref(scope.root = scope.add(operator()));
+  const root = ref(scope.root = scope.add(operator(undefined, undefined, spec)));
 
   // parse top-level signal definitions
   const signals = collectSignals(spec, config);

--- a/packages/vega-parser/src/parsers/view.js
+++ b/packages/vega-parser/src/parsers/view.js
@@ -48,7 +48,7 @@ export default function parseView(spec, scope) {
   const encode = scope.add(Encode(parseEncode(
     rootEncode(spec.encode), GroupMark, FrameRole,
     spec.style, scope, {pulse: ref(input)}
-  )));
+  ), undefined, undefined, spec));
 
   // perform view layout
   const parent = scope.add(ViewLayout({
@@ -57,18 +57,18 @@ export default function parseView(spec, scope) {
     autosize: scope.signalRef('autosize'),
     mark:     root,
     pulse:    ref(encode)
-  }));
+  }, undefined, undefined, spec));
   scope.operators.pop();
 
   // parse remainder of specification
-  scope.pushState(ref(encode), ref(parent), null);
+  scope.pushState(ref(encode), ref(parent), null, spec);
   parseSpec(spec, scope, signals);
   scope.operators.push(parent);
 
   // bound / render / sieve root item
-  let op = scope.add(Bound({mark: root, pulse: ref(parent)}));
-  op = scope.add(Render({pulse: ref(op)}));
-  op = scope.add(Sieve({pulse: ref(op)}));
+  let op = scope.add(Bound({mark: root, pulse: ref(parent)}, undefined, undefined, spec));
+  op = scope.add(Render({pulse: ref(op)}, undefined, undefined, spec));
+  op = scope.add(Sieve({pulse: ref(op)}, undefined, undefined, spec));
 
   // track metadata for root item
   scope.addData('root', new DataScope(scope, input, input, op));

--- a/packages/vega-parser/src/transforms.js
+++ b/packages/vega-parser/src/transforms.js
@@ -1,7 +1,7 @@
 import {entry} from './util';
 
-const transform = name => (params, value, parent) =>
-  entry(name, value, params || undefined, parent);
+const transform = name => (params, value, parent, src) =>
+  entry(name, value, params || undefined, parent, src);
 
 export const Aggregate = transform('aggregate');
 export const AxisTicks = transform('axisticks');

--- a/packages/vega-parser/src/util.js
+++ b/packages/vega-parser/src/util.js
@@ -13,8 +13,8 @@ export function entry(type, value, params, parent, src) {
   return new Entry(type, value, params, parent, src);
 }
 
-export function operator(value, params) {
-  return entry('operator', value, params);
+export function operator(value, params, src) {
+  return entry('operator', value, params, undefined, src);
 }
 
 // -----

--- a/packages/vega-parser/src/util.js
+++ b/packages/vega-parser/src/util.js
@@ -1,15 +1,16 @@
 import {isObject} from 'vega-util';
 
-export function Entry(type, value, params, parent) {
+export function Entry(type, value, params, parent, src) {
   this.id = -1;
   this.type = type;
   this.value = value;
   this.params = params;
+  this.src = src;
   if (parent) this.parent = parent;
 }
 
-export function entry(type, value, params, parent) {
-  return new Entry(type, value, params, parent);
+export function entry(type, value, params, parent, src) {
+  return new Entry(type, value, params, parent, src);
 }
 
 export function operator(value, params) {

--- a/packages/vega-runtime/src/context.js
+++ b/packages/vega-runtime/src/context.js
@@ -123,6 +123,8 @@ Context.prototype = Subcontext.prototype = {
         spec.data[name].forEach(role => data[role] = op);
       }
     }
+
+    op.src = spec?.src;
   },
   resolve() {
     (this.unresolved || []).forEach(fn => fn());

--- a/packages/vega-runtime/src/context.js
+++ b/packages/vega-runtime/src/context.js
@@ -124,7 +124,7 @@ Context.prototype = Subcontext.prototype = {
       }
     }
 
-    op.src = spec?.src;
+    op.src = spec && spec.src;
   },
   resolve() {
     (this.unresolved || []).forEach(fn => fn());


### PR DESCRIPTION
This PR adds a new property `src` to DataFlow nodes. This references the specification property which spawned each node.
It is helpful to be able to map the scenegraph item to the specification.

Scenario: I have a custom Vega renderer which traverses the scenegraph and renders in WebGL. I am using Vega [axes](https://vega.github.io/vega/docs/axes/). I want one of these axes rendered in a 3D plane instead of 2D.

Example: In my spec for the axes, I add a new attribute `plane`:
```json
"axes": [
        { "orient": "bottom", "scale": "x", "title": "X Axis"},
        { "orient": "left", "scale": "y", "title": "Y Axis" },
        { "orient": "left", "scale": "z", "title": "Z Axis", "plane": "z" },
    ],
```
During the scenegraph render pass, I can get to the mark node generated by the DataFlow, and via the `src` property I can get to this axis object from the spec and get the `plane` attribute.

This may also enable other scenarios, such as animation attributes etc.
