### PR TITLE
fix: update touch position on touchmove event

### DIFF
--- a/packages/vega-scenegraph/src/CanvasHandler.js
+++ b/packages/vega-scenegraph/src/CanvasHandler.js
@@ -130,6 +130,7 @@ inherits(CanvasHandler, Handler, {
   },
 
   touchmove(evt) {
+    this._touch = this.pickEvent(evt.changedTouches[0]);
     this.fire(TouchMoveEvent, evt, true);
   },
 


### PR DESCRIPTION
Closes #3065

My screencast recorder doesn't show the pointer even if I turned on the setting, but you'll get the idea.


before:
[Screencast from 2022년 07월 25일 21시 28분 56초.webm](https://user-images.githubusercontent.com/969120/180777545-4da0bc96-9231-44e9-8a50-483c726f109e.webm)

after:
[Screencast from 2022년 07월 25일 21시 27분 05초.webm](https://user-images.githubusercontent.com/969120/180777364-254f9077-187e-4f2b-b3f7-31b90d7dd4be.webm)

