### PR TITLE
fix(vega-view): fix Trusted Types violation in lookup function

### DIFF
--- a/packages/vega-view/src/initialize.js
+++ b/packages/vega-view/src/initialize.js
@@ -62,7 +62,7 @@ function lookup(view, el, clear) {
   }
   if (el && clear) {
     try {
-      el.innerHTML = '';
+      el.textContent = '';
     } catch (e) {
       el = null;
       view.error(e);


### PR DESCRIPTION
Trusted Types is a Content Security Policy feature that blocks insecure usage of unsafe DOM APIs such as innerHTML assignment, to prevent XSS. The lookup function assigns a string to innerHTML, causing a Trusted Types violation. This prevents users of the vega library from adopting Trusted Types.

To fix the violation, replace the innerHTML assignment with an equivalent textContent assignment. Both versions have exactly the same semantics - clearing the content of the given element - but the latter does not cause a Trusted Types violation.