### PR TITLE
fix: sum([invalid]) -> undefined

### DIFF
--- a/packages/vega-transforms/src/util/AggregateOps.js
+++ b/packages/vega-transforms/src/util/AggregateOps.js
@@ -33,7 +33,7 @@ export const AggregateOps = {
   },
   sum: {
     init:  m => m.sum = 0,
-    value: m => m.sum,
+    value: m => m.valid ? m.sum : undefined,
     add:  (m, v) => m.sum += +v,
     rem:  (m, v) => m.sum -= v
   },

--- a/packages/vega-transforms/test/aggregate-test.js
+++ b/packages/vega-transforms/test/aggregate-test.js
@@ -330,7 +330,7 @@ tape('Aggregate handles empty/invalid data', t => {
     'exponential',
     'exponentialb'
   ];
-  const res = [4, 3, 0, 0]; // higher indices 'undefined'
+  const res = [4, 3, 0]; // higher indices 'undefined'
 
   var v = util.field('v'),
       df = new vega.Dataflow(),

--- a/packages/vega-transforms/test/pivot-test.js
+++ b/packages/vega-transforms/test/pivot-test.js
@@ -62,11 +62,11 @@ tape('Pivot pivots values', t => {
   d = out.value;
   t.equal(d.length, 2);
   t.equal(d[0].a, 'A');
-  t.equal(d[0].u, 0);
+  t.equal(d[0].u, undefined);
   t.equal(d[0].v, 9);
   t.equal(d[1].a, 'B');
   t.equal(d[1].u, 3);
-  t.equal(d[1].v, 0);
+  t.equal(d[1].v, undefined);
 
   t.end();
 });


### PR DESCRIPTION
Updating the behaviour of `sum` per https://github.com/vega/vega/issues/3848