### PR TITLE
feat(vega-cli): add ppi setting for png cli export

### DIFF
--- a/packages/vega-cli/bin/vg2png
+++ b/packages/vega-cli/bin/vg2png
@@ -6,6 +6,6 @@ const {createWriteStream} = require('fs'),
 render('png', function(canvas, arg) {
   const file = arg._[1] || null,
         out = file ? createWriteStream(file) : process.stdout,
-        stream = canvas.createPNGStream();
+        stream = canvas.createPNGStream({ resolution: arg.ppi || undefined });
   stream.on('data', chunk => { out.write(chunk); });
 });

--- a/packages/vega-cli/src/args.js
+++ b/packages/vega-cli/src/args.js
@@ -51,6 +51,9 @@ To load data, you may need to set a base directory:
     args.boolean('test')
       .describe('test', 'Disable default PDF metadata for test suites.');
   }
+  else if (type === 'png') {
+    args.number('ppi').describe('ppi', 'Resolution in ppi.');
+  }
 
   return args.help().version().argv;
 };

--- a/packages/vega-cli/src/render.js
+++ b/packages/vega-cli/src/render.js
@@ -30,6 +30,9 @@ module.exports = function(type, callback, opt) {
   // set output image scale factor
   const scale = arg.scale || undefined;
 
+  // Allows for other ppi settings than 72 for png files
+  const ppi = arg.ppi || 72;
+
   // use a seeded random number generator, if specified
   if (typeof arg.seed !== 'undefined') {
     if (Number.isNaN(arg.seed)) throw 'Illegal seed value: must be a valid number.';
@@ -53,7 +56,7 @@ module.exports = function(type, callback, opt) {
 
     return (type === 'svg'
         ? view.toSVG(scale)
-        : view.toCanvas(scale, opt)
+        : view.toCanvas(scale * ppi / 72, opt)
       ).then(_ => callback(_, arg));
   }
 


### PR DESCRIPTION
Fixes https://github.com/vega/vega/issues/2269.

https://github.com/vega/vega-lite/pull/8854 is the same story for vega-lite and has more discussion about the specific choices I made.