### PR TITLE
An attempt to make time scale work with color schemes

### DIFF
--- a/packages/vega-encode/src/Scale.js
+++ b/packages/vega-encode/src/Scale.js
@@ -109,9 +109,11 @@ function scaleKey(_) {
     n = _.rawDomain ? _.rawDomain.length
       : _.domain ? _.domain.length + +(_.domainMid != null)
       : 0;
-    d = n === 2 ? Sequential + '-'
-      : n === 3 ? Diverging + '-'
-      : '';
+    if (t !== Time && t !== UTC) {
+      d = n === 2 ? Sequential + '-'
+        : n === 3 ? Diverging + '-'
+        : '';
+    }
   }
 
   return ((d + t) || Linear).toLowerCase();
@@ -119,7 +121,7 @@ function scaleKey(_) {
 
 function isContinuousColor(_) {
   const t = _.type;
-  return isContinuous(t) && t !== Time && t !== UTC && (
+  return isContinuous(t) && (
     _.scheme || _.range && _.range.length && _.range.every(isString)
   );
 }
@@ -273,6 +275,8 @@ function configureRange(scale, _, count) {
     if (isFunction(range)) {
       if (scale.interpolator) {
         return scale.interpolator(range);
+      } else if (scale.interpolate) {
+        return scale.interpolate(() => range);
       } else {
         error(`Scale type ${type} does not support interpolating color schemes.`);
       }
@@ -280,7 +284,7 @@ function configureRange(scale, _, count) {
   }
 
   // given a range array for an interpolating scale, convert to interpolator
-  if (range && isInterpolating(type)) {
+  if (range && isInterpolating(type) && scale.interpolator) {
     return scale.interpolator(
       interpolateColors(flip(range, _.reverse), _.interpolate, _.interpolateGamma)
     );

--- a/packages/vega-scale/src/scales.js
+++ b/packages/vega-scale/src/scales.js
@@ -69,8 +69,8 @@ scale(Log, $.scaleLog, [C, Log]);
 scale(Pow, $.scalePow, C);
 scale(Sqrt, $.scaleSqrt, C);
 scale(Symlog, $.scaleSymlog, C);
-scale(Time, $.scaleTime, [C, T]);
-scale(UTC, $.scaleUtc, [C, T]);
+scale(Time, $.scaleTime, [C, I, T]);
+scale(UTC, $.scaleUtc, [C, I, T]);
 
 // sequential scales
 scale(Sequential, $.scaleSequential, [C, I]); // backwards compat


### PR DESCRIPTION
Hi, I recently faced an issue when trying to map time/temporal domain to a color scheme like "turbo". 

For example the following code
```js
const data = _.range(10).map(x => ({u: x, v: new Date(2000 + x, 1, 1)}));

embed({
  width: 640,
  mark: { type: "circle", opacity: 1, size: 400 },
  data: {
    values: data
  },
  encoding: {
    x: { field: "u", type: "quantitative" },
    color: {
      field: "v",
      type: "temporal",
      scale: { scheme: "turbo" },
      legend: { orient: "top", format: "%Y" },
    }
  },
});
```
produces

<img width="689" alt="image" src="https://user-images.githubusercontent.com/4602302/164246214-72392637-b2e0-4f3a-a920-db4b98e6aa89.png">

Which is probably not what you would expect from "turbo" color scheme.

I originally posted this as question it in vega-lite discussions, but later I realized that it is more a vega issue, rather than vega-lite. 

For comparison I created the same plot using observable/plot:
```js
Plot.plot({
  color: {
    legend: true,
  },
  marks: [
    Plot.dotX(data, {x: "u", fill: "v", r: 10})
  ]
})
```
and it is correctly mapped time to colors, as I would expect:

<img width="664" alt="image" src="https://user-images.githubusercontent.com/4602302/164248182-13365b06-83b9-485e-8831-efb2cf4901f8.png">

As both vega and observable/plot use d3-scales under the hood, one might wonder, where is the difference comes from. So here is my dive into the world of scales started. TBH, it looked pretty convoluted, at least when you look into it for the first time. I still have questions like why you need `linear` and `sequentiaLinear` as separate scales, or why in some scales you have `interpolator`, but in other scales it is called `interpolate`.

So, what I realized is that in order color schemes to work you need to use `sequential` variant of the scales. But there is no `scaleSequentialTime` in d3. How does observable/plot then work? Looks like it doesn't use sequential scales at all. So, instead of:

```js
scale = d3.scaleSequential().interpolator()(d3.interpolateTurbo)
```
it uses:
```js
scale = d3.scaleLinear().interpolate(() => d3.interpolateTurbo)
```

https://github.com/observablehq/plot/blob/98d846e868e0c30bf3b55249c8ebb3308ea15440/src/scales/quantitative.js#L67-L87
```js
  // Sometimes interpolate is a named interpolator, such as "lab" for Lab color
  // space. Other times interpolate is a function that takes two arguments and
  // is used in conjunction with the range. And other times the interpolate
  // function is a “fixed” interpolator on the [0, 1] interval, as when a
  // color scheme such as interpolateRdBu is used.
  if (typeof interpolate !== "function") {
    interpolate = Interpolator(interpolate);
  }
  if (interpolate.length === 1) {
    if (reverse) {
      interpolate = flip(interpolate);
      reverse = false;
    }
    if (range === undefined) {
      range = Float64Array.from(domain, (_, i) => i / (domain.length - 1));
      if (range.length === 2) range = unit; // optimize common case of [0, 1]
    }
    scale.interpolate((range === unit ? constant : interpolatePiecewise)(interpolate));
  } else {
    scale.interpolate(interpolate);
  }
```

In this PR, I'm trying to implement the same approach for Time and UTC scales in vega. It look like it does the job, but it feels quite hacky, so I doubt it should be merged as is. I just wanted to understand and demonstrate where is the problem comes from and how it could be fixed. But probably there could be a more beautiful solution.

Here is demonstration how it works: https://observablehq.com/d/0af4e109ae46ffc3

https://user-images.githubusercontent.com/4602302/164261164-7137c287-e7cc-456c-b78e-bae9c44587f0.mov
