### PR TITLE
turn off all handlers in View.finalize()

### DIFF
--- a/docs/docs/api/view.md
+++ b/docs/docs/api/view.md
@@ -79,7 +79,7 @@ var view = await new vega.View(runtime, {
 view.<b>finalize</b>()
 [<>](https://github.com/vega/vega/blob/master/packages/vega-view/src/finalize.js "Source")
 
-Prepares the view to be removed. To prevent unwanted behaviors and memory leaks, this method unregisters any timers and removes any event listeners the visualization has registered on external DOM elements. Applications should invoke this method when a View instance is no longer needed.
+Prepares the view to be removed. To prevent unwanted behaviors and memory leaks, this method unregisters any timers and removes any event listeners that have been registered on the View or that the visualization has registered on external DOM elements. Applications should invoke this method when a View instance is no longer needed.
 
 [Back to reference](#reference)
 

--- a/packages/vega-view/src/finalize.js
+++ b/packages/vega-view/src/finalize.js
@@ -7,8 +7,9 @@
 export default function() {
   var tooltip = this._tooltip,
       timers = this._timers,
+      handlers = this._handler.handlers(),
       listeners = this._eventListeners,
-      n, m, e;
+      n, m, e, h, t;
 
   n = timers.length;
   while (--n >= 0) {
@@ -26,6 +27,14 @@ export default function() {
 
   if (tooltip) {
     tooltip.call(this, this._handler, null, null, null);
+  }
+
+  // turn off all registered handlers
+  n = handlers.length;
+  while (--n >= 0) {
+    t = handlers[n].type;
+    h = handlers[n].handler;
+    this._handler.off(t, h);
   }
 
   return this;


### PR DESCRIPTION
We traced a memory leak in our application back to dangling event listeners that had been registered with `addEventListener`. Removing them from outside the library was possible, but tedious - this is much cleaner.