### PR TITLE
fix: correct browserlists for IE support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ For a basic setup allowing you to build Vega and run examples:
 
 This repository includes the Vega website and documentation in the `docs` folder. To launch the website locally, first run `bundle install` in the `docs` folder to install the necessary Jekyll libraries. Afterwards, use `yarn docs` to build the documentation and launch a local webserver. After launching, you can open [`http://127.0.0.1:4000/vega/`](http://127.0.0.1:4000/vega/) to see the website.
 
-## ES5 Support
-For backwards compatibility, Vega includes a [babel-ified](https://babeljs.io/) ES5-compatible version of the code in `packages/vega/build-es5` directory. Older browser would also require several polyfill libraries:
+## Internet Explorer Support
+For backwards compatibility, Vega includes a [babel-ified](https://babeljs.io/) IE-compatible version of the code in the `packages/vega/build-es5` directory. Older browser would also require several polyfill libraries:
 
 ```html
 <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/7.4.4/polyfill.min.js"></script>

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -123,12 +123,12 @@ Vega visualizations will be added to a parent DOM container element. This elemen
 
 ### <a name="ie"></a>Supporting Internet Explorer or Older Browsers
 
-Vega is intended to be used with [ES6](http://es6-features.org/)-compliant JavaScript runtimes. This includes all major modern browsers, including Firefox, Chrome, Safari, and Edge, and server-side using Node.js. Prior to version 4.4, Vega supported Internet Explorer 10 or 11 in conjunction with a set of polyfills; for more details, see the [supporting Internet Explorer](internet-explorer) documentation. Subsequent Vega versions do *not* directly support IE. To use the latest versions of Vega with IE, you can use a JavaScript compiler such as [Babel](https://babeljs.io/) to generate ES5-compliant code or use our precompiled ES5 compliant versions as shown below.
+Vega is intended to be used with [modern JavaScript runtimes](https://browsersl.ist/#q=defaults%2C+last+1+node+versions). This includes all major modern browsers, including Firefox, Chrome, Safari, and Edge, and server-side using Node.js. Prior to version 4.4, Vega supported Internet Explorer 10 or 11 in conjunction with a set of polyfills; for more details, see the [supporting Internet Explorer](internet-explorer) documentation. Subsequent Vega versions do *not* directly support IE. To use the latest versions of Vega with IE, you can use a JavaScript compiler such as [Babel](https://babeljs.io/) to generate IE compatible code or use our precompiled IE compatible versions as shown below.
 
 ```html
 <head>
   <script src="https://cdn.jsdelivr.net/npm/vega@{{ site.data.versions.vega }}/build-es5/vega.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/vega-embed@{{ site.data.versions.vega-embed }}/build-es5/vega-embed.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/vega-embed@6.21.3/build-es5/vega-embed.js"></script>
 </head>
 <body>
   <div id="view"></div>

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -135,7 +135,7 @@ export default function(commandLineArgs) {
       format: 'esm',
       sourcemap: false
     },
-    plugins: [nodePlugin(true), ...commonPlugins('defaults and not IE 11')]
+    plugins: [nodePlugin(true), ...commonPlugins('defaults')]
   }];
 
   if (browser) {
@@ -188,7 +188,7 @@ export default function(commandLineArgs) {
         globals,
         name
       }),
-      plugins: [nodePlugin(true), ...commonPlugins('defaults and not IE 11')]
+      plugins: [nodePlugin(true), ...commonPlugins('defaults')]
     });
 
     if (ie) {
@@ -203,7 +203,7 @@ export default function(commandLineArgs) {
           globals,
           name
         }),
-        plugins: [nodePlugin(true), ...commonPlugins('defaults')]
+        plugins: [nodePlugin(true), ...commonPlugins('defaults, IE 11')]
       });
     }
   }
@@ -221,7 +221,7 @@ export default function(commandLineArgs) {
         globals,
         name
       }),
-      plugins: [nodePlugin(true), ...commonPlugins('defaults and not IE 11')]
+      plugins: [nodePlugin(true), ...commonPlugins('defaults')]
     });
 
     if (ie) {
@@ -238,7 +238,7 @@ export default function(commandLineArgs) {
           globals,
           name
         }),
-        plugins: [nodePlugin(true), ...commonPlugins('defaults')]
+        plugins: [nodePlugin(true), ...commonPlugins('defaults, IE 11')]
       });
     }
   }

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -135,7 +135,7 @@ export default function(commandLineArgs) {
       format: 'esm',
       sourcemap: false
     },
-    plugins: [nodePlugin(true), ...commonPlugins('defaults')]
+    plugins: [nodePlugin(true), ...commonPlugins('defaults, last 1 node versions')]
   }];
 
   if (browser) {
@@ -188,7 +188,7 @@ export default function(commandLineArgs) {
         globals,
         name
       }),
-      plugins: [nodePlugin(true), ...commonPlugins('defaults')]
+      plugins: [nodePlugin(true), ...commonPlugins('defaults, last 1 node versions')]
     });
 
     if (ie) {
@@ -221,7 +221,7 @@ export default function(commandLineArgs) {
         globals,
         name
       }),
-      plugins: [nodePlugin(true), ...commonPlugins('defaults')]
+      plugins: [nodePlugin(true), ...commonPlugins('defaults, last 1 node versions')]
     });
 
     if (ie) {


### PR DESCRIPTION
The previous browserlists was useless since defaults does not support IE anymore. 

fixes #3723 