### PR TITLE
docs: correct typo in production rules documentation

### DIFF
--- a/docs/docs/marks.md
+++ b/docs/docs/marks.md
@@ -188,4 +188,4 @@ For example, the following specification sets a mark's fill colour using a produ
 ]
 ```
 
-Here, if the ID of a particular data point [is found](https://vega.github.io/vega/docs/expressions/#indata) is the `selectedPoints` data source, the fill color is determined by a scale transform. Otherwise, the mark instance is filled grey.
+Here, if the ID of a particular data point [is found](https://vega.github.io/vega/docs/expressions/#indata) in the `selectedPoints` data source, the fill color is determined by a scale transform. Otherwise, the mark instance is filled grey.


### PR DESCRIPTION
correct typo in production rules documentation