### PR TITLE
fix(typing): add missing SignalRef on RangeBand

### DIFF
--- a/packages/vega-typings/types/spec/scale.d.ts
+++ b/packages/vega-typings/types/spec/scale.d.ts
@@ -25,6 +25,7 @@ export type RangeScheme =
 export type RangeBand =
   | RangeEnum
   | RangeRaw
+  | SignalRef
   | {
       step: number | SignalRef;
     };


### PR DESCRIPTION
Based on radar chart https://vega.github.io/vega/examples/radar-chart/ I tried to integrate it on my angular project.

I figure out that RangeBand type has not the SignalRef like declared on the radar-char.

The error below:
```
Error: src/app/components/vega/vega-radar.component.ts:52:18 - error TS2322: Type '{ signal: string; }' is not assignable to type 'RangeBand'.
  Object literal may only specify known properties, and 'signal' does not exist in type 'RangeRaw | { step: number | SignalRef; }'.

52         range: { signal: '[-PI, PI]' },
                    ~~~~~~~~~~~~~~~~~~~
```

The json ref

```typescript
{
  "scales": [
    {
      "name": "angular",
      "type": "point",
      "range": {"signal": "[-PI, PI]"}, // << here signal is not assignable to type RangeBand
      "padding": 0.5,
      "domain": {"data": "table", "field": "key"}
    },
```