### PR TITLE
fix: repair deploy editor preview for vega

### DIFF
--- a/scripts/build-editor-preview.sh
+++ b/scripts/build-editor-preview.sh
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-# Build the editor site and replace main build with local copy of vega-lite
+# Build the editor site and replace the NPM copy with local copy of vega
 echo "Installing Vega"
 
 # Link every package to make sure the editor uses the local version
@@ -47,5 +47,7 @@ cat <<EOF > public/spec/vega/index.json
 {}
 EOF
 
-# Final site build
-yarn run vite build --base /
+# Build the editor site in the dist folder
+# Disable minification to make it easier to debug, and because sourcemaps
+# exceed 25 MB limit on cloudflare
+yarn run build:only --public-url / --no-optimize --no-source-maps


### PR DESCRIPTION
## Motivation

- Repeat https://github.com/vega/vega-lite/pull/9362, but for vega repo instead of vega-lite. Build broke after we changed from vite back to parcel
- Noticed build preview was failing for a recent PR for reasons unrelated to that change ( https://github.com/vega/vega/pull/3930#issuecomment-2161764275 )

## Changes

- Update the build command to match what we have in vega-lite (remove the dependency on vite)

## Testing

The cloudflare deploy preview should succeed on this branch (watch for comment)