### PR TITLE
feat: add "auto" unit to timeunit transform

### DIFF
--- a/docs/vega-schema.json
+++ b/docs/vega-schema.json
@@ -15615,6 +15615,16 @@
             }
           ]
         },
+        "inferUnits": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/signalRef"
+            }
+          ]
+        },
         "step": {
           "anyOf": [
             {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17575,6 +17575,12 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/time-grain-detector": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/time-grain-detector/-/time-grain-detector-1.1.0.tgz",
+      "integrity": "sha512-RiRuAjLNOr7rpwNaVIuJlqSCSRIPirf/ZzG73aYDJ6PwZgtvn6RJ8NrKBWSDYS+zKyCsk/gOafF4jER2eBNjew==",
+      "license": "ISC"
+    },
     "node_modules/tldts": {
       "version": "6.1.85",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.85.tgz",
@@ -19662,6 +19668,7 @@
       "dependencies": {
         "d3-array": "^3.2.4",
         "d3-time": "^3.1.0",
+        "time-grain-detector": "^1.1.0",
         "vega-util": "^2.0.0"
       }
     },

--- a/packages/vega-time/index.js
+++ b/packages/vega-time/index.js
@@ -39,3 +39,7 @@ export {
 export {
   default as timeBin
 } from './src/bin.js';
+
+export {
+  default as detectTimeUnits
+} from './src/detectTimeUnits.js';

--- a/packages/vega-time/package.json
+++ b/packages/vega-time/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "d3-array": "^3.2.4",
     "d3-time": "^3.1.0",
+    "time-grain-detector": "^1.1.0",
     "vega-util": "^2.0.0"
   }
 }

--- a/packages/vega-time/src/detectTimeUnits.js
+++ b/packages/vega-time/src/detectTimeUnits.js
@@ -1,0 +1,30 @@
+import detectTimeGrain from 'time-grain-detector';
+
+import {
+    DATE,
+    HOURS,
+    MILLISECONDS,
+    MINUTES,
+    MONTH,
+    SECONDS,
+    YEAR
+} from './units';
+
+const allowedUnits = [YEAR, MONTH, DATE, HOURS, MINUTES, SECONDS, MILLISECONDS];
+const unitNameConversion = {
+    'year': YEAR,
+    'month': MONTH,
+    'day': DATE,
+    'hour': HOURS,
+    'minute': MINUTES,
+    'second': SECONDS,
+    'millisecond': MILLISECONDS
+};
+
+export default function detectTimeUnits(array, f) {
+    const { unit: rawUnit, count: step } = detectTimeGrain(array.map(f));
+    const unit = unitNameConversion[rawUnit];
+    const unitIndex = allowedUnits.indexOf(unit);
+    const units = allowedUnits.slice(0, unitIndex + 1);
+    return { units, step };
+}

--- a/packages/vega-time/src/detectTimeUnits.js
+++ b/packages/vega-time/src/detectTimeUnits.js
@@ -8,7 +8,7 @@ import {
     MONTH,
     SECONDS,
     YEAR
-} from './units';
+} from './units.js';
 
 const allowedUnits = [YEAR, MONTH, DATE, HOURS, MINUTES, SECONDS, MILLISECONDS];
 const unitNameConversion = {

--- a/packages/vega-time/test/detectTimeUnits-test.js
+++ b/packages/vega-time/test/detectTimeUnits-test.js
@@ -1,0 +1,26 @@
+var tape = require('tape'),
+    vega = require('../'),
+    { utc } = require('./util');
+
+
+tape('detectTimeUnits works for all units', t => {
+    const fn = dates => vega.detectTimeUnits(dates.map(ts => ({ ts })), _ => _.ts).units;
+    t.deepEqual(fn([utc(2000), utc(2001)]), ['year']);
+    t.deepEqual(fn([utc(2000, 0), utc(2000, 1)]), ['year', 'month']);
+    t.deepEqual(fn([utc(2000, 0, 1), utc(2000, 0, 2)]), ['year', 'month', 'date']);
+    t.deepEqual(fn([utc(2000, 0, 1, 0), utc(2000, 0, 1, 1)]), ['year', 'month', 'date', 'hours']);
+    t.deepEqual(fn([utc(2000, 0, 1, 0, 0), utc(2000, 0, 1, 0, 1)]), ['year', 'month', 'date', 'hours', 'minutes']);
+    t.deepEqual(fn([utc(2000, 0, 1, 0, 0, 0), utc(2000, 0, 1, 0, 0, 1)]), ['year', 'month', 'date', 'hours', 'minutes', 'seconds']);
+    t.end();
+});
+
+
+tape('detectTimeUnits returns correct steps', t => {
+    const fn = dates => vega.detectTimeUnits(dates.map(ts => ({ ts })), _ => _.ts);
+    t.deepEqual(fn([utc(2000), utc(2001)]), { units: ['year'], step: 1 });
+    t.deepEqual(fn([utc(2000), utc(2002)]), { units: ['year'], step: 1 });
+    t.deepEqual(fn([utc(2000), utc(2010)]), { units: ['year'], step: 10 });
+    t.deepEqual(fn([utc(2000, 0), utc(2000, 1)]), { units: ['year', 'month'], step: 1 });
+    t.deepEqual(fn([utc(2000, 0), utc(2000, 3)]), { units: ['year', 'month'], step: 3 });
+    t.end();
+});

--- a/packages/vega-time/test/detectTimeUnits-test.js
+++ b/packages/vega-time/test/detectTimeUnits-test.js
@@ -1,6 +1,6 @@
-var tape = require('tape'),
-    vega = require('../'),
-    { utc } = require('./util');
+import tape from 'tape';
+import * as vega from '../index.js';
+import { utc } from './util.js';
 
 
 tape('detectTimeUnits works for all units', t => {

--- a/packages/vega-transforms/src/TimeUnit.js
+++ b/packages/vega-transforms/src/TimeUnit.js
@@ -1,7 +1,7 @@
 import {Transform} from 'vega-dataflow';
 import {
   TIME_UNITS, timeBin, timeFloor, timeInterval, timeUnits,
-  utcFloor, utcInterval
+  utcFloor, utcInterval, detectTimeUnits
 } from 'vega-time';
 import {accessorFields, extent, inherits, peek} from 'vega-util';
 
@@ -27,6 +27,7 @@ TimeUnit.Definition = {
     { 'name': 'step', 'type': 'number', 'default': 1 },
     { 'name': 'maxbins', 'type': 'number', 'default': 40 },
     { 'name': 'extent', 'type': 'date', 'array': true},
+    { 'name': 'inferUnits', 'type': 'boolean', 'default': false },
     { 'name': 'timezone', 'type': 'enum', 'default': 'local', 'values': ['local', 'utc'] },
     { 'name': 'as', 'type': 'string', 'array': true, 'length': 2, 'default': OUTPUT }
   ]
@@ -35,18 +36,18 @@ TimeUnit.Definition = {
 inherits(TimeUnit, Transform, {
   transform(_, pulse) {
     const field = _.field,
-          band = _.interval !== false,
-          utc = _.timezone === 'utc',
-          floor = this._floor(_, pulse),
-          offset = (utc ? utcInterval : timeInterval)(floor.unit).offset,
-          as = _.as || OUTPUT,
-          u0 = as[0],
-          u1 = as[1],
-          step = floor.step;
+      band = _.interval !== false,
+      utc = _.timezone === 'utc',
+      floor = this._floor(_, pulse),
+      offset = (utc ? utcInterval : timeInterval)(floor.unit).offset,
+      as = _.as || OUTPUT,
+      u0 = as[0],
+      u1 = as[1],
+      step = floor.step;
 
     let min = floor.start || Infinity,
-        max = floor.stop || -Infinity,
-        flag = pulse.ADD;
+      max = floor.stop || -Infinity,
+      flag = pulse.ADD;
 
     if (
       _.modified() ||
@@ -83,17 +84,19 @@ inherits(TimeUnit, Transform, {
     const utc = _.timezone === 'utc';
 
     // get parameters
-    const {units, step} = _.units
-      ? {units: _.units, step: _.step || 1}
-      : timeBin({
+    const {units, step} = _.inferUnits
+      ? detectTimeUnits(pulse.materialize(pulse.SOURCE).source, _.field)
+      : _.units
+        ? {units: _.units, step: _.step || 1}
+        : timeBin({
         extent:  _.extent || extent(pulse.materialize(pulse.SOURCE).source, _.field),
-        maxbins: _.maxbins
-      });
+          maxbins: _.maxbins
+        });
 
     // check / standardize time units
     const tunits = timeUnits(units),
-          prev = this.value || {},
-          floor = (utc ? utcFloor : timeFloor)(tunits, step);
+      prev = this.value || {},
+      floor = (utc ? utcFloor : timeFloor)(tunits, step);
 
     floor.unit = peek(tunits);
     floor.units = tunits;

--- a/packages/vega-transforms/src/TimeUnit.js
+++ b/packages/vega-transforms/src/TimeUnit.js
@@ -36,18 +36,18 @@ TimeUnit.Definition = {
 inherits(TimeUnit, Transform, {
   transform(_, pulse) {
     const field = _.field,
-      band = _.interval !== false,
-      utc = _.timezone === 'utc',
-      floor = this._floor(_, pulse),
-      offset = (utc ? utcInterval : timeInterval)(floor.unit).offset,
-      as = _.as || OUTPUT,
-      u0 = as[0],
-      u1 = as[1],
-      step = floor.step;
+          band = _.interval !== false,
+          utc = _.timezone === 'utc',
+          floor = this._floor(_, pulse),
+          offset = (utc ? utcInterval : timeInterval)(floor.unit).offset,
+          as = _.as || OUTPUT,
+          u0 = as[0],
+          u1 = as[1],
+          step = floor.step;
 
     let min = floor.start || Infinity,
-      max = floor.stop || -Infinity,
-      flag = pulse.ADD;
+        max = floor.stop || -Infinity,
+        flag = pulse.ADD;
 
     if (
       _.modified() ||
@@ -89,14 +89,14 @@ inherits(TimeUnit, Transform, {
       : _.units
         ? {units: _.units, step: _.step || 1}
         : timeBin({
-        extent:  _.extent || extent(pulse.materialize(pulse.SOURCE).source, _.field),
+          extent:  _.extent || extent(pulse.materialize(pulse.SOURCE).source, _.field),
           maxbins: _.maxbins
         });
 
     // check / standardize time units
     const tunits = timeUnits(units),
-      prev = this.value || {},
-      floor = (utc ? utcFloor : timeFloor)(tunits, step);
+          prev = this.value || {},
+          floor = (utc ? utcFloor : timeFloor)(tunits, step);
 
     floor.unit = peek(tunits);
     floor.units = tunits;

--- a/packages/vega-typings/types/spec/transform.d.ts
+++ b/packages/vega-typings/types/spec/transform.d.ts
@@ -649,6 +649,7 @@ export interface TimeUnitTransform {
   field: FieldRef;
   interval?: boolean | SignalRef;
   units?: (TimeUnit | SignalRef)[] | SignalRef;
+  inferUnits?: boolean | SignalRef;
   step?: number | SignalRef;
   timezone?: TimeZone | SignalRef;
   as?: Vector2<string | SignalRef> | SignalRef;

--- a/packages/vega/test/specs-valid.json
+++ b/packages/vega/test/specs-valid.json
@@ -11,6 +11,7 @@
   "bar-hover-label",
   "bar-rangestep",
   "bar-time",
+  "bar-time-auto",
   "barley",
   "basemap",
   "box-plot",

--- a/packages/vega/test/specs-valid/bar-time-auto.vg.json
+++ b/packages/vega/test/specs-valid/bar-time-auto.vg.json
@@ -1,0 +1,123 @@
+{
+  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "width": 500,
+  "height": 200,
+  "data": [
+    {
+      "name": "data",
+      "values": [
+        {
+          "t": "2020-01-01",
+          "value": 1
+        },
+        {
+          "t": "2021-01-01",
+          "value": 2
+        },
+        {
+          "t": "2022-01-01",
+          "value": 3
+        },
+        {
+          "t": "2023-01-01",
+          "value": 4
+        }
+      ],
+      "format": {
+        "type": "json",
+        "parse": {
+          "t": "date"
+        }
+      },
+      "transform": [
+        {
+          "type": "timeunit",
+          "field": "t",
+          "inferUnits": true
+        }
+      ]
+    }
+  ],
+  "marks": [
+    {
+      "name": "marks",
+      "type": "rect",
+      "from": {
+        "data": "data"
+      },
+      "encode": {
+        "update": {
+          "fill": {
+            "value": "#4c78a8"
+          },
+          "x": {
+            "scale": "x",
+            "field": "unit0"
+          },
+          "x2": {
+            "scale": "x",
+            "field": "unit1"
+          },
+          "y": {
+            "signal": "height"
+          },
+          "y2": {
+            "scale": "y",
+            "field": "value"
+          }
+        }
+      }
+    }
+  ],
+  "scales": [
+    {
+      "name": "x",
+      "type": "time",
+      "domain": {
+        "data": "data",
+        "fields": [
+          "unit0",
+          "unit1"
+        ]
+      },
+      "range": [
+        0,
+        {
+          "signal": "width"
+        }
+      ]
+    },
+    {
+      "name": "y",
+      "type": "linear",
+      "domain": {
+        "data": "data",
+        "field": "value"
+      },
+      "range": [
+        {
+          "signal": "height"
+        },
+        0
+      ],
+      "zero": true
+    }
+  ],
+  "axes": [
+    {
+      "scale": "x",
+      "orient": "bottom",
+      "labelAlign": "right",
+      "labelAngle": 270,
+      "labelBaseline": "middle"
+    },
+    {
+      "scale": "y",
+      "orient": "left",
+      "title": "value",
+      "tickCount": {
+        "signal": "ceil(height/40)"
+      }
+    }
+  ]
+}

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -27,6 +27,13 @@ const d3Deps = [
   'd3-delaunay'
 ];
 
+const esmDeps = [
+  ...d3Deps,
+  'd3-geo-projection',
+  'd3-scale-chromatic',
+  'time-grain-detector'
+];
+
 const d3CoreDeps = [
   ...d3Deps,
   'topojson-client'

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -27,13 +27,6 @@ const d3Deps = [
   'd3-delaunay'
 ];
 
-const esmDeps = [
-  ...d3Deps,
-  'd3-geo-projection',
-  'd3-scale-chromatic',
-  'time-grain-detector'
-];
-
 const d3CoreDeps = [
   ...d3Deps,
   'topojson-client'


### PR DESCRIPTION
This pull request adds a new infer unit option to the TimeUnit transform. When set to infer units, the transform will automatically choose the appropriate time unit based on the input data.

I wanted to try and solve the problem discussed in #1310: plotting discretized timeseries data without knowing the grain.

Here's [a demo Observable notebook](https://observablehq.com/d/5d869cd32fb125a4). It patches the timeunit transform and uses DuckDB to produce differently grouped time data.

## Problem/Solution
Currently, you can discretize data into months using this transform. 
```json
{"type": "timeunit", "field": "date", "units": ["year", "month"]}
```

But, if your data is _already_ grouped by month, there's no way to infer that from the data.
This PR adds an "auto" unit option that would work with this example data.

```json
[{"date": "2023-01-01"}, {"date": "2023-02-01"}, {"date": "2023-03-01"}]
```

```json
{"type": "timeunit", "field": "date", "inferUnits": true}
```

## Alternate approaches

In [an issue comment](https://github.com/vega/vega/issues/1310#issuecomment-396734615), @jheer suggested creating a new discretizing time scale that acts like a band scale. I believe that discussion happened before the TimeUnit transform was added. Enhancing TimeUnit seemed more natural fit than adding a scale, but I'd love to hear any other thoughts! I meant this PR mostly as a discussion starter with some running code. 

## Questions
- Is the API right?
~I'm uncertain about the `"units": ["auto"]` parameter. Would a separate param be better? e.g. `"inferUnits": true` or similar?~
I updated this to `inferUnits: true`. Very open to feedback on the naming here though!
- Should I pull in the dependency?
I created a small npm package that does the work to determine the likely unit/step. It felt like a separate concern that's not specific to vega, but it's very small. Should I pull that into vega-time as part of this PR?
The main reason to leave it separate IMO is to add tests that would be annoying to have in Vega. I want to run the tests with Node booted into different timezones, but that's annoying requirement to put on a bigger project.