### PR TITLE
Fix SVG path parser null check.

### DIFF
--- a/packages/vega-scenegraph/src/path/parse.js
+++ b/packages/vega-scenegraph/src/path/parse.js
@@ -6,8 +6,9 @@ const flagPattern = /^[01]/;
 
 export default function parse(path) {
   const commands = [];
+  const matches = path.match(commandPattern) || [];
 
-  path.match(commandPattern).forEach(str => {
+  matches.forEach(str => {
     let cmd = str[0];
     const type = cmd.toLowerCase();
 

--- a/packages/vega-scenegraph/test/path-test.js
+++ b/packages/vega-scenegraph/test/path-test.js
@@ -111,6 +111,13 @@ tape('pathParse should parse svg path', t => {
   t.end();
 });
 
+tape('pathParse should handle an empty string', t => {
+  const s = '';
+  const p = [];
+  t.deepEqual(pathParse(s), p);
+  t.end();
+});
+
 tape('pathParse should handle repeated arguments', t => {
   const s = 'M 1 1 L 1 2 3 4';
   const p = [['M',1,1], ['L',1,2], ['L',3,4]];


### PR DESCRIPTION
**vega-scenegraph**

- Fix SVG path parser null check. (#3451).