### PR TITLE
fix: do not cache `devicePixelRatio`

### DIFF
--- a/packages/vega-scenegraph/src/util/canvas/resize.js
+++ b/packages/vega-scenegraph/src/util/canvas/resize.js
@@ -2,14 +2,12 @@ function devicePixelRatio() {
   return typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1;
 }
 
-var pixelRatio = devicePixelRatio();
-
 export default function(canvas, width, height, origin, scaleFactor, opt) {
   const inDOM = typeof HTMLElement !== 'undefined'
               && canvas instanceof HTMLElement
               && canvas.parentNode != null,
         context = canvas.getContext('2d'),
-        ratio = inDOM ? pixelRatio : scaleFactor;
+        ratio = inDOM ? devicePixelRatio() : scaleFactor;
 
   canvas.width = width * ratio;
   canvas.height = height * ratio;

--- a/packages/vega-view/src/size.js
+++ b/packages/vega-view/src/size.js
@@ -81,6 +81,10 @@ export function resizeView(viewWidth, viewHeight, width, height, origin, auto) {
       view._viewWidth = viewWidth;
     }
 
+    if (view._renderer.context().pixelRatio !== window.devicePixelRatio) {
+      view._resize = 1;
+    }
+
     // view height changed: update view property, set resize flag
     if (view._viewHeight !== viewHeight) {
       view._resize = 1;


### PR DESCRIPTION
Currently we cache the `devicePixelRatio` on the creation of the renderer and never check to update it again. The problem with this behavior is that zooming in or out of a page will change the `devicePixelRatio` (which can be observed via `window.onresize`). In turn, a render will be blurry on zoom. This PR makes us recalculate the `devicePixelRatio` on resize, which is negligibly expensive.