### PR TITLE
fix: correct tickMinStep calculation logic

### DIFF
--- a/packages/vega-scale/src/ticks.js
+++ b/packages/vega-scale/src/ticks.js
@@ -27,7 +27,7 @@ export function tickCount(scale, count, minStep) {
     if (minStep != null) {
       count = Math.min(
         count,
-        Math.floor((span(scale.domain()) / minStep) || 1)
+        Math.floor((span(scale.domain()) / minStep) || 1) + 1
       );
     }
   }


### PR DESCRIPTION
If the domain is [0, 1], the span is 1.  The ideal tick count based on minStep should output 2, not 1. 

Not sure how we suppose to test vega-scale. I don't see many test files here. 