### PR TITLE
fix: CanvasHandler should emit mouse events.

### DIFF
--- a/packages/vega-scenegraph/src/CanvasHandler.js
+++ b/packages/vega-scenegraph/src/CanvasHandler.js
@@ -64,7 +64,7 @@ function move(moveEvents, overEvents, outEvents) {
         // suppress if active item was removed from scene
         fireAll(this, outEvents, evt);
       }
-      this._active = p;          // set new active item
+      this._active = p; // set new active item
       fireAll(this, overEvents, evt); // fire over for new active item
       fireAll(this, moveEvents, evt); // fire move for new active item
     }
@@ -84,7 +84,7 @@ inherits(CanvasHandler, Handler, {
 
     // add minimal events required for proper state management
     [
-      ClickEvent,
+      ClickEvent, MouseDownEvent,
       PointerDownEvent, PointerMoveEvent, PointerOutEvent,
       DragLeaveEvent
     ].forEach(type => eventListenerCheck(this, type));
@@ -117,13 +117,16 @@ inherits(CanvasHandler, Handler, {
   ),
   dragover: move([DragOverEvent], [DragEnterEvent], [DragLeaveEvent]),
 
-  // mouseout: inactive(MouseOutEvent),
   pointerout: inactive([PointerOutEvent, MouseOutEvent]),
   dragleave: inactive([DragLeaveEvent]),
 
   pointerdown(evt) {
     this._down = this._active;
     this.fire(PointerDownEvent, evt);
+  },
+
+  mousedown(evt) {
+    this._down = this._active;
     this.fire(MouseDownEvent, evt);
   },
 

--- a/packages/vega-scenegraph/src/CanvasHandler.js
+++ b/packages/vega-scenegraph/src/CanvasHandler.js
@@ -1,9 +1,12 @@
 import Handler from './Handler';
 import Marks from './marks/index';
 import {
-  ClickEvent, DragEnterEvent, DragLeaveEvent, DragOverEvent, Events,
-  HrefEvent, MouseWheelEvent, PointerDownEvent, PointerMoveEvent, PointerOutEvent,
-  PointerOverEvent, TooltipHideEvent, TooltipShowEvent,
+  ClickEvent,
+  DragEnterEvent, DragLeaveEvent, DragOverEvent, Events, HrefEvent,
+  MouseDownEvent, MouseMoveEvent, MouseOutEvent, MouseOverEvent,
+  MouseWheelEvent,
+  PointerDownEvent, PointerMoveEvent, PointerOutEvent, PointerOverEvent,
+  TooltipHideEvent, TooltipShowEvent,
   TouchEndEvent, TouchMoveEvent, TouchStartEvent
 } from './util/events';
 import point from './util/point';
@@ -42,31 +45,35 @@ function addEventListener(handler, type) {
   }
 }
 
-function move(moveEvent, overEvent, outEvent) {
+function fireAll(handler, types, event) {
+  types.forEach(type => handler.fire(type, event));
+}
+
+function move(moveEvents, overEvents, outEvents) {
   return function(evt) {
     const a = this._active,
           p = this.pickEvent(evt);
 
     if (p === a) {
       // active item and picked item are the same
-      this.fire(moveEvent, evt); // fire move
+      fireAll(this, moveEvents, evt); // fire move
     } else {
       // active item and picked item are different
       if (!a || !a.exit) {
         // fire out for prior active item
         // suppress if active item was removed from scene
-        this.fire(outEvent, evt);
+        fireAll(this, outEvents, evt);
       }
       this._active = p;          // set new active item
-      this.fire(overEvent, evt); // fire over for new active item
-      this.fire(moveEvent, evt); // fire move for new active item
+      fireAll(this, overEvents, evt); // fire over for new active item
+      fireAll(this, moveEvents, evt); // fire move for new active item
     }
   };
 }
 
-function inactive(type) {
+function inactive(types) {
   return function(evt) {
-    this.fire(type, evt);
+    fireAll(this, types, evt);
     this._active = null;
   };
 }
@@ -76,8 +83,11 @@ inherits(CanvasHandler, Handler, {
     this._canvas = el && domFind(el, 'canvas');
 
     // add minimal events required for proper state management
-    [ClickEvent, PointerDownEvent, PointerMoveEvent, PointerOutEvent, DragLeaveEvent]
-      .forEach(type => eventListenerCheck(this, type));
+    [
+      ClickEvent,
+      PointerDownEvent, PointerMoveEvent, PointerOutEvent,
+      DragLeaveEvent
+    ].forEach(type => eventListenerCheck(this, type));
 
     return Handler.prototype.initialize.call(this, el, origin, obj);
   },
@@ -100,15 +110,21 @@ inherits(CanvasHandler, Handler, {
     this.fire(MouseWheelEvent, evt);
   },
 
-  pointermove: move(PointerMoveEvent, PointerOverEvent, PointerOutEvent),
-  dragover: move(DragOverEvent, DragEnterEvent, DragLeaveEvent),
+  pointermove: move(
+    [PointerMoveEvent, MouseMoveEvent],
+    [PointerOverEvent, MouseOverEvent],
+    [PointerOutEvent, MouseOutEvent]
+  ),
+  dragover: move([DragOverEvent], [DragEnterEvent], [DragLeaveEvent]),
 
-  pointerout: inactive(PointerOutEvent),
-  dragleave: inactive(DragLeaveEvent),
+  // mouseout: inactive(MouseOutEvent),
+  pointerout: inactive([PointerOutEvent, MouseOutEvent]),
+  dragleave: inactive([DragLeaveEvent]),
 
   pointerdown(evt) {
     this._down = this._active;
     this.fire(PointerDownEvent, evt);
+    this.fire(MouseDownEvent, evt);
   },
 
   click(evt) {

--- a/packages/vega-scenegraph/src/util/events.js
+++ b/packages/vega-scenegraph/src/util/events.js
@@ -4,16 +4,16 @@ export const KeyUpEvent = 'keyup';
 export const DragEnterEvent = 'dragenter';
 export const DragLeaveEvent = 'dragleave';
 export const DragOverEvent = 'dragover';
-export const MouseDownEvent = 'mousedown';
 export const PointerDownEvent = 'pointerdown';
-export const MouseUpEvent = 'mouseup';
 export const PointerUpEvent = 'pointerup';
-export const MouseMoveEvent = 'mousemove';
 export const PointerMoveEvent = 'pointermove';
-export const MouseOutEvent = 'mouseout';
 export const PointerOutEvent = 'pointerout';
-export const MouseOverEvent = 'mouseover';
 export const PointerOverEvent = 'pointerover';
+export const MouseDownEvent = 'mousedown';
+export const MouseUpEvent = 'mouseup';
+export const MouseMoveEvent = 'mousemove';
+export const MouseOutEvent = 'mouseout';
+export const MouseOverEvent = 'mouseover';
 export const ClickEvent = 'click';
 export const DoubleClickEvent = 'dblclick';
 export const WheelEvent = 'wheel';
@@ -34,6 +34,11 @@ export const Events = [
   PointerMoveEvent,
   PointerOutEvent,
   PointerOverEvent,
+  MouseDownEvent,
+  MouseUpEvent,
+  MouseMoveEvent,
+  MouseOutEvent,
+  MouseOverEvent,
   ClickEvent,
   DoubleClickEvent,
   WheelEvent,

--- a/packages/vega-scenegraph/test/canvas-handler-test.js
+++ b/packages/vega-scenegraph/test/canvas-handler-test.js
@@ -119,23 +119,23 @@ tape('CanvasHandler should handle input events ', t => {
     canvas.dispatchEvent(event(name));
   });
 
-  handler.DOMMouseScroll(event('mousewheel'));
-  canvas.dispatchEvent(event('pointermove', 0, 0));
-  canvas.dispatchEvent(event('pointermove', 50, 150));
-  canvas.dispatchEvent(event('pointerdown', 50, 150));
-  canvas.dispatchEvent(event('pointerup', 50, 150));
-  canvas.dispatchEvent(event('click', 50, 150));
-  canvas.dispatchEvent(event('pointermove', 50, 151));
-  canvas.dispatchEvent(event('pointermove', 50, 1));
-  canvas.dispatchEvent(event('pointerout', 1, 1));
-  canvas.dispatchEvent(event('dragover', 50, 151));
-  canvas.dispatchEvent(event('dragover', 50, 1));
-  canvas.dispatchEvent(event('dragleave', 1, 1));
+  // extra mouse events on pointer move, pointer out
+  t.equal(count, handler.events.length + 2);
 
-  // 12 events above + 8 triggered + 13 derived mouse events:
-  //   2*(pointerover, pointerout) + 2*(dragenter, dragleave)
-  //   + 7 above + 2*(mouseover, mouseout)
-  t.equal(count, handler.events.length + 33);
+  // 12 events below + 17 triggered
+  handler.DOMMouseScroll(event('mousewheel'));         // 1 event
+  canvas.dispatchEvent(event('pointermove', 0, 0));    // 2 (pointer, mouse) * move
+  canvas.dispatchEvent(event('pointermove', 50, 150)); // 6 (pointer, mouse) * (out, over, move)
+  canvas.dispatchEvent(event('pointerdown', 50, 150)); // 1 event
+  canvas.dispatchEvent(event('pointerup', 50, 150));   // 1 event
+  canvas.dispatchEvent(event('click', 50, 150));       // 1 event
+  canvas.dispatchEvent(event('pointermove', 50, 151)); // 2 (points, mouse) * move
+  canvas.dispatchEvent(event('pointermove', 50, 1));   // 6 (pointer, mouse) * (out, over, move)
+  canvas.dispatchEvent(event('pointerout', 1, 1));     // 2 (pointer, mouse) * out
+  canvas.dispatchEvent(event('dragover', 50, 151));    // 3 (leave, enter, move)
+  canvas.dispatchEvent(event('dragover', 50, 1));      // 3 (leave, enter, move)
+  canvas.dispatchEvent(event('dragleave', 1, 1));      // 1 event
+  t.equal(count, handler.events.length + 2 + 29);
 
   handler.off('pointermove', {});
   t.equal(handler.handlers().length, handler.events.length);

--- a/packages/vega-scenegraph/test/canvas-handler-test.js
+++ b/packages/vega-scenegraph/test/canvas-handler-test.js
@@ -132,9 +132,10 @@ tape('CanvasHandler should handle input events ', t => {
   canvas.dispatchEvent(event('dragover', 50, 1));
   canvas.dispatchEvent(event('dragleave', 1, 1));
 
-  // 12 events above + 8 triggered:
+  // 12 events above + 8 triggered + 13 derived mouse events:
   //   2*(pointerover, pointerout) + 2*(dragenter, dragleave)
-  t.equal(count, handler.events.length + 20);
+  //   + 7 above + 2*(mouseover, mouseout)
+  t.equal(count, handler.events.length + 33);
 
   handler.off('pointermove', {});
   t.equal(handler.handlers().length, handler.events.length);


### PR DESCRIPTION
Fix #3825 

This patch has some (canvas-level) mouse events emitted in conjunction with (browser-level) pointer events. This fixes the problem with mouse events not being emitted, but also means that non-mouse pointer events can also result in mouse events (`mouseover`, `mousemove`, and `mouseout`) being emitted. The result is inconsistent with the SVG handler, which simply uses the browser directly for event handling.

I think it is preferable to get a fix out and then consider resolving this inconsistency later.