### PR TITLE
 Allow label-transform to place labels out of a chart's boundary with padding: `'Infinity'` or `Infinity`

### DIFF
--- a/packages/vega-label/src/Label.js
+++ b/packages/vega-label/src/Label.js
@@ -33,7 +33,7 @@ const Anchors = [
  *   'bottom', 'top-right', 'right', 'bottom-right', 'middle'.
  * @param {Array<number>} [params.offset] - Label offsets (in pixels) from the base mark bounding box.
  *   This parameter  is parallel to the list of anchor points.
- * @param {number | 'inf'} [params.padding=0] - The amount (in pixels) that a label may exceed the layout size.
+ * @param {number | 'Infinity'} [params.padding=0] - The amount (in pixels) that a label may exceed the layout size.
  * @param {string} [params.lineAnchor='end'] - For group line mark labels only, indicates the anchor
  *   position for labels. One of 'start' or 'end'.
  * @param {string} [params.markIndex=0] - For group mark labels only, an index indicating

--- a/packages/vega-label/src/Label.js
+++ b/packages/vega-label/src/Label.js
@@ -33,7 +33,7 @@ const Anchors = [
  *   'bottom', 'top-right', 'right', 'bottom-right', 'middle'.
  * @param {Array<number>} [params.offset] - Label offsets (in pixels) from the base mark bounding box.
  *   This parameter  is parallel to the list of anchor points.
- * @param {number} [params.padding=0] - The amount (in pixels) that a label may exceed the layout size.
+ * @param {number | 'inf'} [params.padding=0] - The amount (in pixels) that a label may exceed the layout size.
  * @param {string} [params.lineAnchor='end'] - For group line mark labels only, indicates the anchor
  *   position for labels. One of 'start' or 'end'.
  * @param {string} [params.markIndex=0] - For group mark labels only, an index indicating

--- a/packages/vega-label/src/Label.js
+++ b/packages/vega-label/src/Label.js
@@ -32,8 +32,9 @@ const Anchors = [
  *   The available options are 'top-left', 'left', 'bottom-left', 'top',
  *   'bottom', 'top-right', 'right', 'bottom-right', 'middle'.
  * @param {Array<number>} [params.offset] - Label offsets (in pixels) from the base mark bounding box.
- *   This parameter  is parallel to the list of anchor points.
- * @param {number | 'Infinity'} [params.padding=0] - The amount (in pixels) that a label may exceed the layout size.
+ *   This parameter is parallel to the list of anchor points.
+ * @param {number | null} [params.padding=0] - The amount (in pixels) that a label may exceed the layout size.
+ *   If this parameter is null, a label may exceed the layout size without any boundary.
  * @param {string} [params.lineAnchor='end'] - For group line mark labels only, indicates the anchor
  *   position for labels. One of 'start' or 'end'.
  * @param {string} [params.markIndex=0] - For group mark labels only, an index indicating
@@ -59,7 +60,7 @@ Label.Definition = {
     { name: 'sort', type: 'compare' },
     { name: 'anchor', type: 'string', array: true, default: Anchors },
     { name: 'offset', type: 'number', array: true, default: [1] },
-    { name: 'padding', type: 'number', default: 0 },
+    { name: 'padding', type: 'number', default: 0, null: true },
     { name: 'lineAnchor', type: 'string', values: ['start', 'end'], default: 'end' },
     { name: 'markIndex', type: 'number', default: 0 },
     { name: 'avoidBaseMark', type: 'boolean', default: true },
@@ -95,7 +96,7 @@ inherits(Label, Transform, {
       _.avoidBaseMark !== false,
       _.lineAnchor || 'end',
       _.markIndex || 0,
-      _.padding || 0,
+      _.padding === undefined ? 0 : _.padding,
       _.method || 'naive'
     ).forEach(l => {
       // write layout results to data stream

--- a/packages/vega-label/src/LabelLayout.js
+++ b/packages/vega-label/src/LabelLayout.js
@@ -45,7 +45,7 @@ export default function(texts, size, compare, offset, anchor,
         grouptype = marktype === 'group' && texts[0].datum.items[markIndex].marktype,
         isGroupArea = grouptype === 'area',
         boundary = markBoundary(marktype, grouptype, lineAnchor, markIndex),
-        infPadding = padding === 'inf' || padding === Infinity,
+        infPadding = padding === 'Infinity' || padding === Infinity,
         $ = scaler(size[0], size[1], infPadding ? 0 : padding),
         isNaiveGroupArea = isGroupArea && method === 'naive';
 

--- a/packages/vega-label/src/LabelLayout.js
+++ b/packages/vega-label/src/LabelLayout.js
@@ -45,7 +45,8 @@ export default function(texts, size, compare, offset, anchor,
         grouptype = marktype === 'group' && texts[0].datum.items[markIndex].marktype,
         isGroupArea = grouptype === 'area',
         boundary = markBoundary(marktype, grouptype, lineAnchor, markIndex),
-        $ = scaler(size[0], size[1], padding),
+        infPadding = padding === 'inf' || padding === Infinity,
+        $ = scaler(size[0], size[1], infPadding ? 0 : padding),
         isNaiveGroupArea = isGroupArea && method === 'naive';
 
   // prepare text mark data for placing
@@ -88,8 +89,8 @@ export default function(texts, size, compare, offset, anchor,
 
   // generate label placement function
   const place = isGroupArea
-    ? placeAreaLabel[method]($, bitmaps, avoidBaseMark, markIndex)
-    : placeMarkLabel($, bitmaps, anchors, offsets);
+    ? placeAreaLabel[method]($, bitmaps, avoidBaseMark, markIndex, infPadding)
+    : placeMarkLabel($, bitmaps, anchors, offsets, infPadding);
 
   // place all labels
   data.forEach(d => d.opacity = +place(d));

--- a/packages/vega-label/src/LabelLayout.js
+++ b/packages/vega-label/src/LabelLayout.js
@@ -45,7 +45,7 @@ export default function(texts, size, compare, offset, anchor,
         grouptype = marktype === 'group' && texts[0].datum.items[markIndex].marktype,
         isGroupArea = grouptype === 'area',
         boundary = markBoundary(marktype, grouptype, lineAnchor, markIndex),
-        infPadding = padding === 'Infinity' || padding === Infinity,
+        infPadding = padding === null || padding === Infinity,
         $ = scaler(size[0], size[1], infPadding ? 0 : padding),
         isNaiveGroupArea = isGroupArea && method === 'naive';
 

--- a/packages/vega-label/src/util/placeAreaLabel/common.js
+++ b/packages/vega-label/src/util/placeAreaLabel/common.js
@@ -1,4 +1,4 @@
-export function outOfBounds(x, y, textWidth, textHeight, width, height) {
+function outOfBounds(x, y, textWidth, textHeight, width, height) {
   let r = textWidth / 2;
   return x - r < 0
       || x + r > width
@@ -6,7 +6,11 @@ export function outOfBounds(x, y, textWidth, textHeight, width, height) {
       || y + r > height;
 }
 
-export function collision($, x, y, textHeight, textWidth, h, bm0, bm1) {
+function _outOfBounds() {
+  return false;
+}
+
+function collision($, x, y, textHeight, textWidth, h, bm0, bm1) {
   const w = (textWidth * h) / (textHeight * 2),
         x1 = $(x - w),
         x2 = $(x + w),
@@ -16,4 +20,25 @@ export function collision($, x, y, textHeight, textWidth, h, bm0, bm1) {
   return bm0.outOfBounds(x1, y1, x2, y2)
       || bm0.getRange(x1, y1, x2, y2)
       || (bm1 && bm1.getRange(x1, y1, x2, y2));
+}
+
+function _collision($, x, y, textHeight, textWidth, h, bm0, bm1) {
+  const w = (textWidth * h) / (textHeight * 2);
+  let x1 = $(x - w),
+      x2 = $(x + w),
+      y1 = $(y - (h = h/2)),
+      y2 = $(y + h);
+
+  x1 = x1 > 0 ? x1 : 0;
+  y1 = y1 > 0 ? y1 : 0;
+  x2 = x2 < $.width ? x2 : $.width - 1;
+  y2 = y2 < $.height ? y2 : $.height - 1;
+
+  return bm0.getRange(x1, y1, x2, y2) || (bm1 && bm1.getRange(x1, y1, x2, y2));
+}
+
+export function getTests(infPadding) {
+  return infPadding
+    ? [_collision, _outOfBounds]
+    : [collision, outOfBounds];
 }

--- a/packages/vega-label/src/util/placeAreaLabel/placeFloodFill.js
+++ b/packages/vega-label/src/util/placeAreaLabel/placeFloodFill.js
@@ -1,13 +1,14 @@
 import {textMetrics} from 'vega-scenegraph';
-import {collision, outOfBounds} from './common';
+import {getTests} from './common';
 
 // pixel direction offsets for flood fill search
 const X_DIR = [-1, -1, 1, 1];
 const Y_DIR = [-1, 1, -1, 1];
 
-export default function($, bitmaps, avoidBaseMark, markIndex) {
+export default function($, bitmaps, avoidBaseMark, markIndex, infPadding) {
   const width = $.width,
       height = $.height,
+      [collision, outOfBounds] = getTests(infPadding),
       bm0 = bitmaps[0], // where labels have been placed
       bm1 = bitmaps[1], // area outlines
       bm2 = $.bitmap(); // flood-fill visitations

--- a/packages/vega-label/src/util/placeAreaLabel/placeReducedSearch.js
+++ b/packages/vega-label/src/util/placeAreaLabel/placeReducedSearch.js
@@ -1,9 +1,10 @@
 import {textMetrics} from 'vega-scenegraph';
-import {collision, outOfBounds} from './common';
+import {getTests} from './common';
 
-export default function($, bitmaps, avoidBaseMark, markIndex) {
+export default function($, bitmaps, avoidBaseMark, markIndex, infPadding) {
   const width = $.width,
       height = $.height,
+      [collision, outOfBounds] = getTests(infPadding),
       bm0 = bitmaps[0], // where labels have been placed
       bm1 = bitmaps[1]; // area outlines
   

--- a/packages/vega-label/src/util/placeMarkLabel.js
+++ b/packages/vega-label/src/util/placeMarkLabel.js
@@ -3,7 +3,7 @@ import {textMetrics} from 'vega-scenegraph';
 const Aligns = ['right', 'center', 'left'],
       Baselines = ['bottom', 'middle', 'top'];
 
-export default function($, bitmaps, anchors, offsets) {
+export default function($, bitmaps, anchors, offsets, infPadding) {
   const width = $.width,
         height = $.height,
         bm0 = bitmaps[0],
@@ -15,7 +15,7 @@ export default function($, bitmaps, anchors, offsets) {
           textHeight = d.datum.fontSize;
 
     // can not be placed if the mark is not visible in the graph bound
-    if (boundary[2] < 0 || boundary[5] < 0 || boundary[0] > width || boundary[3] > height) {
+    if (!infPadding && (boundary[2] < 0 || boundary[5] < 0 || boundary[0] > width || boundary[3] > height)) {
       return false;
     }
 
@@ -42,6 +42,12 @@ export default function($, bitmaps, anchors, offsets) {
       _y1 = $(y1);
       _y2 = $(y2);
 
+      if (infPadding) {
+        _x1 = _x1 < 0 ? 0 : _x1;
+        _y1 = _y1 < 0 ? 0 : _y1;
+        _y2 = _y2 >= $.height ? ($.height - 1) : _y2;
+      }
+
       if (!textWidth) {
         // to avoid finding width of text label,
         if (!test(_x1, _x1, _y1, _y2, bm0, bm1, x1, x1, y1, y2, boundary, isInside)) {
@@ -59,6 +65,11 @@ export default function($, bitmaps, anchors, offsets) {
 
       _x1 = $(x1);
       _x2 = $(x2);
+
+      if (infPadding) {
+        _x1 = _x1 < 0 ? 0 : _x1;
+        _x2 = _x2 >= $.width ? ($.width - 1) : _x2;
+      }
 
       if (test(_x1, _x2, _y1, _y2, bm0, bm1, x1, x2, y1, y2, boundary, isInside)) {
         // place label if the position is placeable

--- a/packages/vega-label/test/label-test.js
+++ b/packages/vega-label/test/label-test.js
@@ -244,3 +244,130 @@ tape('Label performs label layout with base mark reactive geometry', t => {
 
   t.end();
 });
+
+tape('Label performs label layout over input points with infinity padding', t => {
+  function data() {
+    return [
+      {text: 'very-long-label', x: 5, y: 5, fontSize: 10}
+    ];
+  }
+
+  var df = new vega.Dataflow(),
+      pd = df.add(Infinity),
+      an = df.add('left'),
+      c0 = df.add(Collect),
+      lb = df.add(Label, {
+        size: [10, 10],
+        anchor: [an],
+        offset: [2],
+        padding: pd,
+        pulse: c0
+      });
+
+  df.update(an, 'left')
+    .update(pd, Infinity)
+    .pulse(c0, vega.changeset().insert(data()))
+    .run();
+  t.equal(lb.stamp, df.stamp());
+  let out = c0.value;
+  t.equal(out.length, data().length);
+  closeTo(t, out[0].x, 3);
+  closeTo(t, out[0].y, 5);
+  t.equal(out[0].align, 'right');
+  t.equal(out[0].baseline, 'middle');
+  t.equal(out[0].opacity, 1);
+
+  df.update(an, 'right')
+    .update(pd, Infinity)
+    .pulse(c0, vega.changeset().remove(util.truthy).insert(data()))
+    .run();
+  out = c0.value;
+  t.equal(out.length, data().length);
+  closeTo(t, out[0].x, 7);
+  closeTo(t, out[0].y, 5);
+  t.equal(out[0].align, 'left');
+  t.equal(out[0].baseline, 'middle');
+  t.equal(out[0].opacity, 1);
+
+  df.update(an, 'left')
+    .update(pd, 0)
+    .pulse(c0, vega.changeset().remove(util.truthy).insert(data()))
+    .run();
+  out = c0.value;
+  t.equal(out.length, data().length);
+  t.equal(out[0].opacity, 0);
+
+  df.update(an, 'right')
+    .update(pd, 0)
+    .pulse(c0, vega.changeset().remove(util.truthy).insert(data()))
+    .run();
+  out = c0.value;
+  t.equal(out.length, data().length);
+  t.equal(out[0].opacity, 0);
+
+  df.update(an, 'left')
+    .update(pd, 'inf')
+    .pulse(c0, vega.changeset().remove(util.truthy).insert(data()))
+    .run();
+  out = c0.value;
+  t.equal(out.length, data().length);
+  closeTo(t, out[0].x, 3);
+  closeTo(t, out[0].y, 5);
+  t.equal(out[0].align, 'right');
+  t.equal(out[0].baseline, 'middle');
+  t.equal(out[0].opacity, 1);
+
+  df.update(an, 'right')
+    .update(pd, 'inf')
+    .pulse(c0, vega.changeset().remove(util.truthy).insert(data()))
+    .run();
+  out = c0.value;
+  t.equal(out.length, data().length);
+  closeTo(t, out[0].x, 7);
+  closeTo(t, out[0].y, 5);
+  t.equal(out[0].align, 'left');
+  t.equal(out[0].baseline, 'middle');
+  t.equal(out[0].opacity, 1);
+
+  df.update(an, 'left')
+    .update(pd, 5)
+    .pulse(c0, vega.changeset().remove(util.truthy).insert(data()))
+    .run();
+  out = c0.value;
+  t.equal(out.length, data().length);
+  t.equal(out[0].opacity, 0);
+
+  df.update(an, 'right')
+    .update(pd, 5)
+    .pulse(c0, vega.changeset().remove(util.truthy).insert(data()))
+    .run();
+  out = c0.value;
+  t.equal(out.length, data().length);
+  t.equal(out[0].opacity, 0);
+
+  df.update(an, 'left')
+    .update(pd, 100)
+    .pulse(c0, vega.changeset().remove(util.truthy).insert(data()))
+    .run();
+  out = c0.value;
+  t.equal(out.length, data().length);
+  closeTo(t, out[0].x, 3);
+  closeTo(t, out[0].y, 5);
+  t.equal(out[0].align, 'right');
+  t.equal(out[0].baseline, 'middle');
+  t.equal(out[0].opacity, 1);
+
+  df.update(an, 'right')
+    .update(pd, 100)
+    .pulse(c0, vega.changeset().remove(util.truthy).insert(data()))
+    .run();
+  out = c0.value;
+  t.equal(out.length, data().length);
+  closeTo(t, out[0].x, 7);
+  closeTo(t, out[0].y, 5);
+  t.equal(out[0].align, 'left');
+  t.equal(out[0].baseline, 'middle');
+  t.equal(out[0].opacity, 1);
+
+  t.end();
+});

--- a/packages/vega-label/test/label-test.js
+++ b/packages/vega-label/test/label-test.js
@@ -306,7 +306,7 @@ tape('Label performs label layout over input points with infinity padding', t =>
   t.equal(out[0].opacity, 0);
 
   df.update(an, 'left')
-    .update(pd, 'Infinity')
+    .update(pd, null)
     .pulse(c0, vega.changeset().remove(util.truthy).insert(data()))
     .run();
   out = c0.value;
@@ -318,7 +318,7 @@ tape('Label performs label layout over input points with infinity padding', t =>
   t.equal(out[0].opacity, 1);
 
   df.update(an, 'right')
-    .update(pd, 'Infinity')
+    .update(pd, null)
     .pulse(c0, vega.changeset().remove(util.truthy).insert(data()))
     .run();
   out = c0.value;

--- a/packages/vega-label/test/label-test.js
+++ b/packages/vega-label/test/label-test.js
@@ -306,7 +306,7 @@ tape('Label performs label layout over input points with infinity padding', t =>
   t.equal(out[0].opacity, 0);
 
   df.update(an, 'left')
-    .update(pd, 'inf')
+    .update(pd, 'Infinity')
     .pulse(c0, vega.changeset().remove(util.truthy).insert(data()))
     .run();
   out = c0.value;
@@ -318,7 +318,7 @@ tape('Label performs label layout over input points with infinity padding', t =>
   t.equal(out[0].opacity, 1);
 
   df.update(an, 'right')
-    .update(pd, 'inf')
+    .update(pd, 'Infinity')
     .pulse(c0, vega.changeset().remove(util.truthy).insert(data()))
     .run();
   out = c0.value;

--- a/packages/vega-typings/types/spec/transform.d.ts
+++ b/packages/vega-typings/types/spec/transform.d.ts
@@ -514,7 +514,7 @@ export interface LabelTransform {
   sort?: Compare;
   offset?: number[] | number | SignalRef;
   anchor?: LabelAnchor[] | LabelAnchor | SignalRef;
-  padding?: number | SignalRef;
+  padding?: number | 'inf' | SignalRef;
   markIndex?: number;
   lineAnchor?: LineLabelAnchor | SignalRef;
   avoidBaseMark?: boolean | SignalRef;

--- a/packages/vega-typings/types/spec/transform.d.ts
+++ b/packages/vega-typings/types/spec/transform.d.ts
@@ -514,7 +514,7 @@ export interface LabelTransform {
   sort?: Compare;
   offset?: number[] | number | SignalRef;
   anchor?: LabelAnchor[] | LabelAnchor | SignalRef;
-  padding?: number | 'inf' | SignalRef;
+  padding?: number | 'Infinity' | SignalRef;
   markIndex?: number;
   lineAnchor?: LineLabelAnchor | SignalRef;
   avoidBaseMark?: boolean | SignalRef;

--- a/packages/vega-typings/types/spec/transform.d.ts
+++ b/packages/vega-typings/types/spec/transform.d.ts
@@ -514,7 +514,7 @@ export interface LabelTransform {
   sort?: Compare;
   offset?: number[] | number | SignalRef;
   anchor?: LabelAnchor[] | LabelAnchor | SignalRef;
-  padding?: number | 'Infinity' | SignalRef;
+  padding?: number | null | SignalRef;
   markIndex?: number;
   lineAnchor?: LineLabelAnchor | SignalRef;
   avoidBaseMark?: boolean | SignalRef;


### PR DESCRIPTION
Add an option to `label-transform`.
Allow `padding: 'inf'`.