### PR TITLE
fix npe for voronoi path point

### DIFF
--- a/packages/vega-voronoi/src/Voronoi.js
+++ b/packages/vega-voronoi/src/Voronoi.js
@@ -41,7 +41,7 @@ inherits(Voronoi, Transform, {
     // map polygons to paths
     for (let i=0, n=data.length; i<n; ++i) {
       const polygon = voronoi.cellPolygon(i);
-      data[i][as] = polygon ? toPathString(polygon) : null;
+      data[i][as] = polygon && !isPoint(polygon) ? toPathString(polygon) : null;
     }
 
     return pulse.reflow(_.modified()).modifies(as);
@@ -57,4 +57,8 @@ function toPathString(p) {
   for (; p[n][0] === x && p[n][1] === y; --n);
 
   return 'M' + p.slice(0, n + 1).join('L') + 'Z';
+}
+
+function isPoint(p) {
+  return p.length === 2 && p[0][0] === p[1][0] && p[0][1] === p[1][1];
 }


### PR DESCRIPTION
When getting [the path string while computing the voronoi transform](https://github.com/vega/vega/blob/main/packages/vega-voronoi/src/Voronoi.js#L44), if the polygon is a point, we run into an issue where the counter in the [`toPathString` function](https://github.com/vega/vega/blob/main/packages/vega-voronoi/src/Voronoi.js#L57) throws an NPE due to the counter (`n`) getting down to -1.

In my case the chart container sometimes had 0 width/height and then expanded to fit size, and having that initial size to be 0 resulted in this issue.

This PR fixes this issue by only computing a polygon's path string only when the polygon is not a point