### PR TITLE
fix: allow label inside when label is larger than base mark

### DIFF
--- a/packages/vega-label/src/LabelLayout.js
+++ b/packages/vega-label/src/LabelLayout.js
@@ -77,13 +77,11 @@ export default function(texts, size, compare, offset, anchor,
 
     // extract data information from base mark when base mark is to be avoided
     // base mark is implicitly avoided if it is a group area
-    if (marktype && (avoidBaseMark || isGroupArea)) {
-      avoidMarks = [texts.map(d => d.datum)].concat(avoidMarks);
-    }
+    const baseMark = ((marktype && avoidBaseMark) || isGroupArea) && texts.map(d => d.datum);
 
     // generate bitmaps for layout calculation
-    bitmaps = avoidMarks.length
-      ? markBitmaps($, avoidMarks, labelInside, isGroupArea)
+    bitmaps = avoidMarks.length || baseMark
+      ? markBitmaps($, baseMark || [], avoidMarks, labelInside, isGroupArea)
       : baseBitmaps($, avoidBaseMark && data);
   }
 

--- a/packages/vega-label/src/util/markBitmaps.js
+++ b/packages/vega-label/src/util/markBitmaps.js
@@ -36,12 +36,14 @@ export function markBitmaps($, baseMark, avoidMarks, labelInside, isGroupArea) {
         layer2 = border && $.bitmap();
 
   // populate bitmap layers
-  let x, y, u, v, alpha, strokeAlpha, baseMarkAlpha;
+  let x, y, u, v, index, alpha, strokeAlpha, baseMarkAlpha;
   for (y=0; y < height; ++y) {
     for (x=0; x < width; ++x) {
-      alpha = buffer[y * width + x] & ALPHA_MASK;
-      baseMarkAlpha = baseMarkBuffer[y * width + x] & ALPHA_MASK;
-      strokeAlpha = border && (strokeBuffer[y * width + x] & ALPHA_MASK);
+      index = y * width + x;
+
+      alpha = buffer[index] & ALPHA_MASK;
+      baseMarkAlpha = baseMarkBuffer[index] & ALPHA_MASK;
+      strokeAlpha = border && (strokeBuffer[index] & ALPHA_MASK);
 
       if (alpha || strokeAlpha || baseMarkAlpha) {
         u = $(x);

--- a/packages/vega-label/src/util/placeMarkLabel.js
+++ b/packages/vega-label/src/util/placeMarkLabel.js
@@ -92,13 +92,6 @@ export default function($, bitmaps, anchors, offsets, infPadding) {
 function test(_x1, _x2, _y1, _y2, bm0, bm1, x1, x2, y1, y2, boundary, isInside) {
   return !(
     bm0.outOfBounds(_x1, _y1, _x2, _y2) ||
-    (isInside && bm1
-      ? bm1.getRange(_x1, _y1, _x2, _y2) || !isInMarkBound(x1, y1, x2, y2, boundary)
-      : bm0.getRange(_x1, _y1, _x2, _y2))
+    ((isInside && bm1) || bm0).getRange(_x1, _y1, _x2, _y2)
   );
-}
-
-function isInMarkBound(x1, y1, x2, y2, boundary) {
-  return boundary[0] <= x1 && x2 <= boundary[2]
-      && boundary[3] <= y1 && y2 <= boundary[5];
 }

--- a/packages/vega-label/test/label-test.js
+++ b/packages/vega-label/test/label-test.js
@@ -145,11 +145,13 @@ tape('Label performs label layout with base mark reactive geometry', t => {
   var df = new vega.Dataflow(),
       an = df.add('left'),
       c0 = df.add(Collect),
+      avoidBaseMark = df.add(true),
       lb = df.add(Label, {
         size: [50, 30],
         anchor: [an],
         offset: [2],
-        pulse: c0
+        pulse: c0,
+        avoidBaseMark
       });
 
   df.update(an, 'left')
@@ -239,6 +241,26 @@ tape('Label performs label layout with base mark reactive geometry', t => {
   closeTo(t, out[0].y, 17 + 2 * Math.SQRT1_2);
   t.equal(out[0].align, 'left');
   t.equal(out[0].baseline, 'top');
+  t.equal(out[0].opacity, 1);
+  t.equal(out[1].opacity, 0);
+
+  df.update(an, 'middle')
+    .update(avoidBaseMark, true)
+    .pulse(c0, vega.changeset().remove(util.truthy).insert(data()))
+    .run();
+  out = c0.value;
+  t.equal(out[0].opacity, 0);
+  t.equal(out[1].opacity, 0);
+
+  df.update(an, 'middle')
+    .update(avoidBaseMark, false)
+    .pulse(c0, vega.changeset().remove(util.truthy).insert(data()))
+    .run();
+  out = c0.value;
+  closeTo(t, out[0].x, 21);
+  closeTo(t, out[0].y, 16);
+  t.equal(out[0].align, 'center');
+  t.equal(out[0].baseline, 'middle');
   t.equal(out[0].opacity, 1);
   t.equal(out[1].opacity, 0);
 


### PR DESCRIPTION
When setting `avoidBaseMark` to be `false`, a label should be placed inside its base mark even if the label size is larger than the base mark.