### PR TITLE
fix: Add 'hybrid' renderer to vega-typings

### DIFF
--- a/packages/vega-typings/types/runtime/renderer.d.ts
+++ b/packages/vega-typings/types/runtime/renderer.d.ts
@@ -1,6 +1,6 @@
 import { Loader } from '.';
 
-export type Renderers = 'canvas' | 'svg' | 'none';
+export type Renderers = 'canvas' | 'svg' | 'hybrid' | 'none';
 
 export class Renderer {
   constructor(loader: Loader);


### PR DESCRIPTION
Follow on to https://github.com/vega/vega/pull/3810 that adds the 'hybrid' renderer type to vega-typings