### PR TITLE
chore: bump many workspace deps

### DIFF
--- a/packages/vega-crossfilter/package.json
+++ b/packages/vega-crossfilter/package.json
@@ -20,9 +20,9 @@
     "prepublishOnly": "yarn test && yarn build"
   },
   "dependencies": {
-    "d3-array": "^3.2.2",
+    "d3-array": "^3.2.4",
     "vega-dataflow": "^5.7.5",
-    "vega-util": "^1.17.1"
+    "vega-util": "^1.17.2"
   },
   "devDependencies": {
     "vega-transforms": "*"

--- a/packages/vega-dataflow/package.json
+++ b/packages/vega-dataflow/package.json
@@ -25,6 +25,6 @@
   "dependencies": {
     "vega-format": "^1.1.1",
     "vega-loader": "^4.5.1",
-    "vega-util": "^1.17.1"
+    "vega-util": "^1.17.2"
   }
 }

--- a/packages/vega-encode/package.json
+++ b/packages/vega-encode/package.json
@@ -22,11 +22,11 @@
     "prepublishOnly": "yarn test && yarn build"
   },
   "dependencies": {
-    "d3-array": "^3.2.2",
+    "d3-array": "^3.2.4",
     "d3-interpolate": "^3.0.1",
     "vega-dataflow": "^5.7.5",
-    "vega-scale": "^7.3.0",
-    "vega-util": "^1.17.1"
+    "vega-scale": "^7.4.0",
+    "vega-util": "^1.17.2"
   },
   "devDependencies": {
     "vega-transforms": "*"

--- a/packages/vega-expression/package.json
+++ b/packages/vega-expression/package.json
@@ -23,7 +23,7 @@
     "prepublishOnly": "yarn test && yarn build"
   },
   "dependencies": {
-    "vega-util": "^1.17.1",
-    "@types/estree": "^1.0.0"
+    "vega-util": "^1.17.2",
+    "@types/estree": "^1.0.5"
   }
 }

--- a/packages/vega-force/package.json
+++ b/packages/vega-force/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "d3-force": "^3.0.0",
     "vega-dataflow": "^5.7.5",
-    "vega-util": "^1.17.1"
+    "vega-util": "^1.17.2"
   },
   "devDependencies": {
     "vega-transforms": "*"

--- a/packages/vega-format/package.json
+++ b/packages/vega-format/package.json
@@ -23,10 +23,10 @@
     "prepublishOnly": "yarn test && yarn build"
   },
   "dependencies": {
-    "d3-array": "^3.2.2",
+    "d3-array": "^3.2.4",
     "d3-format": "^3.1.0",
     "d3-time-format": "^4.1.0",
     "vega-time": "^2.1.1",
-    "vega-util": "^1.17.1"
+    "vega-util": "^1.17.2"
   }
 }

--- a/packages/vega-functions/package.json
+++ b/packages/vega-functions/package.json
@@ -21,19 +21,19 @@
     "prepublishOnly": "yarn test && yarn build"
   },
   "dependencies": {
-    "d3-array": "^3.2.2",
+    "d3-array": "^3.2.4",
     "d3-color": "^3.1.0",
-    "d3-geo": "^3.1.0",
+    "d3-geo": "^3.1.1",
     "vega-dataflow": "^5.7.5",
     "vega-expression": "^5.1.0",
-    "vega-scale": "^7.3.0",
-    "vega-scenegraph": "^4.10.2",
+    "vega-scale": "^7.4.0",
+    "vega-scenegraph": "^4.12.0",
     "vega-selections": "^5.4.2",
-    "vega-statistics": "^1.8.1",
+    "vega-statistics": "^1.9.0",
     "vega-time": "^2.1.1",
-    "vega-util": "^1.17.1"
+    "vega-util": "^1.17.2"
   },
   "devDependencies": {
-    "vega-format": "^1.1.0"
+    "vega-format": "^1.1.1"
   }
 }

