### PR TITLE
fix: label-transform should not assume that a label always has some part inside the chart's bounding box

### DIFF
--- a/packages/vega-label/src/util/placeAreaLabel/common.js
+++ b/packages/vega-label/src/util/placeAreaLabel/common.js
@@ -1,4 +1,4 @@
-function outOfBounds(x, y, textWidth, textHeight, width, height) {
+export function outOfBounds(x, y, textWidth, textHeight, width, height) {
   let r = textWidth / 2;
   return x - r < 0
       || x + r > width
@@ -6,11 +6,7 @@ function outOfBounds(x, y, textWidth, textHeight, width, height) {
       || y + r > height;
 }
 
-function _outOfBounds() {
-  return false;
-}
-
-function collision($, x, y, textHeight, textWidth, h, bm0, bm1) {
+export function collision($, x, y, textHeight, textWidth, h, bm0, bm1) {
   const w = (textWidth * h) / (textHeight * 2),
         x1 = $(x - w),
         x2 = $(x + w),
@@ -20,25 +16,4 @@ function collision($, x, y, textHeight, textWidth, h, bm0, bm1) {
   return bm0.outOfBounds(x1, y1, x2, y2)
       || bm0.getRange(x1, y1, x2, y2)
       || (bm1 && bm1.getRange(x1, y1, x2, y2));
-}
-
-function _collision($, x, y, textHeight, textWidth, h, bm0, bm1) {
-  const w = (textWidth * h) / (textHeight * 2);
-  let x1 = $(x - w),
-      x2 = $(x + w),
-      y1 = $(y - (h = h/2)),
-      y2 = $(y + h);
-
-  x1 = x1 > 0 ? x1 : 0;
-  y1 = y1 > 0 ? y1 : 0;
-  x2 = x2 < $.width ? x2 : $.width - 1;
-  y2 = y2 < $.height ? y2 : $.height - 1;
-
-  return bm0.getRange(x1, y1, x2, y2) || (bm1 && bm1.getRange(x1, y1, x2, y2));
-}
-
-export function getTests(infPadding) {
-  return infPadding
-    ? [_collision, _outOfBounds]
-    : [collision, outOfBounds];
 }

--- a/packages/vega-label/src/util/placeAreaLabel/placeFloodFill.js
+++ b/packages/vega-label/src/util/placeAreaLabel/placeFloodFill.js
@@ -1,14 +1,13 @@
 import {textMetrics} from 'vega-scenegraph';
-import {getTests} from './common';
+import {collision, outOfBounds} from './common';
 
 // pixel direction offsets for flood fill search
 const X_DIR = [-1, -1, 1, 1];
 const Y_DIR = [-1, 1, -1, 1];
 
-export default function($, bitmaps, avoidBaseMark, markIndex, infPadding) {
+export default function($, bitmaps, avoidBaseMark, markIndex) {
   const width = $.width,
       height = $.height,
-      [collision, outOfBounds] = getTests(infPadding),
       bm0 = bitmaps[0], // where labels have been placed
       bm1 = bitmaps[1], // area outlines
       bm2 = $.bitmap(); // flood-fill visitations

--- a/packages/vega-label/src/util/placeAreaLabel/placeReducedSearch.js
+++ b/packages/vega-label/src/util/placeAreaLabel/placeReducedSearch.js
@@ -1,10 +1,9 @@
 import {textMetrics} from 'vega-scenegraph';
-import {getTests} from './common';
+import {collision, outOfBounds} from './common';
 
-export default function($, bitmaps, avoidBaseMark, markIndex, infPadding) {
+export default function($, bitmaps, avoidBaseMark, markIndex) {
   const width = $.width,
       height = $.height,
-      [collision, outOfBounds] = getTests(infPadding),
       bm0 = bitmaps[0], // where labels have been placed
       bm1 = bitmaps[1]; // area outlines
   

--- a/packages/vega-label/src/util/placeMarkLabel.js
+++ b/packages/vega-label/src/util/placeMarkLabel.js
@@ -3,7 +3,7 @@ import {textMetrics} from 'vega-scenegraph';
 const Aligns = ['right', 'center', 'left'],
       Baselines = ['bottom', 'middle', 'top'];
 
-export default function($, bitmaps, anchors, offsets, infPadding) {
+export default function($, bitmaps, anchors, offsets) {
   const width = $.width,
         height = $.height,
         bm0 = bitmaps[0],
@@ -15,11 +15,11 @@ export default function($, bitmaps, anchors, offsets, infPadding) {
           textHeight = d.datum.fontSize;
 
     // can not be placed if the mark is not visible in the graph bound
-    if (!infPadding && (boundary[2] < 0 || boundary[5] < 0 || boundary[0] > width || boundary[3] > height)) {
+    if (boundary[2] < 0 || boundary[5] < 0 || boundary[0] > width || boundary[3] > height) {
       return false;
     }
 
-    let textWidth = 0,
+    let textWidth = d.textWidth ?? 0,
         dx, dy, isInside, sizeFactor, insideFactor,
         x1, x2, y1, y2, xc, yc,
         _x1, _x2, _y1, _y2;
@@ -42,13 +42,6 @@ export default function($, bitmaps, anchors, offsets, infPadding) {
       _y1 = $(y1);
       _y2 = $(y2);
 
-      if (infPadding) {
-        _x1 = _x1 < 0 ? 0 : _x1;
-        _x1 = _x1 >= $.width ? ($.width - 1) : _x1;
-        _y1 = _y1 < 0 ? 0 : _y1;
-        _y2 = _y2 >= $.height ? ($.height - 1) : _y2;
-      }
-
       if (!textWidth) {
         // to avoid finding width of text label,
         if (!test(_x1, _x1, _y1, _y2, bm0, bm1, x1, x1, y1, y2, boundary, isInside)) {
@@ -66,11 +59,6 @@ export default function($, bitmaps, anchors, offsets, infPadding) {
 
       _x1 = $(x1);
       _x2 = $(x2);
-
-      if (infPadding) {
-        _x1 = _x1 < 0 ? 0 : _x1;
-        _x2 = _x2 >= $.width ? ($.width - 1) : _x2;
-      }
 
       if (test(_x1, _x2, _y1, _y2, bm0, bm1, x1, x2, y1, y2, boundary, isInside)) {
         // place label if the position is placeable

--- a/packages/vega-label/test/label-test.js
+++ b/packages/vega-label/test/label-test.js
@@ -267,7 +267,7 @@ tape('Label performs label layout with base mark reactive geometry', t => {
   t.end();
 });
 
-tape('Label performs label layout over input points with infinity padding', t => {
+tape('Label performs label layout over input point with infinity padding', t => {
   function data() {
     return [
       {text: 'very-long-label', x: 5, y: 5, fontSize: 10}
@@ -390,6 +390,49 @@ tape('Label performs label layout over input points with infinity padding', t =>
   t.equal(out[0].align, 'left');
   t.equal(out[0].baseline, 'middle');
   t.equal(out[0].opacity, 1);
+
+  t.end();
+});
+
+tape('Label performs label layout over input multiple points outside of chart\'s bounding box with infinity padding', t => {
+  function data() {
+    return [
+      {text: 'l', x: 0, y: 5, fontSize: 10},
+      {text: 'l', x: 9, y: 5, fontSize: 10}
+    ];
+  }
+
+  var df = new vega.Dataflow(),
+      pd = df.add(Infinity),
+      an = df.add('left'),
+      c0 = df.add(Collect),
+      lb = df.add(Label, {
+        size: [10, 10],
+        anchor: [an],
+        offset: [10],
+        padding: pd,
+        pulse: c0
+      });
+
+  df.update(an, 'left')
+    .update(pd, Infinity)
+    .pulse(c0, vega.changeset().insert(data()))
+    .run();
+
+  t.equal(lb.stamp, df.stamp());
+  const out = c0.value;
+  t.equal(out.length, data().length);
+  closeTo(t, out[0].x, -10);
+  closeTo(t, out[0].y, 5);
+  t.equal(out[0].align, 'right');
+  t.equal(out[0].baseline, 'middle');
+  t.equal(out[0].opacity, 1);
+
+  closeTo(t, out[1].x, -1);
+  closeTo(t, out[1].y, 5);
+  t.equal(out[1].align, 'right');
+  t.equal(out[1].baseline, 'middle');
+  t.equal(out[1].opacity, 1);
 
   t.end();
 });


### PR DESCRIPTION
In the previous implementation of infinity padding in label, I was trying to optimize the space of bitmap by shrinking the size of labels to always be within the chart's bounding box.
For example:
When a label extends passthrough the chart's bounding box, we did not actually expand the bitmap. Instead, the occupancy area of the label is clipped.
![Picture1](https://user-images.githubusercontent.com/30903997/148400731-7701cfdd-9225-4349-be25-d2da2a0e1f56.png)

If the whole label is outside of the chart's bounding box, in the previous implementation, the labeling algorithm create an 1-pixel-wide occupancy area to represent the label.
![Picture2](https://user-images.githubusercontent.com/30903997/148401335-afed4199-24ef-4296-a274-5d639a228a56.png)

However, there are 2 labels extending passthrough the chart's bounding box (say on the left side), one of them would be hidden by the labeling algorithm if they horizontally overlaps with each other, which is incorrect.
![Picture5](https://user-images.githubusercontent.com/30903997/148402019-88ede2c9-3f5a-45e2-a92c-de9e705087e9.png)

In the new implementation, we just increase the size of the bitmap to be large enough to fit the largest label outside of the chart's bounding box.

Should fix the first issue in https://github.com/vega/vega-lite/issues/7883
