### PR TITLE
Remove always querying always empty $name key from expression parameter lookup

### DIFF
--- a/packages/vega-runtime/src/parameters.js
+++ b/packages/vega-runtime/src/parameters.js
@@ -64,11 +64,10 @@ function getExpression(_, ctx, params) {
   if (_.$params) { // parse expression parameters
     ctx.parseParameters(_.$params, params);
   }
-  const k = 'e:' + _.$expr.code + '_' + _.$name;
+  const k = 'e:' + _.$expr.code;
   return ctx.fn[k] || (ctx.fn[k] = accessor(
     ctx.parameterExpression(_.$expr),
-    _.$fields,
-    _.$name
+    _.$fields
   ));
 }
 


### PR DESCRIPTION
In the process of trying to create type definitions for the runtime dataflow (#3237), I came across some code that I believe is dead. It is run, but as far as I can tell, there is never a `$name` param set on an expression parameter in the dataflow. However, Vega currently uses that property to compute a name for that expression. This removes that lookup and should be a no-op. 

I am not sure why the `$name` property is there, I am guessing it may be a relic of an older expression implementation that had a name.