--- a/packages/vega-geo/package.json
+++ b/packages/vega-geo/package.json
@@ -22,14 +22,14 @@
     "prepublishOnly": "yarn test && yarn build"
   },
   "dependencies": {
-    "d3-array": "^3.2.2",
+    "d3-array": "^3.2.4",
     "d3-color": "^3.1.0",
-    "d3-geo": "^3.1.0",
+    "d3-geo": "^3.1.1",
     "vega-canvas": "^1.2.7",
     "vega-dataflow": "^5.7.5",
     "vega-projection": "^1.6.0",
-    "vega-statistics": "^1.8.1",
-    "vega-util": "^1.17.1"
+    "vega-statistics": "^1.9.0",
+    "vega-util": "^1.17.2"
   },
   "devDependencies": {
     "vega-transforms": "*"

--- a/packages/vega-hierarchy/package.json
+++ b/packages/vega-hierarchy/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "d3-hierarchy": "^3.1.2",
     "vega-dataflow": "^5.7.5",
-    "vega-util": "^1.17.1"
+    "vega-util": "^1.17.2"
   },
   "devDependencies": {
     "vega-transforms": "*"

--- a/packages/vega-label/package.json
+++ b/packages/vega-label/package.json
@@ -24,10 +24,10 @@
     "prepublishOnly": "yarn test && yarn build"
   },
   "dependencies": {
-    "vega-canvas": "^1.2.6",
-    "vega-dataflow": "^5.7.3",
-    "vega-scenegraph": "^4.9.2",
-    "vega-util": "^1.15.2"
+    "vega-canvas": "^1.2.7",
+    "vega-dataflow": "^5.7.5",
+    "vega-scenegraph": "^4.12.0",
+    "vega-util": "^1.17.2"
   },
   "devDependencies": {
     "vega-transforms": "*"

--- a/packages/vega-loader/package.json
+++ b/packages/vega-loader/package.json
@@ -39,6 +39,6 @@
     "node-fetch": "^2.6.7",
     "topojson-client": "^3.1.0",
     "vega-format": "^1.1.1",
-    "vega-util": "^1.17.1"
+    "vega-util": "^1.17.2"
   }
 }

--- a/packages/vega-parser/package.json
+++ b/packages/vega-parser/package.json
@@ -25,7 +25,7 @@
     "vega-dataflow": "^5.7.5",
     "vega-event-selector": "^3.0.1",
     "vega-functions": "^5.14.0",
-    "vega-scale": "^7.3.1",
+    "vega-scale": "^7.4.0",
     "vega-util": "^1.17.2"
   }
 }

--- a/packages/vega-projection/package.json
+++ b/packages/vega-projection/package.json
@@ -21,8 +21,8 @@
     "prepublishOnly": "yarn test && yarn build"
   },
   "dependencies": {
-    "d3-geo": "^3.1.0",
+    "d3-geo": "^3.1.1",
     "d3-geo-projection": "^4.0.0",
-    "vega-scale": "^7.3.0"
+    "vega-scale": "^7.4.0"
   }
 }

--- a/packages/vega-regression/package.json
+++ b/packages/vega-regression/package.json
@@ -21,10 +21,10 @@
     "prepublishOnly": "yarn test && yarn build"
   },
   "dependencies": {
-    "d3-array": "^3.2.2",
-    "vega-dataflow": "^5.7.3",
+    "d3-array": "^3.2.4",
+    "vega-dataflow": "^5.7.5",
     "vega-statistics": "^1.9.0",
-    "vega-util": "^1.15.2"
+    "vega-util": "^1.17.2"
   },
   "devDependencies": {
     "vega-transforms": "*"

--- a/packages/vega-runtime/package.json
+++ b/packages/vega-runtime/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "vega-dataflow": "^5.7.5",
-    "vega-util": "^1.17.1"
+    "vega-util": "^1.17.2"
   },
   "devDependencies": {
     "vega-encode": "*",

--- a/packages/vega-scale/package.json
+++ b/packages/vega-scale/package.json
@@ -22,11 +22,11 @@
     "prepublishOnly": "yarn test && yarn build"
   },
   "dependencies": {
-    "d3-array": "^3.2.2",
+    "d3-array": "^3.2.4",
     "d3-interpolate": "^3.0.1",
     "d3-scale": "^4.0.2",
     "d3-scale-chromatic": "^3.1.0",
     "vega-time": "^2.1.1",
-    "vega-util": "^1.17.1"
+    "vega-util": "^1.17.2"
   }
 }

--- a/packages/vega-scenegraph/package.json
+++ b/packages/vega-scenegraph/package.json
@@ -23,7 +23,7 @@
     "d3-shape": "^3.2.0",
     "vega-canvas": "^1.2.7",
     "vega-loader": "^4.5.1",
-    "vega-scale": "^7.3.0",
-    "vega-util": "^1.17.1"
+    "vega-scale": "^7.4.0",
+    "vega-util": "^1.17.2"
   }
 }

