### PR TITLE
feat(vega-force): Enable expr support for nbody 'strength' param

### DIFF
--- a/docs/docs/transforms/force.md
+++ b/docs/docs/transforms/force.md
@@ -69,8 +69,8 @@ An n-body force that causes nodes to either attract or repel each other.
 | Property            | Type                           | Description   |
 | :------------------ | :----------------------------: | :------------ |
 | force               | {% include type t="String" %}  | The value `"nbody"`.|
-| strength            | {% include type t="Number" %}  | The relative strength of this force (default `-30`). Negative values cause nodes to repel, positive values to attract.|
-| theta               | {% include type t="Number" %}  | Approximation parameter for aggregating more distance forces (default `0.9`).|
+| strength            | {% include type t="Number|Expr" %}  | The relative strength of this force (default `-30`). Negative values cause nodes to repel, positive values to attract.|
+| theta               | {% include type t="Number|Expr" %}  | Approximation parameter for aggregating more distance forces (default `0.9`).|
 | distanceMin         | {% include type t="Number" %}  | The minimum distance over which this force acts. If two nodes are close than _distanceMin_, the exerted forces will be as if they are _distanceMin_ apart (default `1`).|
 | distanceMax         | {% include type t="Number" %}  | The maximum distance over which this force acts. If two nodes exceed _distanceMax_, they will not exert forces on each other.|
 

--- a/docs/docs/transforms/force.md
+++ b/docs/docs/transforms/force.md
@@ -70,7 +70,7 @@ An n-body force that causes nodes to either attract or repel each other.
 | :------------------ | :----------------------------: | :------------ |
 | force               | {% include type t="String" %}  | The value `"nbody"`.|
 | strength            | {% include type t="Number|Expr" %}  | The relative strength of this force (default `-30`). Negative values cause nodes to repel, positive values to attract.|
-| theta               | {% include type t="Number|Expr" %}  | Approximation parameter for aggregating more distance forces (default `0.9`).|
+| theta               | {% include type t="Number" %}  | Approximation parameter for aggregating more distance forces (default `0.9`).|
 | distanceMin         | {% include type t="Number" %}  | The minimum distance over which this force acts. If two nodes are close than _distanceMin_, the exerted forces will be as if they are _distanceMin_ apart (default `1`).|
 | distanceMax         | {% include type t="Number" %}  | The maximum distance over which this force acts. If two nodes exceed _distanceMax_, they will not exert forces on each other.|
 

--- a/packages/vega-force/src/Force.js
+++ b/packages/vega-force/src/Force.js
@@ -66,8 +66,8 @@ Force.Definition = {
         {
           'key': {'force': 'nbody'},
           'params': [
-            { 'name': 'strength', 'type': 'number', 'default': -30 },
-            { 'name': 'theta', 'type': 'number', 'default': 0.9 },
+            { 'name': 'strength', 'type': 'number', 'default': -30, 'expr': true },
+            { 'name': 'theta', 'type': 'number', 'default': 0.9, 'expr': true },
             { 'name': 'distanceMin', 'type': 'number', 'default': 1 },
             { 'name': 'distanceMax', 'type': 'number' }
           ]

--- a/packages/vega-force/src/Force.js
+++ b/packages/vega-force/src/Force.js
@@ -67,7 +67,7 @@ Force.Definition = {
           'key': {'force': 'nbody'},
           'params': [
             { 'name': 'strength', 'type': 'number', 'default': -30, 'expr': true },
-            { 'name': 'theta', 'type': 'number', 'default': 0.9, 'expr': true },
+            { 'name': 'theta', 'type': 'number', 'default': 0.9 },
             { 'name': 'distanceMin', 'type': 'number', 'default': 1 },
             { 'name': 'distanceMax', 'type': 'number' }
           ]

--- a/packages/vega-typings/types/spec/transform.d.ts
+++ b/packages/vega-typings/types/spec/transform.d.ts
@@ -330,7 +330,7 @@ export interface ForceLink {
 }
 export interface ForceNBody {
   force: 'nbody';
-  strength?: number | SignalRef;
+  strength?: number | SignalRef | ExprRef;
   theta?: number | SignalRef;
   distanceMin?: number | SignalRef;
   distanceMax?: number | SignalRef;


### PR DESCRIPTION
Improve n-body force flexibility by enabling support for per-node _expr_ control of the 'strength' parameter. 