### PR TITLE
feat: add sort expressions

### DIFF
--- a/docs/docs/expressions.md
+++ b/docs/docs/expressions.md
@@ -522,6 +522,10 @@ Returns an array containing an arithmetic sequence of numbers. If _step_ is omit
 <b>slice</b>(<i>array</i>, <i>start</i>[, <i>end</i>])<br/>
 Returns a section of _array_ between the _start_ and _end_ indices. If the _end_ argument is negative, it is treated as an offset from the end of the array (_length(array) + end_).
 
+<a name="sort" href="#sort">#</a>
+<b>sort</b>(<i>array</i>)<br/>
+Sorts the array in natural order using [ascending from Vega Utils](https://vega.github.io/vega/docs/api/util/#ascending).
+
 <a name="span" href="#span">#</a>
 <b>span</b>(<i>array</i>)<br/>
 Returns the span of _array_: the difference between the last and first elements, or _array[array.length-1] - array[0]_.

--- a/packages/vega-expression/README.md
+++ b/packages/vega-expression/README.md
@@ -128,6 +128,7 @@ This package provides the following constants and functions:
 - [`lastindexof`](https://vega.github.io/vega/docs/expressions/#lastindexof)
 - [`reverse`](https://vega.github.io/vega/docs/expressions/#reverse)
 - [`slice`](https://vega.github.io/vega/docs/expressions/#slice)
+- [`sort`](https://vega.github.io/vega/docs/expressions/#sort)
 
 **String Functions**
 

--- a/packages/vega-interpreter/package.json
+++ b/packages/vega-interpreter/package.json
@@ -22,6 +22,9 @@
     "test": "TZ=America/Los_Angeles tape 'test/**/*-test.js'",
     "prepublishOnly": "yarn test && yarn build"
   },
+  "dependencies": {
+    "vega-util": "^1.17.2"
+  },
   "devDependencies": {
     "vega": "*"
   }

--- a/packages/vega-interpreter/src/functions.js
+++ b/packages/vega-interpreter/src/functions.js
@@ -1,3 +1,5 @@
+import { ascending } from "vega-util";
+
 const slice = Array.prototype.slice;
 
 const apply = (m, args, cast) => {
@@ -62,8 +64,7 @@ export default {
   lastindexof:  function() { return apply('lastIndexOf', arguments); },
   slice:        function() { return apply('slice', arguments); },
   reverse:      x => x.slice().reverse(),
-  sort:         x => x.slice().sort(),
-  sortNumeric:  x => x.slice().sort((a, b) => a - b),
+  sort:         x => x.slice().sort(ascending),
 
   // string functions
   parseFloat:   parseFloat,

--- a/packages/vega-interpreter/src/functions.js
+++ b/packages/vega-interpreter/src/functions.js
@@ -1,4 +1,4 @@
-import { ascending } from "vega-util";
+import { ascending } from 'vega-util';
 
 const slice = Array.prototype.slice;
 

--- a/packages/vega-interpreter/src/functions.js
+++ b/packages/vega-interpreter/src/functions.js
@@ -62,6 +62,8 @@ export default {
   lastindexof:  function() { return apply('lastIndexOf', arguments); },
   slice:        function() { return apply('slice', arguments); },
   reverse:      x => x.slice().reverse(),
+  sort:         x => x.slice().sort(),
+  sortNumeric:  x => x.slice().sort((a, b) => a - b),
 
   // string functions
   parseFloat:   parseFloat,


### PR DESCRIPTION
I think it would be useful to have sort function in the expression language. My immediate use case is for https://github.com/vega/altair/pull/3394#pullrequestreview-2231115960, where we need to sort an array returned by `domain()`.

I'm not at all sure what the best implementation is here, or what tests are needed, so this PR is partly to move the discussion I started with @hydrosquall on slack and get additional input. I think that ideally there would just be one `sort` function that handles both numbers, strings, and mixed types, but that seems considerably more complex and I'm not comfortable writing it so I'm suggesting these simple ones which @hydrosquall showed me on slack and that directly maps to the built in JS array methods.