### PR TITLE
Use willReadFrequently on 2D canvas contexts, where appropriate

### DIFF
--- a/packages/vega-geo/src/Heatmap.js
+++ b/packages/vega-geo/src/Heatmap.js
@@ -126,7 +126,7 @@ function toCanvas(grid, obj, color, opacity) {
         val = grid.values,
         value = val ? i => val[i] : zero,
         can = canvas(x2 - x1, y2 - y1),
-        ctx = can.getContext('2d'),
+        ctx = can.getContext('2d', {willReadFrequently: true}),
         img = ctx.getImageData(0, 0, x2 - x1, y2 - y1),
         pix = img.data;
 

--- a/packages/vega-label/src/util/markBitmaps.js
+++ b/packages/vega-label/src/util/markBitmaps.js
@@ -17,9 +17,9 @@ export function markBitmaps($, baseMark, avoidMarks, labelInside, isGroupArea) {
   const width = $.width,
         height = $.height,
         border = labelInside || isGroupArea,
-        context = canvas(width, height).getContext('2d'),
-        baseMarkContext = canvas(width, height).getContext('2d'),
-        strokeContext = border && canvas(width, height).getContext('2d');
+        context = canvas(width, height).getContext('2d', {willReadFrequently: true}),
+        baseMarkContext = canvas(width, height).getContext('2d', {willReadFrequently: true}),
+        strokeContext = border && canvas(width, height).getContext('2d', {willReadFrequently: true});
 
   // render all marks to be avoided into canvas
   avoidMarks.forEach(items => draw(context, items, false));

--- a/packages/vega-wordcloud/src/CloudLayout.js
+++ b/packages/vega-wordcloud/src/CloudLayout.js
@@ -96,7 +96,7 @@ export default function() {
 
   function getContext(canvas) {
     canvas.width = canvas.height = 1;
-    var ratio = Math.sqrt(canvas.getContext('2d').getImageData(0, 0, 1, 1).data.length >> 2);
+    var ratio = Math.sqrt(canvas.getContext('2d', {willReadFrequently: true}).getImageData(0, 0, 1, 1).data.length >> 2);
     canvas.width = (cw << 5) / ratio;
     canvas.height = ch / ratio;
 


### PR DESCRIPTION
willReadFrequently is a performance hint that tells browsers to
expect calls to getImageData on that context.  This allows browsers
to optimize performance for readback use cases.

See: https://html.spec.whatwg.org/multipage/canvas.html#concept-canvas-will-read-frequently

This feature will soon be released in Chromium-based Web Browsers
(i.e. Chrome, Edge, Opera, etc.)

This pull request aims to improve performance and prevent possible
performance regressions when the new API goes live in various Web
browsers.