### PR TITLE
refactor: convert some of the Scenegraph types to classes

### DIFF
--- a/packages/vega-scenegraph/src/CanvasHandler.js
+++ b/packages/vega-scenegraph/src/CanvasHandler.js
@@ -11,14 +11,163 @@ import {
 } from './util/events';
 import point from './util/point';
 import {domFind} from './util/dom';
-import {inherits} from 'vega-util';
 
-export default function CanvasHandler(loader, tooltip) {
-  Handler.call(this, loader, tooltip);
-  this._down = null;
-  this._touch = null;
-  this._first = true;
-  this._events = {};
+export default class CanvasHandler extends Handler {
+  constructor(loader, tooltip) {
+    super(loader, tooltip);
+    this._down = null;
+    this._touch = null;
+    this._first = true;
+    this._events = {};
+
+    // supported events
+    this.events = Events;
+    this.pointermove = move(
+      [PointerMoveEvent, MouseMoveEvent],
+      [PointerOverEvent, MouseOverEvent],
+      [PointerOutEvent, MouseOutEvent]
+    );
+
+    this.dragover = move([DragOverEvent], [DragEnterEvent], [DragLeaveEvent]),
+
+    this.pointerout = inactive([PointerOutEvent, MouseOutEvent]);
+    this.dragleave = inactive([DragLeaveEvent]);
+  }
+
+  initialize(el, origin, obj) {
+    this._canvas = el && domFind(el, 'canvas');
+
+    // add minimal events required for proper state management
+    [
+      ClickEvent, MouseDownEvent,
+      PointerDownEvent, PointerMoveEvent, PointerOutEvent,
+      DragLeaveEvent
+    ].forEach(type => eventListenerCheck(this, type));
+
+    return super.initialize(el, origin, obj);
+  }
+
+  // return the backing canvas instance
+  canvas() {
+    return this._canvas;
+  }
+
+  // retrieve the current canvas context
+  context() {
+    return this._canvas.getContext('2d');
+  }
+
+
+  // to keep old versions of firefox happy
+  DOMMouseScroll(evt) {
+    this.fire(MouseWheelEvent, evt);
+  }
+
+  pointerdown(evt) {
+    this._down = this._active;
+    this.fire(PointerDownEvent, evt);
+  }
+
+  mousedown(evt) {
+    this._down = this._active;
+    this.fire(MouseDownEvent, evt);
+  }
+
+  click(evt) {
+    if (this._down === this._active) {
+      this.fire(ClickEvent, evt);
+      this._down = null;
+    }
+  }
+
+  touchstart(evt) {
+    this._touch = this.pickEvent(evt.changedTouches[0]);
+
+    if (this._first) {
+      this._active = this._touch;
+      this._first = false;
+    }
+
+    this.fire(TouchStartEvent, evt, true);
+  }
+
+  touchmove(evt) {
+    this.fire(TouchMoveEvent, evt, true);
+  }
+
+  touchend(evt) {
+    this.fire(TouchEndEvent, evt, true);
+    this._touch = null;
+  }
+
+  // fire an event
+  fire(type, evt, touch) {
+    const a = touch ? this._touch : this._active,
+          h = this._handlers[type];
+
+    // set event type relative to scenegraph items
+    evt.vegaType = type;
+
+    // handle hyperlinks and tooltips first
+    if (type === HrefEvent && a && a.href) {
+      this.handleHref(evt, a, a.href);
+    } else if (type === TooltipShowEvent || type === TooltipHideEvent) {
+      this.handleTooltip(evt, a, type !== TooltipHideEvent);
+    }
+
+    // invoke all registered handlers
+    if (h) {
+      for (let i=0, len=h.length; i<len; ++i) {
+        h[i].handler.call(this._obj, evt, a);
+      }
+    }
+  }
+
+  // add an event handler
+  on(type, handler) {
+    const name = this.eventName(type),
+          h = this._handlers,
+          i = this._handlerIndex(h[name], type, handler);
+
+    if (i < 0) {
+      eventListenerCheck(this, type);
+      (h[name] || (h[name] = [])).push({
+        type:    type,
+        handler: handler
+      });
+    }
+
+    return this;
+  }
+
+  // remove an event handler
+  off(type, handler) {
+    const name = this.eventName(type),
+          h = this._handlers[name],
+          i = this._handlerIndex(h, type, handler);
+
+    if (i >= 0) {
+      h.splice(i, 1);
+    }
+
+    return this;
+  }
+
+  pickEvent(evt) {
+    const p = point(evt, this._canvas),
+          o = this._origin;
+    return this.pick(this._scene, p[0], p[1], p[0] - o[0], p[1] - o[1]);
+  }
+
+  // find the scenegraph item at the current pointer position
+  // x, y -- the absolute x, y pointer coordinates on the canvas element
+  // gx, gy -- the relative coordinates within the current group
+  pick(scene, x, y, gx, gy) {
+    const g = this.context(),
+          mark = Marks[scene.marktype];
+    return mark.pick.call(this, g, scene, x, y, gx, gy);
+  }
+
 }
 
 const eventBundle = type => (
@@ -77,151 +226,3 @@ function inactive(types) {
     this._active = null;
   };
 }
-
-inherits(CanvasHandler, Handler, {
-  initialize(el, origin, obj) {
-    this._canvas = el && domFind(el, 'canvas');
-
-    // add minimal events required for proper state management
-    [
-      ClickEvent, MouseDownEvent,
-      PointerDownEvent, PointerMoveEvent, PointerOutEvent,
-      DragLeaveEvent
-    ].forEach(type => eventListenerCheck(this, type));
-
-    return Handler.prototype.initialize.call(this, el, origin, obj);
-  },
-
-  // return the backing canvas instance
-  canvas() {
-    return this._canvas;
-  },
-
-  // retrieve the current canvas context
-  context() {
-    return this._canvas.getContext('2d');
-  },
-
-  // supported events
-  events: Events,
-
-  // to keep old versions of firefox happy
-  DOMMouseScroll(evt) {
-    this.fire(MouseWheelEvent, evt);
-  },
-
-  pointermove: move(
-    [PointerMoveEvent, MouseMoveEvent],
-    [PointerOverEvent, MouseOverEvent],
-    [PointerOutEvent, MouseOutEvent]
-  ),
-  dragover: move([DragOverEvent], [DragEnterEvent], [DragLeaveEvent]),
-
-  pointerout: inactive([PointerOutEvent, MouseOutEvent]),
-  dragleave: inactive([DragLeaveEvent]),
-
-  pointerdown(evt) {
-    this._down = this._active;
-    this.fire(PointerDownEvent, evt);
-  },
-
-  mousedown(evt) {
-    this._down = this._active;
-    this.fire(MouseDownEvent, evt);
-  },
-
-  click(evt) {
-    if (this._down === this._active) {
-      this.fire(ClickEvent, evt);
-      this._down = null;
-    }
-  },
-
-  touchstart(evt) {
-    this._touch = this.pickEvent(evt.changedTouches[0]);
-
-    if (this._first) {
-      this._active = this._touch;
-      this._first = false;
-    }
-
-    this.fire(TouchStartEvent, evt, true);
-  },
-
-  touchmove(evt) {
-    this.fire(TouchMoveEvent, evt, true);
-  },
-
-  touchend(evt) {
-    this.fire(TouchEndEvent, evt, true);
-    this._touch = null;
-  },
-
-  // fire an event
-  fire(type, evt, touch) {
-    const a = touch ? this._touch : this._active,
-          h = this._handlers[type];
-
-    // set event type relative to scenegraph items
-    evt.vegaType = type;
-
-    // handle hyperlinks and tooltips first
-    if (type === HrefEvent && a && a.href) {
-      this.handleHref(evt, a, a.href);
-    } else if (type === TooltipShowEvent || type === TooltipHideEvent) {
-      this.handleTooltip(evt, a, type !== TooltipHideEvent);
-    }
-
-    // invoke all registered handlers
-    if (h) {
-      for (let i=0, len=h.length; i<len; ++i) {
-        h[i].handler.call(this._obj, evt, a);
-      }
-    }
-  },
-
-  // add an event handler
-  on(type, handler) {
-    const name = this.eventName(type),
-          h = this._handlers,
-          i = this._handlerIndex(h[name], type, handler);
-
-    if (i < 0) {
-      eventListenerCheck(this, type);
-      (h[name] || (h[name] = [])).push({
-        type:    type,
-        handler: handler
-      });
-    }
-
-    return this;
-  },
-
-  // remove an event handler
-  off(type, handler) {
-    const name = this.eventName(type),
-          h = this._handlers[name],
-          i = this._handlerIndex(h, type, handler);
-
-    if (i >= 0) {
-      h.splice(i, 1);
-    }
-
-    return this;
-  },
-
-  pickEvent(evt) {
-    const p = point(evt, this._canvas),
-          o = this._origin;
-    return this.pick(this._scene, p[0], p[1], p[0] - o[0], p[1] - o[1]);
-  },
-
-  // find the scenegraph item at the current pointer position
-  // x, y -- the absolute x, y pointer coordinates on the canvas element
-  // gx, gy -- the relative coordinates within the current group
-  pick(scene, x, y, gx, gy) {
-    const g = this.context(),
-          mark = Marks[scene.marktype];
-    return mark.pick.call(this, g, scene, x, y, gx, gy);
-  }
-});

--- a/packages/vega-scenegraph/src/Handler.js
+++ b/packages/vega-scenegraph/src/Handler.js
@@ -2,29 +2,23 @@ import {domCreate} from './util/dom';
 import resolveItem from './util/resolveItem';
 import {loader} from 'vega-loader';
 
-/**
- * Create a new Handler instance.
- * @param {object} [customLoader] - Optional loader instance for
- *   href URL sanitization. If not specified, a standard loader
- *   instance will be generated.
- * @param {function} [customTooltip] - Optional tooltip handler
- *   function for custom tooltip display.
- * @constructor
- */
-export default function Handler(customLoader, customTooltip) {
-  this._active = null;
-  this._handlers = {};
-  this._loader = customLoader || loader();
-  this._tooltip = customTooltip || defaultTooltip;
-}
+export default class Handler {
+  /**
+   * Create a new Handler instance.
+   * @param {object} [customLoader] - Optional loader instance for
+   *   href URL sanitization. If not specified, a standard loader
+   *   instance will be generated.
+   * @param {function} [customTooltip] - Optional tooltip handler
+   *   function for custom tooltip display.
+   * @constructor
+   */
+  constructor(customLoader, customTooltip) {
+    this._active = null;
+    this._handlers = {};
+    this._loader = customLoader || loader();
+    this._tooltip = customTooltip || defaultTooltip;
+  }
 
-// The default tooltip display handler.
-// Sets the HTML title attribute on the visualization container.
-function defaultTooltip(handler, event, item, value) {
-  handler.element().setAttribute('title', value || '');
-}
-
-Handler.prototype = {
   /**
    * Initialize a new Handler instance.
    * @param {DOMElement} el - The containing DOM element for the display.
@@ -38,7 +32,7 @@ Handler.prototype = {
     this._el = el;
     this._obj = obj || null;
     return this.origin(origin);
-  },
+  }
 
   /**
    * Returns the parent container element for a visualization.
@@ -46,7 +40,7 @@ Handler.prototype = {
    */
   element() {
     return this._el;
-  },
+  }
 
   /**
    * Returns the scene element (e.g., canvas or SVG) of the visualization
@@ -55,7 +49,7 @@ Handler.prototype = {
    */
   canvas() {
     return this._el && this._el.firstChild;
-  },
+  }
 
   /**
    * Get / set the origin coordinates of the visualization.
@@ -67,7 +61,7 @@ Handler.prototype = {
     } else {
       return this._origin.slice();
     }
-  },
+  }
 
   /**
    * Get / set the scenegraph root.
@@ -76,17 +70,17 @@ Handler.prototype = {
     if (!arguments.length) return this._scene;
     this._scene = scene;
     return this;
-  },
+  }
 
   /**
    * Add an event handler. Subclasses should override this method.
    */
-  on(/*type, handler*/) {},
+  on( /*type, handler*/) { }
 
   /**
    * Remove an event handler. Subclasses should override this method.
    */
-  off(/*type, handler*/) {},
+  off( /*type, handler*/) { }
 
   /**
    * Utility method for finding the array index of an event handler.
@@ -96,13 +90,13 @@ Handler.prototype = {
    * @return {number} - The handler's array index or -1 if not registered.
    */
   _handlerIndex(h, type, handler) {
-    for (let i = h ? h.length : 0; --i>=0;) {
+    for (let i = h ? h.length : 0; --i >= 0;) {
       if (h[i].type === type && (!handler || h[i].handler === handler)) {
         return i;
       }
     }
     return -1;
-  },
+  }
 
   /**
    * Returns an array with registered event handlers.
@@ -120,7 +114,7 @@ Handler.prototype = {
       for (const k in h) { a.push(...h[k]); }
     }
     return a;
-  },
+  }
 
   /**
    * Parses an event name string to return the specific event type.
@@ -131,7 +125,7 @@ Handler.prototype = {
   eventName(name) {
     const i = name.indexOf('.');
     return i < 0 ? name : name.slice(0, i);
-  },
+  }
 
   /**
    * Handle hyperlink navigation in response to an item.href value.
@@ -141,15 +135,14 @@ Handler.prototype = {
    */
   handleHref(event, item, href) {
     this._loader
-      .sanitize(href, {context:'href'})
+      .sanitize(href, { context: 'href' })
       .then(opt => {
-        const e = new MouseEvent(event.type, event),
-              a = domCreate(null, 'a');
+        const e = new MouseEvent(event.type, event), a = domCreate(null, 'a');
         for (const name in opt) a.setAttribute(name, opt[name]);
         a.dispatchEvent(e);
       })
-      .catch(() => { /* do nothing */ });
-  },
+      .catch(() => { });
+  }
 
   /**
    * Handle tooltip display in response to an item.tooltip value.
@@ -164,7 +157,7 @@ Handler.prototype = {
       const value = (show && item && item.tooltip) || null;
       this._tooltip.call(this._obj, this, event, item, value);
     }
-  },
+  }
 
   /**
    * Returns the size of a scenegraph item and its position relative
@@ -178,14 +171,9 @@ Handler.prototype = {
     const el = this.canvas();
     if (!el) return;
 
-    const rect = el.getBoundingClientRect(),
-          origin = this._origin,
-          bounds = item.bounds,
-          width = bounds.width(),
-          height = bounds.height();
+    const rect = el.getBoundingClientRect(), origin = this._origin, bounds = item.bounds, width = bounds.width(), height = bounds.height();
 
-    let x = bounds.x1 + origin[0] + rect.left,
-        y = bounds.y1 + origin[1] + rect.top;
+    let x = bounds.x1 + origin[0] + rect.left, y = bounds.y1 + origin[1] + rect.top;
 
     // translate coordinate for each parent group
     while (item.mark && (item = item.mark.group)) {
@@ -199,4 +187,12 @@ Handler.prototype = {
       left: x, top: y, right: x + width, bottom: y + height
     };
   }
-};
+}
+
+// The default tooltip display handler.
+// Sets the HTML title attribute on the visualization container.
+function defaultTooltip(handler, event, item, value) {
+  handler.element().setAttribute('title', value || '');
+}
+
+

--- a/packages/vega-scenegraph/src/HybridHandler.js
+++ b/packages/vega-scenegraph/src/HybridHandler.js
@@ -1,15 +1,14 @@
 import CanvasHandler from './CanvasHandler';
 import {OPTS} from './HybridRenderer';
-import {inherits} from 'vega-util';
 import {domChild} from './util/dom';
 
-export default function HybridHandler(loader, tooltip) {
-  CanvasHandler.call(this, loader, tooltip);
-}
+export default class HybridHandler extends CanvasHandler {
+  constructor (loader, tooltip) {
+    super(loader, tooltip);
+  }
 
-inherits(HybridHandler, CanvasHandler, {
   initialize(el, origin, obj) {
     const canvas = domChild(domChild(el, 0, 'div'), OPTS.svgOnTop? 0: 1, 'div');
-    return CanvasHandler.prototype.initialize.call(this, canvas, origin, obj);
+    return super.initialize(canvas, origin, obj);
   }
-});
+}

--- a/packages/vega-scenegraph/src/HybridRenderer.js
+++ b/packages/vega-scenegraph/src/HybridRenderer.js
@@ -1,7 +1,6 @@
 import Renderer from './Renderer';
 import SVGRenderer from './SVGRenderer';
 import CanvasRenderer from './CanvasRenderer';
-import {inherits} from 'vega-util';
 import {domChild} from './util/dom';
 
 /**
@@ -34,15 +33,13 @@ export function setHybridRendererOptions(options) {
   OPTS['debug'] = options.debug ?? false;
 }
 
-export default function HybridRenderer(loader) {
-  Renderer.call(this, loader);
-  this._svgRenderer = new SVGRenderer(loader);
-  this._canvasRenderer = new CanvasRenderer(loader);
-}
+export default class HybridRenderer extends Renderer {
+  constructor(loader) {
+    super(loader);
+    this._svgRenderer = new SVGRenderer(loader);
+    this._canvasRenderer = new CanvasRenderer(loader);
+  }
 
-const base = Renderer.prototype;
-
-inherits(HybridRenderer, Renderer, {
   /**
    * Initialize a new HybridRenderer instance.
    * @param {DOMElement} el - The containing DOM element for the display.
@@ -80,8 +77,8 @@ inherits(HybridRenderer, Renderer, {
 
     this._canvasRenderer.initialize(this._canvasEl, width, height, origin, scaleFactor);
     this._svgRenderer.initialize(this._svgEl, width, height, origin, scaleFactor);
-    return base.initialize.call(this, el, width, height, origin, scaleFactor);
-  },
+    return super.initialize(el, width, height, origin, scaleFactor);
+  }
 
   /**
    * Flag a mark item as dirty.
@@ -94,7 +91,7 @@ inherits(HybridRenderer, Renderer, {
       this._canvasRenderer.dirty(item);
     }
     return this;
-  },
+  }
 
   /**
    * Internal rendering method.
@@ -109,7 +106,7 @@ inherits(HybridRenderer, Renderer, {
     const canvasMarkTypes = allMarkTypes.filter((m) => !OPTS.svgMarkTypes.includes(m));
     this._svgRenderer.render(scene, OPTS.svgMarkTypes);
     this._canvasRenderer.render(scene, canvasMarkTypes);
-  },
+  }
 
   /**
    * Resize the display.
@@ -122,11 +119,11 @@ inherits(HybridRenderer, Renderer, {
    * @return {SVGRenderer} - This renderer instance;
    */
   resize(width, height, origin, scaleFactor) {
-    base.resize.call(this, width, height, origin, scaleFactor);
+    super.resize(width, height, origin, scaleFactor);
     this._svgRenderer.resize(width, height, origin, scaleFactor);
     this._canvasRenderer.resize(width, height, origin, scaleFactor);
     return this;
-  },
+  }
 
   background(bgcolor) {
     // Propagate background color to lower canvas renderer
@@ -137,4 +134,4 @@ inherits(HybridRenderer, Renderer, {
     }
     return this;
   }
-});
+}

