### PR TITLE
Fall back to textMetrics.width for user defined width function

### DIFF
--- a/packages/vega-scenegraph/src/util/text.js
+++ b/packages/vega-scenegraph/src/util/text.js
@@ -79,10 +79,13 @@ function widthGetter(item) {
     // we are using canvas
     const currentFont = font(item);
     return text => _measureWidth(text, currentFont);
-  } else {
+  } else if (textMetrics.width === estimateWidth) {
     // we are relying on estimates
     const currentFontHeight = fontSize(item);
     return text => _estimateWidth(text, currentFontHeight);
+  } else {
+    // User defined textMetrics.width function in use (e.g. vl-convert)
+    return text => textMetrics.width(item, text);
   }
 }
 


### PR DESCRIPTION
Closes https://github.com/vega/vega/issues/3715

## Overview
vl-convert runs Vega and Vega-Lite inside the Deno JavaScript runtime to perform static image export. Since node canvas is not compatible with Deno, vl-convert overrides the default vega-scenegraph [textMetrics.width](https://github.com/vega/vega/blob/d0b886881bd27da626b0d33f2db23bd17f6f4277/packages/vega-scenegraph/src/util/text.js#L7-L13) function to use a Rust function to compute text metrics.

This works really well in practice, the only issue we've run into is that text truncation logic ends up using the `estimateWidth` logic path rather than the overridden `textMetrics.width`.  This PR updates the `widthGetter` function to fall back to using `textMetrics.width` when this function is not equal to Vega's own `measureWidth` and `estimateWidth` functions.

cc @jheer as it looks like you wrote the widthGetter and text truncation logic 😄 