### PR TITLE
docs: Update packed bubble example

### DIFF
--- a/docs/examples/packed-bubble-chart.md
+++ b/docs/examples/packed-bubble-chart.md
@@ -8,4 +8,6 @@ image: /examples/img/packed-bubble-chart.png
 
 A packed bubble chart displays relatively sized circles arbitrarily packed together. You can change the shape of the packing by adjusting the x or y gravity. This example shows dummy categorical data where node areas are proportional to the amount value.
 
+This Vega example made by David Bacci [@PBI-David](https://github.com/PBI-David).
+
 {% include example spec=page.spec %}

--- a/docs/examples/packed-bubble-chart.vg.json
+++ b/docs/examples/packed-bubble-chart.vg.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://vega.github.io/schema/vega/v5.json",
-  "description": "Warming Stripes Chart. Originally designed by Ed Hawkins.",
+  "description": "A packed bubble chart.",
   "usermeta": {
     "author": "David Bacci",
     "github": "https://github.com/PBI-David/Deneb-Showcase"

--- a/docs/examples/packed-bubble-chart.vg.json
+++ b/docs/examples/packed-bubble-chart.vg.json
@@ -1,5 +1,10 @@
 {
   "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "description": "Warming Stripes Chart. Originally designed by Ed Hawkins.",
+  "usermeta": {
+    "author": "David Bacci",
+    "github": "https://github.com/PBI-David/Deneb-Showcase"
+  },
   "width": 800,
   "height": 500,
   "padding": {"left": 5, "right": 5, "top": 20, "bottom": 0},
@@ -44,8 +49,9 @@
   "scales": [
     {
       "name": "size",
+      "type": "sqrt",
       "domain": {"data": "table", "field": "amount"},
-      "range": [100, 3000]
+      "range": [0, 5000]
     },
     {
       "name": "color",

--- a/docs/examples/packed-bubble-chart.vg.json
+++ b/docs/examples/packed-bubble-chart.vg.json
@@ -49,9 +49,8 @@
   "scales": [
     {
       "name": "size",
-      "type": "sqrt",
       "domain": {"data": "table", "field": "amount"},
-      "range": [0, 5000]
+      "range": [0, 10000]
     },
     {
       "name": "color",
@@ -72,7 +71,7 @@
           "yfocus": {"signal": "cy"}
         },
         "update": {
-          "size": {"signal": "pow(2 * datum.amount, 2)", "scale": "size"},
+          "size": {"signal": "datum.amount", "scale": "size"},
           "stroke": {"value": "white"},
           "strokeWidth": {"value": 1},
           "tooltip": {"signal": "datum"}
@@ -87,7 +86,7 @@
             {
               "force": "collide",
               "iterations": 2,
-              "radius": {"expr": "sqrt(datum.size) / 2"}
+              "radius": {"expr": "sqrt(datum.size)/2"}
             },
             {"force": "center", "x": {"signal": "cx"}, "y": {"signal": "cy"}},
             {"force": "x", "x": "xfocus", "strength": {"signal": "gravityX"}},


### PR DESCRIPTION
Update the packed bubble chart to use a square root scale so as not to be misrepresentative. 