### PR TITLE
fix(legend): add third mode, `discrete`, to `LegendType`

### DIFF
--- a/docs/docs/legends.md
+++ b/docs/docs/legends.md
@@ -13,7 +13,7 @@ Properties for specifying a legend. Legends accept one or more [scales](../scale
 
 | Property      | Type                           | Description    |
 | :------------ |:------------------------------:| :------------- |
-| type          | {% include type t="String" %}  | The type of legend to include. One of `symbol` for discrete symbol legends, or `gradient` for a continuous color gradient. If `gradient` is used only the _fill_ or _stroke_ scale parameters are considered. If unspecified, the _type_ will be inferred based on the scale parameters used and their backing scale types.|
+| type          | {% include type t="String" %}  | The type of legend to include. One of `"symbol"` for discrete symbol legends, `"gradient"` for a continuous color gradient, or `"discrete"` for a discrete color gradient. If gradient or discrete are used, only the fill or stroke scale parameters are considered. If unspecified, the type will be inferred based on the scale parameters used and their backing scale types.|
 | direction     | {% include type t="String" %}  | The direction of the legend, one of `"vertical"` (default) or `"horizontal"`.|
 | orient        | {% include type t="String" %}  | The orientation of the legend, determining where the legend is placed relative to a chart's data rectangle (default `right`). See the [legend orientation reference](#orientation). |
 | fill          | {% include type t="String" %}  | The name of a scale that maps to a fill color. |

--- a/packages/vega-parser/src/parsers/guides/constants.js
+++ b/packages/vega-parser/src/parsers/guides/constants.js
@@ -22,6 +22,7 @@ export const GuideTitleStyle = 'guide-title';
 export const GroupTitleStyle = 'group-title';
 export const GroupSubtitleStyle = 'group-subtitle';
 
+/** All values of LegendType */
 export const Symbols = 'symbol';
 export const Gradient = 'gradient';
 export const Discrete = 'discrete';

--- a/packages/vega-typings/types/spec/legend.d.ts
+++ b/packages/vega-typings/types/spec/legend.d.ts
@@ -40,7 +40,7 @@ export interface GuideEncodeEntry<T> {
   hover?: T;
 }
 
-export type LegendType = 'gradient' | 'symbol';
+export type LegendType = 'gradient' | 'symbol' | 'discrete';
 
 export type LegendOrient =
   | 'none'
@@ -63,7 +63,7 @@ export interface Legend extends BaseLegend {
   opacity?: string;
 
   /**
-   * The type of legend to include. One of `"symbol"` for discrete symbol legends, or `"gradient"` for a continuous color gradient. If gradient is used only the fill or stroke scale parameters are considered. If unspecified, the type will be inferred based on the scale parameters used and their backing scale types.
+   * The type of legend to include. One of `"symbol"` for discrete symbol legends `"gradient"` for a continuous color gradient, or `"discrete"` for a discrete color gradient. If gradient or discrete are used, only the fill or stroke scale parameters are considered. If unspecified, the type will be inferred based on the scale parameters used and their backing scale types.
    */
   type?: LegendType;
 

--- a/packages/vega-typings/types/spec/legend.d.ts
+++ b/packages/vega-typings/types/spec/legend.d.ts
@@ -63,7 +63,7 @@ export interface Legend extends BaseLegend {
   opacity?: string;
 
   /**
-   * The type of legend to include. One of `"symbol"` for discrete symbol legends `"gradient"` for a continuous color gradient, or `"discrete"` for a discrete color gradient. If gradient or discrete are used, only the fill or stroke scale parameters are considered. If unspecified, the type will be inferred based on the scale parameters used and their backing scale types.
+   * The type of legend to include. One of `"symbol"` for discrete symbol legends, `"gradient"` for a continuous color gradient, or `"discrete"` for a discrete color gradient. If gradient or discrete are used, only the fill or stroke scale parameters are considered. If unspecified, the type will be inferred based on the scale parameters used and their backing scale types.
    */
   type?: LegendType;
 


### PR DESCRIPTION
## Motivation

- Fix https://github.com/vega/vega/issues/3954

## Changes

- Adds a type to align with the runtime behavior, + docstring update

https://github.com/vega/vega/blob/ddd2bbff9897415be968fb60e2afa6c695c9eec4/packages/vega-parser/src/parsers/legend.js#L35-L36

- [x] (Checked w/ @jheer to confirm if this is the intended behavior based on the commit that introduced this, https://github.com/vega/vega/commit/ddd2bbff9897415be968fb60e2afa6c695c9eec4

## Notes

- Broader question: would we be interested to have portions of the vega sub-packages converted to TS so we don't have to sync `.d.ts` files with JS source code as a separate step?