### PR TITLE
fix autosize="fit-x/y" when legend is larger than plot

### DIFF
--- a/packages/vega-view-transforms/src/ViewLayout.js
+++ b/packages/vega-view-transforms/src/ViewLayout.js
@@ -113,7 +113,9 @@ function layoutGroup(view, group, _) {
         view.dirty(item);
       }
 
-      if (_.autosize && _.autosize.type === Fit) {
+      if (_.autosize && (_.autosize.type === Fit  || 
+                         _.autosize.type === FitX || 
+                         _.autosize.type === FitY )) {
         // For autosize fit, incorporate the orthogonal dimension only.
         // Legends that overrun the chart area will then be clipped;
         // otherwise the chart area gets reduced to nothing!


### PR DESCRIPTION
Hello, I noticed that if you put legend at the top and its width is larger than plot's width, then with autosize="fit-x" plot collapses. I'm new to vega, so I'm not sure in this fix, but I tested it on Observable with different combinations of autosize/orient/direction and it seems to work.

You can try it yourself: https://observablehq.com/d/5cc4306667a37292

https://user-images.githubusercontent.com/4602302/163847170-7ded874f-5591-4a3c-88ce-62483500e625.mov

