### PR TITLE
Update title.js

### DIFF
--- a/packages/vega-parser/src/parsers/title.js
+++ b/packages/vega-parser/src/parsers/title.js
@@ -92,10 +92,10 @@ function buildTitle(spec, _, userEncode, dataRef) {
 
   addEncoders(encode, {
     text:       text,
-    align:      {signal: 'item.mark.group.align'},
-    angle:      {signal: 'item.mark.group.angle'},
-    limit:      {signal: 'item.mark.group.limit'},
-    baseline:   'top',
+    align:      _('align'),
+    angle:      _('angle'),
+    limit:      _('limit'),
+    baseline:   _('baseline'),
     dx:         _('dx'),
     dy:         _('dy'),
     fill:       _('color'),
@@ -130,10 +130,10 @@ function buildSubTitle(spec, _, userEncode, dataRef) {
 
   addEncoders(encode, {
     text:       text,
-    align:      {signal: 'item.mark.group.align'},
-    angle:      {signal: 'item.mark.group.angle'},
-    limit:      {signal: 'item.mark.group.limit'},
-    baseline:   'top',
+    align:      _('align'),
+    angle:      _('angle'),
+    limit:      _('limit'),
+    baseline:   _('baseline'),
     dx:         _('dx'),
     dy:         _('dy'),
     fill:       _('subtitleColor'),


### PR DESCRIPTION
PR to fix issue #[6894 ](https://github.com/vega/vega-lite/issues/6894) in vega-lite 

The `config.title.align, config.title.angle, config.title.limit,` and `config.title.baseline` are being ignored on rendering in vega-lite. Meanwhile, `config.title.dx, config.title.dy, config.title.font`, and other title configurations are working fine. 

This, however, appears to be a Vega issue instead of a Vega-lite issue. When I set dx, limit, and angle in config.style["group-title"], only dx is changed:

```
{
  "$schema": "https://vega.github.io/schema/vega/v5.json", 
  "width" : 500,
  "height" : 500,
  "title": {
    "text": "Hello"
          },
  "config": {
    "style" : {
      "group-title" :
      {
        "dx" : 100,
        "limit" : 1,
        "angle" : 100
      }
    }
  }
}
```