### PR TITLE
docs: update to the zoomable circle packing example

### DIFF
--- a/docs/examples/zoomable-circle-packing.md
+++ b/docs/examples/zoomable-circle-packing.md
@@ -6,6 +6,6 @@ spec: zoomable-circle-packing
 image: /examples/img/zoomable-circle-packing.png
 ---
 
-This is an extension of the [Circle Packing Example](../circle-packing). This version was implemented by [@giammaria](https://github.com/Giammaria). It incorporates a timer to facilitate zoom and fade animations, offering a technique beneficial for drill-down behavior and exploration. For simplicity, the example reveals only a few text marks upon zoom, corresponding to the user-selected node. Alternatively, you can render various mark types, axes, legends, etc., to provide additional insights into the selected node."
+This is an extension of the [Circle Packing Example](../circle-packing). This version was implemented by [@giammaria](https://github.com/Giammaria). It incorporates a timer to facilitate zoom and fade animations, offering a technique beneficial for drill-down behavior and exploration. For simplicity, the example reveals only a few text marks upon zoom, corresponding to the user-selected node. Alternatively, you can render various mark types, axes, legends, etc., to provide additional insights into the selected node. Click [here](https://vega.github.io/editor/#/gist/566dc5abf4ba78d4187b1788c96136ac/spec.json) to see a more involved example in the editor.
 
 {% include example spec=page.spec %}

--- a/docs/examples/zoomable-circle-packing.md
+++ b/docs/examples/zoomable-circle-packing.md
@@ -6,6 +6,6 @@ spec: zoomable-circle-packing
 image: /examples/img/zoomable-circle-packing.png
 ---
 
-This is an extension of the [Circle Packing Example](../circle-packing). This version was implemented by [@giammaria](https://github.com/Giammaria). It incorporates a timer to facilitate zoom and fade animations, offering a technique beneficial for drill-down behavior and exploration. For simplicity, the example reveals only a few text marks upon zoom, corresponding to the user-selected node. Alternatively, you can render various mark types, axes, legends, etc., to provide additional insights into the selected node. Click [here](https://vega.github.io/editor/#/gist/566dc5abf4ba78d4187b1788c96136ac/spec.json) to see a more involved example in the editor.
+This is an extension of the [Circle Packing Example](../circle-packing). This version was implemented by [@giammaria](https://github.com/Giammaria). It incorporates a timer to facilitate zoom and fade animations, offering a technique beneficial for drill-down behavior and exploration. For simplicity, the example reveals only a few text marks upon zoom, corresponding to the user-selected node. Alternatively, you can render various mark types, axes, legends, etc., to provide additional insights into the selected node. [Here](https://vega.github.io/editor/#/gist/566dc5abf4ba78d4187b1788c96136ac/spec.json) is a more involved example in the editor.
 
 {% include example spec=page.spec %}

--- a/docs/examples/zoomable-circle-packing.vg.json
+++ b/docs/examples/zoomable-circle-packing.vg.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://vega.github.io/schema/vega/v5.json",
   "description": "An example of a zoomable circle packing layout for hierarchical data.",
-  "width": 800,
-  "height": 800,
+  "width": 600,
+  "height": 600,
   "padding": 5,
   "signals": [
     {


### PR DESCRIPTION
Removed trailing double quote (") from description; added a hyperlink to a more complex example; adjusted width and height of example to match the regular circle packing example

Note - accidentally overwrote the commits in my local repository for #3856. That PR has been closed. This PR is intended to replace that one.

INFO: @domoritz 