### PR TITLE
fix: handle consecutive escapes for splitAccessPath

### DIFF
--- a/packages/vega-util/src/splitAccessPath.js
+++ b/packages/vega-util/src/splitAccessPath.js
@@ -20,8 +20,7 @@ export default function(p) {
   for (i=j=0; j<n; ++j) {
     c = p[j];
     if (c === '\\') {
-      s += p.substring(i, j);
-      s += p.substring(++j, ++j);
+      s += p.substring(i, j++);
       i = j;
     } else if (c === q) {
       push();

--- a/packages/vega-util/test/splitAccessPath-test.js
+++ b/packages/vega-util/test/splitAccessPath-test.js
@@ -18,6 +18,8 @@ tape('splitAccessPath parses field accessor paths', t => {
   t.deepEqual(vega.splitAccessPath('y\\[foo\\]'), ['y[foo]']);
   t.deepEqual(vega.splitAccessPath('y\\[foo'), ['y[foo']);
   t.deepEqual(vega.splitAccessPath('yfoo\\]'), ['yfoo]']);
+  t.deepEqual(vega.splitAccessPath("\\[\\'foo\\'\\]"), ["['foo']"]);
+  t.deepEqual(vega.splitAccessPath('\\a\\b\\c'), ['abc']);
   t.end();
 });
 


### PR DESCRIPTION
There was a bug in `splitAccessPaths` where if there were consecutive `\\`s it would skip a character due to an extra increment in the index

For example:
- `\\a\\b\\c` -> `a\\bc` (which is wrong but perhaps harmless)
- `\\[\\"foo\\"\\]` -> `Access path missing open bracket` error due to skipping the last `\\` following `\\"` and getting in the `]` conditional although it's been escaped

Added tests for these cases