--- a/packages/vega-schema/package.json
+++ b/packages/vega-schema/package.json
@@ -20,7 +20,7 @@
     "prepublishOnly": "yarn test"
   },
   "dependencies": {
-    "vega-scale": "^7.3.1"
+    "vega-scale": "^7.4.0"
   },
   "devDependencies": {
     "vega-crossfilter": "*",

--- a/packages/vega-selections/package.json
+++ b/packages/vega-selections/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "d3-array": "3.2.4",
-    "vega-expression": "^5.0.1",
-    "vega-util": "^1.17.1"
+    "vega-expression": "^5.1.0",
+    "vega-util": "^1.17.2"
   }
 }

--- a/packages/vega-statistics/package.json
+++ b/packages/vega-statistics/package.json
@@ -22,6 +22,6 @@
     "prepublishOnly": "yarn test && yarn build"
   },
   "dependencies": {
-    "d3-array": "^3.2.2"
+    "d3-array": "^3.2.4"
   }
 }

--- a/packages/vega-time/package.json
+++ b/packages/vega-time/package.json
@@ -22,8 +22,8 @@
     "prepublishOnly": "yarn test && yarn build"
   },
   "dependencies": {
-    "d3-array": "^3.2.2",
+    "d3-array": "^3.2.4",
     "d3-time": "^3.1.0",
-    "vega-util": "^1.17.1"
+    "vega-util": "^1.17.2"
   }
 }

--- a/packages/vega-transforms/package.json
+++ b/packages/vega-transforms/package.json
@@ -28,10 +28,10 @@
     "prepublishOnly": "yarn test && yarn build"
   },
   "dependencies": {
-    "d3-array": "^3.2.2",
+    "d3-array": "^3.2.4",
     "vega-dataflow": "^5.7.5",
-    "vega-statistics": "^1.8.1",
+    "vega-statistics": "^1.9.0",
     "vega-time": "^2.1.1",
-    "vega-util": "^1.17.1"
+    "vega-util": "^1.17.2"
   }
 }

--- a/packages/vega-view-transforms/package.json
+++ b/packages/vega-view-transforms/package.json
@@ -22,8 +22,8 @@
   },
   "dependencies": {
     "vega-dataflow": "^5.7.5",
-    "vega-scenegraph": "^4.10.2",
-    "vega-util": "^1.17.1"
+    "vega-scenegraph": "^4.12.0",
+    "vega-util": "^1.17.2"
   },
   "devDependencies": {
     "vega-transforms": "*"

--- a/packages/vega-view/package.json
+++ b/packages/vega-view/package.json
@@ -21,13 +21,13 @@
     "prepublishOnly": "yarn test && yarn build"
   },
   "dependencies": {
-    "d3-array": "^3.2.2",
+    "d3-array": "^3.2.4",
     "d3-timer": "^3.0.1",
     "vega-dataflow": "^5.7.5",
     "vega-format": "^1.1.1",
-    "vega-functions": "^5.13.1",
+    "vega-functions": "^5.14.0",
     "vega-runtime": "^6.1.4",
-    "vega-scenegraph": "^4.10.2",
-    "vega-util": "^1.17.1"
+    "vega-scenegraph": "^4.12.0",
+    "vega-util": "^1.17.2"
   }
 }

