### PR TITLE
chore: bump `vega` version to 5.28.0

### DIFF
--- a/packages/vega/package.json
+++ b/packages/vega/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vega",
-  "version": "5.27.0",
+  "version": "5.28.0",
   "description": "The Vega visualization grammar.",
   "keywords": [
     "vega",


### PR DESCRIPTION
In #3889 I forgot to bump the version on `vega` itself. This PR handles that issue.