### PR TITLE
chore: bump vega-cli version

### DIFF
--- a/packages/vega-cli/package.json
+++ b/packages/vega-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vega-cli",
-  "version": "5.27.0",
+  "version": "5.28.0",
   "description": "Command line utilities for server-side Vega.",
   "keywords": [
     "vega",
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "canvas": "^2.11.2",
-    "vega": "5.27.0",
+    "vega": "5.28.0",
     "yargs": "17"
   }
 }


### PR DESCRIPTION
As a follow up to the v5.28.0 release, we also have to bump the CLI.