--- a/packages/vega-voronoi/package.json
+++ b/packages/vega-voronoi/package.json
@@ -20,9 +20,9 @@
     "prepublishOnly": "yarn test && yarn build"
   },
   "dependencies": {
-    "d3-delaunay": "^6.0.2",
+    "d3-delaunay": "^6.0.4",
     "vega-dataflow": "^5.7.5",
-    "vega-util": "^1.17.1"
+    "vega-util": "^1.17.2"
   },
   "devDependencies": {
     "vega-transforms": "*"

--- a/packages/vega-wordcloud/package.json
+++ b/packages/vega-wordcloud/package.json
@@ -23,9 +23,9 @@
   "dependencies": {
     "vega-canvas": "^1.2.7",
     "vega-dataflow": "^5.7.5",
-    "vega-scale": "^7.3.0",
-    "vega-statistics": "^1.8.1",
-    "vega-util": "^1.17.1"
+    "vega-scale": "^7.4.0",
+    "vega-statistics": "^1.9.0",
+    "vega-util": "^1.17.2"
   },
   "devDependencies": {
     "vega-transforms": "*"

--- a/packages/vega/package.json
+++ b/packages/vega/package.json
@@ -51,7 +51,7 @@
     "vega-statistics": "~1.9.0",
     "vega-time": "~2.1.1",
     "vega-transforms": "~4.11.1",
-    "vega-typings": "~1.1.0",
+    "vega-typings": "~1.3.0",
     "vega-util": "~1.17.2",
     "vega-view": "~5.12.1",
     "vega-view-transforms": "~4.5.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8232,16 +8232,6 @@ vega-datasets@^2.8.0:
   resolved "https://registry.yarnpkg.com/vega-datasets/-/vega-datasets-2.8.0.tgz#9c7022be6fac8aa7ab9104befaf09bc6c6851d83"
   integrity sha512-pIoP8Cqtq/3Y4rPgtuCle4QWrK2DidmqQzwoNjVVhnNO3H4OWki7vzvDD4/CzWg9wVjoDN98plb3EpJfLcQ5Tw==
 
-vega-typings@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/vega-typings/-/vega-typings-1.1.0.tgz#95bee43fff8a3c9cb921dd5aee2ea87c7f4ca58b"
-  integrity sha512-uI6RWlMiGRhsgmw/LzJtjCc0kwhw2f0JpyNMTAnOy90kE4e4CiaZN5nJp8S9CcfcBoPEZHc166AOn2SSNrKn3A==
-  dependencies:
-    "@types/geojson" "7946.0.4"
-    vega-event-selector "^3.0.1"
-    vega-expression "^5.1.0"
-    vega-util "^1.17.2"
-
 verror@1.10.0:
   version "1.10.0"
   resolved "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3208,7 +3208,7 @@ cssstyle@^4.0.1:
   dependencies:
     rrweb-cssom "^0.6.0"
 
-"d3-array@1 - 3", "d3-array@2 - 3", "d3-array@2.10.0 - 3", "d3-array@2.5.0 - 3", d3-array@3.2.4, d3-array@^3.2.2, d3-array@^3.2.4:
+"d3-array@1 - 3", "d3-array@2 - 3", "d3-array@2.10.0 - 3", "d3-array@2.5.0 - 3", d3-array@3.2.4, d3-array@^3.2.4:
   version "3.2.4"
   resolved "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz"
   integrity sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3208,7 +3208,7 @@ cssstyle@^4.0.1:
   dependencies:
     rrweb-cssom "^0.6.0"
 
-"d3-array@1 - 3", "d3-array@2 - 3", "d3-array@2.10.0 - 3", "d3-array@2.5.0 - 3", d3-array@3.2.4, d3-array@^3.2.2:
+"d3-array@1 - 3", "d3-array@2 - 3", "d3-array@2.10.0 - 3", "d3-array@2.5.0 - 3", d3-array@3.2.4, d3-array@^3.2.2, d3-array@^3.2.4:
   version "3.2.4"
   resolved "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz"
   integrity sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1790,7 +1790,7 @@
     "@types/estree" "*"
     "@types/json-schema" "*"
 
-"@types/estree@*":
+"@types/estree@*", "@types/estree@^1.0.5":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.5.tgz#a6ce3e556e00fd9895dd872dd172ad0d4bd687f4"
   integrity sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3271,6 +3271,13 @@ d3-geo-projection@^4.0.0:
   dependencies:
     d3-array "2.5.0 - 3"
 
+d3-geo@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/d3-geo/-/d3-geo-3.1.1.tgz#6027cf51246f9b2ebd64f99e01dc7c3364033a4d"
+  integrity sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==
+  dependencies:
+    d3-array "2.5.0 - 3"
+
 d3-hierarchy@^3.1.2:
   version "3.1.2"
   resolved "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3220,9 +3220,9 @@ cssstyle@^4.0.1:
   resolved "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz"
   integrity sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==
 
-d3-delaunay@^6.0.2:
+d3-delaunay@^6.0.4:
   version "6.0.4"
-  resolved "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz"
+  resolved "https://registry.yarnpkg.com/d3-delaunay/-/d3-delaunay-6.0.4.tgz#98169038733a0a5babbeda55054f795bb9e4a58b"
   integrity sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==
   dependencies:
     delaunator "5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3264,7 +3264,7 @@ d3-geo-projection@^4.0.0:
     d3-array "1 - 3"
     d3-geo "1.12.0 - 3"
 
-"d3-geo@1.12.0 - 3", d3-geo@^3.1.0:
+"d3-geo@1.12.0 - 3":
   version "3.1.0"
   resolved "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.0.tgz"
   integrity sha512-JEo5HxXDdDYXCaWdwLRt79y7giK8SbhZJbFWXqbRTolCHFI5jRqteLzCsq51NKbUoX0PjBVSohxrx+NoOUujYA==


### PR DESCRIPTION
The goal of this PR is to reduce out of date interdependencies in the workspace. I basically just went through and ran `ncu -ui` in each folder, and updated any minor or patch versions. The only project where this didn't work is in `vega-typings`, which has some issues related to the ts-schema-generator that we can look into later (and are semi-unrelated to the goal of this PR anyway).