### PR TITLE
update tickCount types to correspond to TimeFormatSpecifier

### DIFF
--- a/packages/vega-typings/types/spec/axis.d.ts
+++ b/packages/vega-typings/types/spec/axis.d.ts
@@ -4,10 +4,9 @@ import {
   RuleEncodeEntry,
   SignalRef,
   TextEncodeEntry,
-  TimeInterval,
+  TimeUnit
 } from '.';
 import { Text } from './encode';
-import { TimeIntervalStep } from './scale';
 import {
   AlignValue,
   AnchorValue,
@@ -26,9 +25,14 @@ export type AxisOrient = 'top' | 'bottom' | 'left' | 'right';
 
 export type LabelOverlap = boolean | 'parity' | 'greedy';
 
-export type TickCount = number | TimeInterval | TimeIntervalStep | SignalRef;
+export type TickCount = number | TimeUnit | TickCountIntervalStep | SignalRef;
 
 export type FormatType = 'number' | 'time' | 'utc';
+
+export type TickCountIntervalStep = {
+  interval: TimeUnit;
+  step: number;
+}
 
 export interface TimeFormatSpecifier {
   year?: string;


### PR DESCRIPTION
Looking at the code in here: https://github.com/vega/vega/blob/main/packages/vega-scale/src/ticks.js#L41 the `tickCount` calls the `timeInterval` function defined in [intervals.js](https://github.com/vega/vega/blob/main/packages/vega-time/src/interval.js#L62-L64) which uses the [`TimeUnit` type](https://github.com/vega/vega/blob/main/packages/vega-typings/types/spec/transform.d.ts#L655). Updated the typings to reflect this.

I'm new to the codebase and might be missing some link between axis tickCount and scales, so if this looks wrong, let me know how I can fix it. Thanks!