### PR TITLE
feat: Add aggregate parameters to vega-transform, and exponential moving average

### DIFF
--- a/packages/vega-transforms/src/Aggregate.js
+++ b/packages/vega-transforms/src/Aggregate.js
@@ -11,6 +11,7 @@ import {accessorFields, accessorName, array, error, inherits} from 'vega-util';
  * @param {Array<function(object): *>} [params.groupby] - An array of accessors to groupby.
  * @param {Array<function(object): *>} [params.fields] - An array of accessors to aggregate.
  * @param {Array<string>} [params.ops] - An array of strings indicating aggregation operations.
+ * @param {Array<object>} [params.aggregate_params=[null]] - An optional array of parameters for aggregation operations.
  * @param {Array<string>} [params.as] - An array of output field names for aggregated values.
  * @param {boolean} [params.cross=false] - A flag indicating that the full
  *   cross-product of groupby values should be generated, including empty cells.
@@ -45,6 +46,7 @@ Aggregate.Definition = {
   'params': [
     { 'name': 'groupby', 'type': 'field', 'array': true },
     { 'name': 'ops', 'type': 'enum', 'array': true, 'values': ValidAggregateOps },
+    { 'name': 'aggregate_params', 'type': 'field', 'null': true, 'array': true, 'default': [null] },
     { 'name': 'fields', 'type': 'field', 'null': true, 'array': true },
     { 'name': 'as', 'type': 'string', 'null': true, 'array': true },
     { 'name': 'drop', 'type': 'boolean', 'default': true },
@@ -161,10 +163,11 @@ inherits(Aggregate, Transform, {
 
     const fields = _.fields || [null],
           ops = _.ops || ['count'],
+          aggregate_params = _.aggregate_params || [null],
           as = _.as || [],
           n = fields.length,
           map = {};
-    let field, op, m, mname, outname, i;
+    let field, op, aggregate_param, m, mname, outname, i;
 
     if (n !== ops.length) {
       error('Unmatched number of fields and aggregate ops.');
@@ -173,6 +176,7 @@ inherits(Aggregate, Transform, {
     for (i=0; i<n; ++i) {
       field = fields[i];
       op = ops[i];
+      aggregate_param = aggregate_params[i] || null;
 
       if (field == null && op !== 'count') {
         error('Null aggregate field specified.');
@@ -195,7 +199,7 @@ inherits(Aggregate, Transform, {
       }
 
       if (op !== 'count') this._countOnly = false;
-      m.push(createMeasure(op, outname));
+      m.push(createMeasure(op, aggregate_param, outname));
     }
 
     this._measures = this._measures.map(m => compileMeasures(m, m.field));

--- a/packages/vega-transforms/src/Window.js
+++ b/packages/vega-transforms/src/Window.js
@@ -17,6 +17,7 @@ import {bisector} from 'd3-array';
  * @param {Array<function(object): *>} [params.fields] - An array of accessors
  *   for data fields to use as inputs to window operations.
  * @param {Array<*>} [params.params] - An array of parameter values for window operations.
+ * @param {Array<object>} [params.aggregate_params] - An optional array of parameter values for aggregation operations.
  * @param {Array<string>} [params.as] - An array of output field names for window operations.
  * @param {Array<number>} [params.frame] - Window frame definition as two-element array.
  * @param {boolean} [params.ignorePeers=false] - If true, base window frame boundaries on row
@@ -37,6 +38,7 @@ Window.Definition = {
     { 'name': 'groupby', 'type': 'field', 'array': true },
     { 'name': 'ops', 'type': 'enum', 'array': true, 'values': ValidWindowOps.concat(ValidAggregateOps) },
     { 'name': 'params', 'type': 'number', 'null': true, 'array': true },
+    { 'name': 'aggregate_params', 'type': 'field', 'null': true, 'array': true, 'default': [null] },
     { 'name': 'fields', 'type': 'field', 'null': true, 'array': true },
     { 'name': 'as', 'type': 'string', 'null': true, 'array': true },
     { 'name': 'frame', 'type': 'number', 'null': true, 'array': true, 'length': 2, 'default': [null, 0] },

--- a/packages/vega-transforms/src/util/AggregateOps.js
+++ b/packages/vega-transforms/src/util/AggregateOps.js
@@ -127,6 +127,16 @@ export const AggregateOps = {
     add:  (m, v, t) => { if (v > m.max) m.argmax = t; },
     rem:  (m, v) => { if (v >= m.max) m.argmax = undefined; },
     req:  ['max', 'values'], idx: 3
+  },
+  exponential: {
+    init: (m, r) => { m.exp = 0; m.exp_r = r; },
+    value: m => m.valid ? (m.exp * (1 - m.exp_r) / (1 - m.exp_r ** m.valid)) : undefined,
+    add:  (m, v) => m.exp = m.exp_r * m.exp + v,
+    rem:  (m, v) => m.exp = (m.exp - v / m.exp_r ** (m.valid - 1)) / m.exp_r
+  },
+  exponentialb: {
+    value: m => m.valid ? (m.exp * (1 - m.exp_r)) : undefined,
+    req:  ['exponential'], idx: 1
   }
 };
 

--- a/packages/vega-transforms/src/util/AggregateOps.js
+++ b/packages/vega-transforms/src/util/AggregateOps.js
@@ -133,8 +133,9 @@ export const AggregateOps = {
 export const ValidAggregateOps = Object.keys(AggregateOps).filter(d => d !== '__count__');
 
 function measure(key, value) {
-  return out => extend({
+  return (out, aggregate_param) => extend({
     name: key,
+    aggregate_param: aggregate_param,
     out: out || key
   }, base_op, value);
 }
@@ -143,8 +144,8 @@ function measure(key, value) {
   AggregateOps[key] = measure(key, AggregateOps[key]);
 });
 
-export function createMeasure(op, name) {
-  return AggregateOps[op](name);
+export function createMeasure(op, param, name) {
+  return AggregateOps[op](name, param);
 }
 
 function compareIndex(a, b) {
@@ -169,7 +170,7 @@ function resolve(agg) {
 function init() {
   this.valid = 0;
   this.missing = 0;
-  this._ops.forEach(op => op.init(this));
+  this._ops.forEach(op => (op.aggregate_param == null) ? op.init(this) : op.init(this, op.aggregate_param));
 }
 
 function add(v, t) {

--- a/packages/vega-transforms/src/util/WindowState.js
+++ b/packages/vega-transforms/src/util/WindowState.js
@@ -7,6 +7,7 @@ export default function WindowState(_) {
   const ops = array(_.ops),
         fields = array(_.fields),
         params = array(_.params),
+        aggregate_params = array(_.aggregate_params),
         as = array(_.as),
         outputs = this.outputs = [],
         windows = this.windows = [],
@@ -24,6 +25,8 @@ export default function WindowState(_) {
 
   ops.forEach((op, i) => {
     const field = fields[i],
+          param = params[i],
+          aggregate_param = aggregate_params[i] || null,
           mname = accessorName(field),
           name = measureName(op, mname, as[i]);
 
@@ -32,7 +35,7 @@ export default function WindowState(_) {
 
     // Window operation
     if (hasOwnProperty(WindowOps, op)) {
-      windows.push(WindowOp(op, fields[i], params[i], name));
+      windows.push(WindowOp(op, field, param, name));
     }
 
     // Aggregate operation
@@ -52,7 +55,7 @@ export default function WindowState(_) {
         m.field = field;
         measures.push(m);
       }
-      m.push(createMeasure(op, name));
+      m.push(createMeasure(op, aggregate_param, name));
     }
   });
 

--- a/packages/vega-transforms/test/aggregate-test.js
+++ b/packages/vega-transforms/test/aggregate-test.js
@@ -18,8 +18,9 @@ tape('Aggregate aggregates tuples', t => {
       col = df.add(Collect),
       agg = df.add(Aggregate, {
         groupby: [key],
-        fields: [val, val, val, val, val],
-        ops: ['count', 'sum', 'min', 'max', 'product'],
+        fields: [val, val, val, val, val, val],
+        ops: ['exponential', 'count', 'sum', 'min', 'max', 'product'],
+        aggregate_params: [0.5],
         pulse: col
       }),
       out = df.add(Collect, {pulse: agg});
@@ -34,12 +35,14 @@ tape('Aggregate aggregates tuples', t => {
   t.equal(d[0].min_v, 1);
   t.equal(d[0].max_v, 2);
   t.equal(d[0].product_v, 2);
+  t.equal(d[0].exponential_v, 1.6666666666666667);
   t.equal(d[1].k, 'b');
   t.equal(d[1].count_v, 2);
   t.equal(d[1].sum_v, 7);
   t.equal(d[1].min_v, 3);
   t.equal(d[1].max_v, 4);
   t.equal(d[1].product_v, 12);
+  t.equal(d[1].exponential_v, 3.6666666666666665);
 
   // -- test rems
   df.pulse(col, changeset().remove(data.slice(0, 2))).run();
@@ -323,7 +326,9 @@ tape('Aggregate handles empty/invalid data', t => {
     'stdev',
     'min',
     'max',
-    'median'
+    'median',
+    'exponential',
+    'exponentialb'
   ];
   const res = [4, 3, 0, 0]; // higher indices 'undefined'
 


### PR DESCRIPTION
This adds exponential moving averages, fixing #3341. In order to do this, it enables supplying parameters to aggregation functions. This addresses the block on https://github.com/vega/vega-lite/issues/4439.

As I'm not a javascript programmer, feedback will be gratefully taken on board.