### PR TITLE
fix(vega-typings): narrow type signature for vega-loader.http

### DIFF
--- a/packages/vega-typings/types/runtime/index.d.ts
+++ b/packages/vega-typings/types/runtime/index.d.ts
@@ -28,7 +28,7 @@ export function parse(spec: Spec, config?: Config, opt?: { ast?: boolean }): Run
 export interface Loader {
   load: (uri: string, options?: any) => Promise<string>;
   sanitize: (uri: string, options: any) => Promise<{ href: string }>;
-  http: (uri: string, options: any) => Promise<string>;
+  http: (uri: string, options: RequestInit) => Promise<string>;
   file: (filename: string) => Promise<string>;
 }
 


### PR DESCRIPTION
## Motivation

- Providing a custom data fetcher, and noticed the response type could be narrowed.
- ~Checked `vega-loader`, I think it's already behaving as if this type is a `Response` rather than a `string`.~ (You can't use fetch directly, you have to wrap it so that it returns a string. See comment below for a usage example. )

## References

- RequestInit: https://microsoft.github.io/PowerBI-JavaScript/interfaces/_node_modules_typedoc_node_modules_typescript_lib_lib_dom_d_.requestinit.html
- fetch: https://github.com/microsoft/TypeScript/blob/e96c10fe0ced0aa27ff40f0108df8e7153b348c7/lib/lib.dom.d.ts#L17373
- https://github.com/vega/vega/blob/774165e29850b66ec8b79ba52a7955f1ab936ea6/packages/vega-loader/src/loader.js#L175-L180
