### PR TITLE
feat: add stroke, fill, and opacity to various SceneItem types

### DIFF
--- a/packages/vega-typings/types/runtime/scene.d.ts
+++ b/packages/vega-typings/types/runtime/scene.d.ts
@@ -50,6 +50,7 @@ export interface SceneItem {
   };
   x: number;
   y: number;
+  opacity?: number;
 }
 
 export type SceneAxis = SceneItem & {
@@ -58,12 +59,16 @@ export type SceneAxis = SceneItem & {
 
 export type SceneRect = SceneItem & {
   fill: string;
+  fillOpacity?: number;
+  stroke?: string;
+  strokeWidth?: number;
+  strokeOpacity?: number;
   height: number;
   width: number;
+  cornerRadius?: number;
 };
 
 export type SceneLine = SceneItem & {
-  opacity: number;
   stroke: string;
   strokeWidth: number;
   x2: number;
@@ -84,9 +89,12 @@ export type SceneGroup = SceneItem & {
 
 export type SceneSymbol = SceneItem & {
   fill: string;
+  fillOpacity: number;
   shape: string;
   size: number;
+  stroke: string;
   strokeWidth: number;
+  strokeOpacity: number;
 };
 
 export type SceneTextBaseline = 'top' | 'middle' | 'bottom';

--- a/packages/vega-typings/types/runtime/scene.d.ts
+++ b/packages/vega-typings/types/runtime/scene.d.ts
@@ -89,12 +89,12 @@ export type SceneGroup = SceneItem & {
 
 export type SceneSymbol = SceneItem & {
   fill: string;
-  fillOpacity: number;
+  fillOpacity?: number;
   shape: string;
   size: number;
-  stroke: string;
-  strokeWidth: number;
-  strokeOpacity: number;
+  stroke?: string;
+  strokeWidth?: number;
+  strokeOpacity?: number;
 };
 
 export type SceneTextBaseline = 'top' | 'middle' | 'bottom';


### PR DESCRIPTION
In [vega-scenegraph](https://github.com/vega/vega/tree/main/packages/vega-scenegraph), several fields are expected on the runtime types which are not present in the TypeScript representation.

Specifically:
Adds opacity and stroke related fields to `SceneSymbol` and `SceneRect`, along with the general `opacity` field to `SceneItem`.

`cornerRadius` is also added to `SceneRect`.

Before merging it is worth discussing:
- Should the fill fields and stroke fields be abstracted to `FilledSceneItem` and `StrokedSceneItem` types, or should the fields be inlined as they are currently?
- Which of these fields should be optional?