--- a/packages/vega-scenegraph/src/Renderer.js
+++ b/packages/vega-scenegraph/src/Renderer.js
@@ -1,19 +1,19 @@
 import ResourceLoader from './ResourceLoader';
 
-/**
- * Create a new Renderer instance.
- * @param {object} [loader] - Optional loader instance for
- *   image and href URL sanitization. If not specified, a
- *   standard loader instance will be generated.
- * @constructor
- */
-export default function Renderer(loader) {
-  this._el = null;
-  this._bgcolor = null;
-  this._loader = new ResourceLoader(loader);
-}
+export default class Renderer {
+  /**
+   * Create a new Renderer instance.
+   * @param {object} [loader] - Optional loader instance for
+   *   image and href URL sanitization. If not specified, a
+   *   standard loader instance will be generated.
+   * @constructor
+   */
+  constructor(loader) {
+    this._el = null;
+    this._bgcolor = null;
+    this._loader = new ResourceLoader(loader);
+  }
 
-Renderer.prototype = {
   /**
    * Initialize a new Renderer instance.
    * @param {DOMElement} el - The containing DOM element for the display.
@@ -28,7 +28,7 @@ Renderer.prototype = {
   initialize(el, width, height, origin, scaleFactor) {
     this._el = el;
     return this.resize(width, height, origin, scaleFactor);
-  },
+  }
 
   /**
    * Returns the parent container element for a visualization.
@@ -36,7 +36,7 @@ Renderer.prototype = {
    */
   element() {
     return this._el;
-  },
+  }
 
   /**
    * Returns the scene element (e.g., canvas or SVG) of the visualization
@@ -45,7 +45,7 @@ Renderer.prototype = {
    */
   canvas() {
     return this._el && this._el.firstChild;
-  },
+  }
 
   /**
    * Get / set the background color.
@@ -54,7 +54,7 @@ Renderer.prototype = {
     if (arguments.length === 0) return this._bgcolor;
     this._bgcolor = bgcolor;
     return this;
-  },
+  }
 
   /**
    * Resize the display.
@@ -72,7 +72,7 @@ Renderer.prototype = {
     this._origin = origin || [0, 0];
     this._scale = scaleFactor || 1;
     return this;
-  },
+  }
 
   /**
    * Report a dirty item whose bounds should be redrawn.
@@ -80,7 +80,7 @@ Renderer.prototype = {
    * incremental should implement this method.
    * @param {Item} item - The dirty item whose bounds should be redrawn.
    */
