### PR TITLE
fix: Revert TooltipHideEvent to MouseOutEvent

### DIFF
--- a/packages/vega-scenegraph/src/util/events.js
+++ b/packages/vega-scenegraph/src/util/events.js
@@ -50,6 +50,6 @@ export const Events = [
 
 export const TooltipShowEvent = PointerMoveEvent;
 
-export const TooltipHideEvent = PointerOutEvent;
+export const TooltipHideEvent = MouseOutEvent;
 
 export const HrefEvent = ClickEvent;


### PR DESCRIPTION
Alternative approach to #3907, which selectively reverts only one line from #3781 in order to mitigate #3893.

**Untested**; I haven't been able to build a test bundle of the project as the `yarn` install is failing on my M1 mac due to missing build dependencies.