### PR TITLE
fix: bounds calc for empty visualization with absent legend title

### DIFF
--- a/packages/vega-typings/tests/spec/valid/legends-empty.ts
+++ b/packages/vega-typings/tests/spec/valid/legends-empty.ts
@@ -1,0 +1,35 @@
+import { Spec } from 'vega';
+
+export const spec: Spec = {
+  $schema: 'https://vega.github.io/schema/vega/v5.json',
+  autosize: {
+    type: 'pad'
+  },
+  background: 'red',
+  width: 500,
+  height: 500,
+  data: [
+    {
+      name: 'data',
+      values: []
+    }
+  ],
+  scales: [
+    {
+      name: 'color',
+      type: 'ordinal',
+      domain: {
+        data: 'data',
+        field: 'series',
+        sort: true
+      },
+      range: 'category'
+    }
+  ],
+  legends: [
+    {
+      stroke: 'color',
+      symbolType: 'stroke'
+    }
+  ]
+};

--- a/packages/vega-view-transforms/src/layout/legend.js
+++ b/packages/vega-view-transforms/src/layout/legend.js
@@ -124,6 +124,11 @@ function legendBounds(item, b) {
   // aggregate item bounds
   item.items.forEach(_ => b.union(_.bounds));
 
+  if (b.empty()) {
+    b.x2 = item.padding;
+    b.y2 = item.padding;
+  }
+
   // anchor to legend origin
   b.x1 = item.padding;
   b.y1 = item.padding;

--- a/packages/vega/test/scenegraphs/legends-empty.json
+++ b/packages/vega/test/scenegraphs/legends-empty.json
@@ -1,0 +1,59 @@
+{
+  "marktype": "group",
+  "name": "root",
+  "role": "frame",
+  "interactive": true,
+  "clip": false,
+  "items": [
+    {
+      "items": [
+        {
+          "marktype": "group",
+          "role": "legend",
+          "interactive": false,
+          "clip": false,
+          "items": [
+            {
+              "items": [
+                {
+                  "marktype": "group",
+                  "role": "legend-entry",
+                  "interactive": false,
+                  "clip": false,
+                  "items": [
+                    {
+                      "items": [
+                        {
+                          "marktype": "group",
+                          "role": "scope",
+                          "interactive": false,
+                          "clip": false,
+                          "items": [],
+                          "zindex": 0
+                        }
+                      ],
+                      "x": 0,
+                      "y": 0
+                    }
+                  ],
+                  "zindex": 0
+                }
+              ],
+              "x": 518,
+              "y": 0,
+              "width": 0,
+              "height": 0,
+              "orient": "right"
+            }
+          ],
+          "zindex": 0
+        }
+      ],
+      "x": 0,
+      "y": 0,
+      "width": 500,
+      "height": 500
+    }
+  ],
+  "zindex": 0
+}

--- a/packages/vega/test/specs-valid.json
+++ b/packages/vega/test/specs-valid.json
@@ -63,6 +63,7 @@
   "legends-discrete",
   "legends-ordinal",
   "legends-symbol",
+  "legends-empty",
   "lifelines",
   "map",
   "map-area-compare",

--- a/packages/vega/test/specs-valid/legends-empty.vg.json
+++ b/packages/vega/test/specs-valid/legends-empty.vg.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "autosize": {
+    "type": "pad"
+  },
+  "background": "red",
+  "width": 500,
+  "height": 500,
+  "data": [
+    {
+      "name": "data",
+      "values": []
+    }
+  ],
+  "scales": [
+    {
+      "name": "color",
+      "type": "ordinal",
+      "domain": {
+        "data": "data",
+        "field": "series",
+        "sort": true
+      },
+      "range": "category"
+    }
+  ],
+  "legends": [
+    {
+      "stroke": "color",
+      "symbolType": "stroke"
+    }
+  ]
+}


### PR DESCRIPTION
Some empty visualizations will generate svg element of huge size

Following criteria must be met to trigger bug:

* visualization has legend, but has no legend title (undefined/null)
* has no data
* autosize.type is pad

In this case bounds calculation will create svg element width `width` and `height` attributes equal to `Number.MAX_VALUE`, but runtime value, accessible through `clientWidth` / `clientHeight`, will depend on browser, as they are doing capping (i.e. Firefox caps value at 17_895_698).

Example of vega spec

```json
{
  "$schema": "https://vega.github.io/schema/vega/v5.json",
  "autosize": {
    "type": "pad"
  },
  "background": "red",
  "width": 500,
  "height": 500,
  "data": [
    {
      "name": "data",
      "values": []
    }
  ],
  "scales": [
    {
      "name": "color",
      "type": "ordinal",
      "domain": {
        "data": "data",
        "field": "series",
        "sort": true
      },
      "range": "category"
    }
  ],
  "legends": [
    {
      "stroke": "color",
      "symbolType": "stroke"
    }
  ]
}
```

And also vega-lite spec that produces broken vega spec

```json
{
  "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
  "width": 200,
  "height": 200,
  "data": {
    "name": "data",
    "values": []
  },
  "encoding": {
    "color": {
      "field": "series",
      "legend": {
        "title": ""
      }
    }
  },
  "mark": {
    "type": "line"
  }
}
```

closes #2881