-  dirty(/*item*/) {},
+  dirty( /*item*/) { }
 
   /**
    * Render an input scenegraph, potentially with a set of dirty items.
@@ -99,7 +99,7 @@ Renderer.prototype = {
 
     // bind arguments into a render call, and cache it
     // this function may be subsequently called for async redraw
-    r._call = function() { r._render(scene, markTypes); };
+    r._call = function () { r._render(scene, markTypes); };
 
     // invoke the renderer
     r._call();
@@ -109,7 +109,7 @@ Renderer.prototype = {
     r._call = null;
 
     return r;
-  },
+  }
 
   /**
    * Internal rendering method. Renderer subclasses should override this
@@ -118,9 +118,9 @@ Renderer.prototype = {
    * @param {Array} markTypes - Array of the mark types to render.
    *                            If undefined, render all mark types
    */
-  _render(/*scene, markTypes*/) {
+  _render( /*scene, markTypes*/) {
     // subclasses to override
-  },
+  }
 
   /**
    * Asynchronous rendering method. Similar to render, but returns a Promise
@@ -137,7 +137,7 @@ Renderer.prototype = {
     return this._ready
       ? this._ready.then(() => r)
       : Promise.resolve(r);
-  },
+  }
 
   /**
    * Internal method for asynchronous resource loading.
@@ -148,8 +148,7 @@ Renderer.prototype = {
    * @return {Promise} - A Promise that resolves to the requested resource.
    */
   _load(method, uri) {
-    var r = this,
-        p = r._loader[method](uri);
+    var r = this, p = r._loader[method](uri);
 
     if (!r._ready) {
       // re-render the scene when loading completes
@@ -162,7 +161,7 @@ Renderer.prototype = {
     }
 
     return p;
-  },
+  }
 
   /**
    * Sanitize a URL to include as a hyperlink in the rendered scene.
@@ -173,7 +172,7 @@ Renderer.prototype = {
    */
   sanitizeURL(uri) {
     return this._load('sanitizeURL', uri);
-  },
+  }
 
   /**
    * Requests an image to include in the rendered scene.
@@ -185,4 +184,5 @@ Renderer.prototype = {
   loadImage(uri) {
     return this._load('loadImage', uri);
   }
-};
+}
+

--- a/packages/vega-scenegraph/src/ResourceLoader.js
+++ b/packages/vega-scenegraph/src/ResourceLoader.js
@@ -2,29 +2,21 @@ import {image} from 'vega-canvas';
 import {loader} from 'vega-loader';
 import {hasOwnProperty} from 'vega-util';
 
-export default function ResourceLoader(customLoader) {
-  this._pending = 0;
-  this._loader = customLoader || loader();
-}
+export default class ResourceLoader {
+  constructor(customLoader) {
+    this._pending = 0;
+    this._loader = customLoader || loader();
+  }
 
-function increment(loader) {
-  loader._pending += 1;
-}
-
-function decrement(loader) {
-  loader._pending -= 1;
-}
-
-ResourceLoader.prototype = {
   pending() {
     return this._pending;
-  },
+  }
 
   sanitizeURL(uri) {
     const loader = this;
     increment(loader);
 
-    return loader._loader.sanitize(uri, {context:'href'})
+    return loader._loader.sanitize(uri, { context: 'href' })
       .then(opt => {
         decrement(loader);
         return opt;
@@ -33,18 +25,17 @@ ResourceLoader.prototype = {
         decrement(loader);
         return null;
       });
-  },
+  }
 
   loadImage(uri) {
-    const loader = this,
-          Image = image();
+    const loader = this, Image = image();
     increment(loader);
 
     return loader._loader
-      .sanitize(uri, {context: 'image'})
+      .sanitize(uri, { context: 'image' })
       .then(opt => {
         const url = opt.href;
-        if (!url || !Image) throw {url: url};
+        if (!url || !Image) throw { url: url };
 
         const img = new Image();
 
@@ -62,9 +53,9 @@ ResourceLoader.prototype = {
       })
       .catch(e => {
         decrement(loader);
-        return {complete: false, width: 0, height: 0, src: e && e.url || ''};
+        return { complete: false, width: 0, height: 0, src: e && e.url || '' };
       });
-  },
+  }
 
   ready() {
     const loader = this;
@@ -76,4 +67,13 @@ ResourceLoader.prototype = {
       poll(false);
     });
   }
-};
+}
+
+function increment(loader) {
+  loader._pending += 1;
+}
+
+function decrement(loader) {
+  loader._pending -= 1;
+}
+

--- a/packages/vega-scenegraph/src/SVGHandler.js
+++ b/packages/vega-scenegraph/src/SVGHandler.js
@@ -1,28 +1,19 @@
 import Handler from './Handler';
 import {domFind} from './util/dom';
 import {HrefEvent, TooltipHideEvent, TooltipShowEvent} from './util/events';
-import {inherits} from 'vega-util';
 
-export default function SVGHandler(loader, tooltip) {
-  Handler.call(this, loader, tooltip);
-  const h = this;
-  h._hrefHandler = listener(h, (evt, item) => {
-    if (item && item.href) h.handleHref(evt, item, item.href);
-  });
-  h._tooltipHandler = listener(h, (evt, item) => {
-    h.handleTooltip(evt, item, evt.type !== TooltipHideEvent);
-  });
-}
+export default class SVGHandler extends Handler {
+  constructor(loader, tooltip) {
+    super(loader, tooltip);
+    const h = this;
+    h._hrefHandler = listener(h, (evt, item) => {
+      if (item && item.href) h.handleHref(evt, item, item.href);
+    });
+    h._tooltipHandler = listener(h, (evt, item) => {
+      h.handleTooltip(evt, item, evt.type !== TooltipHideEvent);
+    });
+  }
 
-// wrap an event listener for the SVG DOM
-const listener = (context, handler) => evt => {
-  let item = evt.target.__data__;
-  item = Array.isArray(item) ? item[0] : item;
-  evt.vegaType = evt.type;
-  handler.call(context._obj, evt, item);
-};
-
-inherits(SVGHandler, Handler, {
   initialize(el, origin, obj) {
     let svg = this._svg;
     if (svg) {
@@ -36,12 +27,12 @@ inherits(SVGHandler, Handler, {
       svg.addEventListener(TooltipShowEvent, this._tooltipHandler);
       svg.addEventListener(TooltipHideEvent, this._tooltipHandler);
     }
-    return Handler.prototype.initialize.call(this, el, origin, obj);
-  },
+    return super.initialize(el, origin, obj);
+  }
 
   canvas() {
     return this._svg;
-  },
+  }
 
   // add an event handler
   on(type, handler) {
@@ -63,7 +54,7 @@ inherits(SVGHandler, Handler, {
     }
 
     return this;
-  },
+  }
 
   // remove an event handler
   off(type, handler) {
@@ -80,4 +71,12 @@ inherits(SVGHandler, Handler, {
 
     return this;
   }
-});
+}
+
+// wrap an event listener for the SVG DOM
+const listener = (context, handler) => evt => {
+  let item = evt.target.__data__;
+  item = Array.isArray(item) ? item[0] : item;
+  evt.vegaType = evt.type;
+  handler.call(context._obj, evt, item);
+};

--- a/packages/vega-scenegraph/src/SVGRenderer.js
+++ b/packages/vega-scenegraph/src/SVGRenderer.js
@@ -9,24 +9,22 @@ import {visit} from './util/visit';
 import clip from './util/svg/clip';
 import metadata from './util/svg/metadata';
 import {rootAttributes, stylesAttr, stylesCss} from './util/svg/styles';
-import {inherits, isArray} from 'vega-util';
+import {isArray} from 'vega-util';
 
 const RootIndex = 0,
       xmlns = 'http://www.w3.org/2000/xmlns/',
       svgns = metadata.xmlns;
 
-export default function SVGRenderer(loader) {
-  Renderer.call(this, loader);
-  this._dirtyID = 0;
-  this._dirty = [];
-  this._svg = null;
-  this._root = null;
-  this._defs = null;
-}
+export default class SVGRenderer extends Renderer {
+  constructor(loader) {
+    super(loader);
+    this._dirtyID = 0;
+    this._dirty = [];
+    this._svg = null;
+    this._root = null;
+    this._defs = null;
+  }
 
-const base = Renderer.prototype;
-
-inherits(SVGRenderer, Renderer, {
   /**
    * Initialize a new SVGRenderer instance.
    * @param {DOMElement} el - The containing DOM element for the display.
@@ -62,8 +60,8 @@ inherits(SVGRenderer, Renderer, {
     // set background color if defined
     this.background(this._bgcolor);
 
-    return base.initialize.call(this, el, width, height, origin, scaleFactor);
-  },
+    return super.initialize(el, width, height, origin, scaleFactor);
+  }
 
   /**
    * Get / set the background color.
@@ -72,8 +70,8 @@ inherits(SVGRenderer, Renderer, {
     if (arguments.length && this._svg) {
       this._svg.style.setProperty('background-color', bgcolor);
     }
-    return base.background.apply(this, arguments);
-  },
+    return super.background(...arguments);
+  }
 
   /**
    * Resize the display.
@@ -86,7 +84,7 @@ inherits(SVGRenderer, Renderer, {
    * @return {SVGRenderer} - This renderer instance;
    */
   resize(width, height, origin, scaleFactor) {
-    base.resize.call(this, width, height, origin, scaleFactor);
+    super.resize(width, height, origin, scaleFactor);
 
     if (this._svg) {
       setAttributes(this._svg, {
@@ -100,7 +98,7 @@ inherits(SVGRenderer, Renderer, {
     this._dirty = [];
 
     return this;
-  },
+  }
 
   /**
    * Returns the SVG element of the visualization.
@@ -108,7 +106,7 @@ inherits(SVGRenderer, Renderer, {
    */
   canvas() {
     return this._svg;
-  },
+  }
 
   /**
    * Returns an SVG text string for the rendered content,
@@ -135,7 +133,7 @@ inherits(SVGRenderer, Renderer, {
     }
 
     return text;
-  },
+  }
 
   /**
    * Internal rendering method.
@@ -157,7 +155,7 @@ inherits(SVGRenderer, Renderer, {
     ++this._dirtyID;
 
     return this;
-  },
+  }
 
   // -- Manage rendering of items marked as dirty --
 
@@ -170,7 +168,7 @@ inherits(SVGRenderer, Renderer, {
       item.dirty = this._dirtyID;
       this._dirty.push(item);
     }
-  },
+  }
 
   /**
    * Check if a mark item is considered dirty.
@@ -181,7 +179,7 @@ inherits(SVGRenderer, Renderer, {
       || !item._svg
       || !item._svg.ownerSVGElement
       || item.dirty === this._dirtyID;
-  },
+  }
 
   /**
    * Internal method to check dirty status and, if possible,
@@ -240,7 +238,7 @@ inherits(SVGRenderer, Renderer, {
       item._update = id;
     }
     return !this._dirtyAll;
-  },
+  }
 
   // -- Construct & maintain scenegraph to SVG mapping ---
 
@@ -305,7 +303,7 @@ inherits(SVGRenderer, Renderer, {
 
     domClear(parent, i);
     return parent;
-  },
+  }
 
   /**
    * Update the attributes of an SVG element for a mark item.
@@ -332,7 +330,7 @@ inherits(SVGRenderer, Renderer, {
     // apply svg style attributes
     // note: element state may have been modified by 'extra' method
     if (element) this.style(element, item);
-  },
+  }
 
   /**
    * Update the presentation attributes of an SVG element for a mark item.
@@ -362,7 +360,7 @@ inherits(SVGRenderer, Renderer, {
     for (const prop in stylesCss) {
       setStyle(el, stylesCss[prop], item[prop]);
     }
-  },
+  }
 
   /**
    * Render SVG defs, as needed.
@@ -392,7 +390,7 @@ inherits(SVGRenderer, Renderer, {
         ? (svg.removeChild(el), defs.el = null)
         : domClear(el, index);
     }
-  },
+  }
 
   /**
    * Clear defs caches.
@@ -402,7 +400,7 @@ inherits(SVGRenderer, Renderer, {
     def.gradient = {};
     def.clipping = {};
   }
-});
+}
 
 // mark ancestor chain with a dirty id
 function dirtyParents(item, id) {

--- a/packages/vega-scenegraph/src/SVGStringRenderer.js
+++ b/packages/vega-scenegraph/src/SVGStringRenderer.js
@@ -9,25 +9,25 @@ import {visit} from './util/visit';
 import clip from './util/svg/clip';
 import metadata from './util/svg/metadata';
 import {rootAttributes, stylesAttr, stylesCss} from './util/svg/styles';
-import {extend, inherits, isArray} from 'vega-util';
+import {extend, isArray} from 'vega-util';
 
-export default function SVGStringRenderer(loader) {
-  Renderer.call(this, loader);
-  this._text = null;
-  this._defs = {
-    gradient: {},
-    clipping: {}
-  };
-}
+export default class SVGStringRenderer extends Renderer {
+  constructor(loader) {
+    super(loader);
+    this._text = null;
+    this._defs = {
+      gradient: {},
+      clipping: {}
+    };
+  }
 
-inherits(SVGStringRenderer, Renderer, {
   /**
    * Returns the rendered SVG text string,
    * or null if rendering has not yet occurred.
    */
   svg() {
     return this._text;
-  },
+  }
 
   /**
    * Internal rendering method.
@@ -68,7 +68,7 @@ inherits(SVGStringRenderer, Renderer, {
     this._text = m.close() + '';
 
     return this;
-  },
+  }
 
   /**
    * Render a set of mark items.
@@ -165,7 +165,7 @@ inherits(SVGStringRenderer, Renderer, {
 
     // render closing group tag
     return m.close(); // </g>
-  },
+  }
 
   /**
    * Get href attributes for a hyperlinked mark item.
@@ -188,7 +188,7 @@ inherits(SVGStringRenderer, Renderer, {
       }
     }
     return null;
-  },
+  }
 
   /**
    * Get an object of SVG attributes for a mark item.
@@ -216,7 +216,7 @@ inherits(SVGStringRenderer, Renderer, {
     }
 
     return object;
-  },
+  }
 
   /**
    * Render SVG defs, as needed.
@@ -309,7 +309,7 @@ inherits(SVGStringRenderer, Renderer, {
 
     m.close();
   }
-});
+}
 
 // Helper function for attr for style presentation attributes
 function style(s, item, scene, tag, defs) {

--- a/packages/vega-scenegraph/src/Scenegraph.js
+++ b/packages/vega-scenegraph/src/Scenegraph.js
@@ -2,23 +2,23 @@ import Bounds from './Bounds';
 import GroupItem from './GroupItem';
 import {sceneFromJSON, sceneToJSON} from './util/serialize';
 
-export default function Scenegraph(scene) {
-  if (arguments.length) {
-    this.root = sceneFromJSON(scene);
-  } else {
-    this.root = createMark({
-      marktype: 'group',
-      name: 'root',
-      role: 'frame'
-    });
-    this.root.items = [new GroupItem(this.root)];
+export default class Scenegraph {
+  constructor(scene) {
+    if (arguments.length) {
+      this.root = sceneFromJSON(scene);
+    } else {
+      this.root = createMark({
+        marktype: 'group',
+        name: 'root',
+        role: 'frame'
+      });
+      this.root.items = [new GroupItem(this.root)];
+    }
   }
-}
 
-Scenegraph.prototype = {
   toJSON(indent) {
     return sceneToJSON(this.root, indent || 0);
-  },
+  }
 
   mark(markdef, group, index) {
     group = group || this.root.items[0];
@@ -27,7 +27,8 @@ Scenegraph.prototype = {
     if (mark.zindex) mark.group.zdirty = true;
     return mark;
   }
-};
+}
+
 
 function createMark(def, group) {
   const mark = {


### PR DESCRIPTION
Vega currently uses the `inherits` method in a bunch of places mimic classes, and many of the classes are ES5 style classes. This PR upgrades some of the scenegraph types to ES6 classes and uses built in inheritance so that we get benefits of editor support and our code is more idiomatic.