### PR TITLE
fix: move __Default value:__ above JSDoc tags

### DIFF
--- a/packages/vega-typings/types/spec/config.d.ts
+++ b/packages/vega-typings/types/spec/config.d.ts
@@ -317,16 +317,16 @@ export interface MarkConfig {
   /**
    * The inner radius in pixels of arc marks.
    *
-   * @minimum 0
    * __Default value:__ `0`
+   * @minimum 0
    */
   innerRadius?: number | SignalRef;
 
   /**
    * The outer radius in pixels of arc marks.
    *
-   * @minimum 0
    * __Default value:__ `0`
+   * @minimum 0
    */
   outerRadius?: number | SignalRef;
 

--- a/packages/vega-typings/types/spec/legend.d.ts
+++ b/packages/vega-typings/types/spec/legend.d.ts
@@ -455,9 +455,9 @@ export interface BaseLegend {
 
   /**
    * The offset of the legend label.
-   * @minimum 0
    *
    * __Default value:__ `4`.
+   * @minimum 0
    */
   labelOffset?: NumberValue;
 


### PR DESCRIPTION
Fixes [this comment on an issue](https://github.com/vega/ts-json-schema-generator/issues/977#issuecomment-938117468).

Since vega/ts-json-schema-generator uses vega/vega-lite as a test case and vega/vega-lite uses vega/vega/packages/vega-typings, the order of `__Default value:__` and JSDoc tags needs to be fixed before new features can be added to the schema generator.