### PR TITLE
feat: bump vega typings to 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "rollup-plugin-bundle-size": "^1.0.3",
     "serve": "^14.2.0",
     "tape": "^5.6.3",
-    "typescript": "~5.0.4",
+    "typescript": "~5.1.6",
     "vega-datasets": "^2.7.0"
   },
   "workspaces": [

--- a/packages/vega-typings/package.json
+++ b/packages/vega-typings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vega-typings",
-  "version": "0.24.2",
+  "version": "1.0.0",
   "description": "Typings for Vega.",
   "types": "types",
   "repository": "vega/vega",
@@ -21,8 +21,8 @@
   "dependencies": {
     "@types/geojson": "7946.0.4",
     "vega-event-selector": "^3.0.1",
-    "vega-expression": "^5.0.1",
-    "vega-util": "^1.17.1"
+    "vega-expression": "^5.1.0",
+    "vega-util": "^1.17.2"
   },
   "devDependencies": {
     "ts-json-schema-generator": "^1.2.0"

--- a/packages/vega/package.json
+++ b/packages/vega/package.json
@@ -51,7 +51,7 @@
     "vega-statistics": "~1.9.0",
     "vega-time": "~2.1.1",
     "vega-transforms": "~4.10.2",
-    "vega-typings": "~0.24.0",
+    "vega-typings": "~1.0.0",
     "vega-util": "~1.17.2",
     "vega-view": "~5.11.1",
     "vega-view-transforms": "~4.5.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8132,10 +8132,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
-typescript@~5.0.4:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
-  integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
+typescript@~5.1.6:
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.6.tgz#02f8ac202b6dad2c0dd5e0913745b47a37998274"
+  integrity sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==
 
 uglify-js@^3.1.4:
   version "3.17.4"


### PR DESCRIPTION
This will make it easier to release patch versions of the typings. 