### PR TITLE
Fix the "Edit this Page" link

### DIFF
--- a/docs/_layouts/base.html
+++ b/docs/_layouts/base.html
@@ -46,7 +46,7 @@
     <footer>
       <div class="page-centered">
         <span class="edit-page">
-          <a href="https://github.com/vega/vega/edit/master/docs/{{page.path}}">Edit this Page</a>
+          <a href="https://github.com/vega/vega/edit/main/docs/{{page.path}}">Edit this Page</a>
         </span>
         <span class="fill"></span>
         <a href="http://idl.cs.washington.edu" title="UW Interactive Data Lab" class="logo">


### PR DESCRIPTION
- The link pointed to the `master` branch, which does not exist in the vega repo so resulted in a 404
- Update the link to point to `main` branch instead
- There are other references in the repo (such as in docs/docs/api/time.md) to the `master` branch, but GitHub seems to redirect those correctly so I did not update those
