### PR TITLE
fix: add missing `aggregate_params` to window transform type

### DIFF
--- a/packages/vega-typings/types/spec/transform.d.ts
+++ b/packages/vega-typings/types/spec/transform.d.ts
@@ -717,6 +717,7 @@ export interface WindowTransform {
   sort?: Compare;
   groupby?: FieldRef[] | SignalRef;
   ops?: (AggregateOp | WindowOnlyOp | SignalRef)[];
+  aggregate_params?: number[];
   params?: (number | SignalRef | null)[] | SignalRef;
   fields?: (FieldRef | null)[] | SignalRef;
   as?: (string | SignalRef | null)[] | SignalRef;


### PR DESCRIPTION
`aggregate_params` can also be used in [window transforms](https://github.com/vega/vega/blob/main/packages/vega-transforms/src/Window.js#L41), but the type `WindowTransform` is not updated. 

Related to https://github.com/vega/vega-lite/pull/9225#discussion_r1450647420, followup to #3686