### PR TITLE
Add `view` style for Vega-Lite

### DIFF
--- a/packages/vega-parser/src/config.js
+++ b/packages/vega-parser/src/config.js
@@ -125,6 +125,9 @@ export default function() {
       cell: {
         fill: 'transparent',
         stroke: lightGray
+      },
+      view: {
+        fill: 'transparent'
       }
     },
 


### PR DESCRIPTION
Vega-Lite styles group marks as `cell` only if they define cartesian plots (vega/vega-lite#7665). For other types of group marks (namely, projections), we need another style in order to continue setting `transparent` fills on group marks to capture events.