### PR TITLE
doc: use the main data set to obtain domain for grouped bars in grouped bar chart example

### DIFF
--- a/docs/examples/grouped-bar-chart.vg.json
+++ b/docs/examples/grouped-bar-chart.vg.json
@@ -82,7 +82,7 @@
           "name": "pos",
           "type": "band",
           "range": "height",
-          "domain": {"data": "facet", "field": "position"}
+          "domain": {"data": "table", "field": "position"}
         }
       ],
 


### PR DESCRIPTION
The reason for this PR is that currently when one of the group has fewer categories then the bar widths will be unequal.