### PR TITLE
fix: return adjusted stop from bin transform

### DIFF
--- a/packages/vega-statistics/test/bin-test.js
+++ b/packages/vega-statistics/test/bin-test.js
@@ -77,15 +77,6 @@ tape('bin generates boundaries with minimum step size', t => {
   t.end();
 });
 
-tape('bin generates boundaries around the data', t => {
-  const b = bin({extent:[-0.25, 0], maxbins:3});
-  t.equal(b.start, -0.30000000000000004);  // floating point issues can come from this
-  t.equal(b.stop, 0);
-  t.equal(b.step, 0.1);
-
-  t.end();
-});
-
 tape('bin generates boundaries for given span size', t => {
   let b = bin({extent:[0, 100], span:10, maxbins:10, nice:false});
   t.equal(b.start, 0);

--- a/packages/vega-statistics/test/bin-test.js
+++ b/packages/vega-statistics/test/bin-test.js
@@ -79,9 +79,9 @@ tape('bin generates boundaries with minimum step size', t => {
 
 tape('bin generates boundaries around the data', t => {
   const b = bin({extent:[-0.25, 0], maxbins:3});
-  t.equal(b.start, -0.3);
+  t.equal(b.start, -0.30000000000000004);  // floating point issues can come from this
   t.equal(b.stop, 0);
-  t.equal(b.step, 0.3);
+  t.equal(b.step, 0.1);
 
   t.end();
 });

--- a/packages/vega-statistics/test/bin-test.js
+++ b/packages/vega-statistics/test/bin-test.js
@@ -77,6 +77,15 @@ tape('bin generates boundaries with minimum step size', t => {
   t.end();
 });
 
+tape('bin generates boundaries around the data', t => {
+  const b = bin({extent:[-0.25, 0], maxbins:3});
+  t.equal(b.start, -0.3);
+  t.equal(b.stop, 0);
+  t.equal(b.step, 0.3);
+
+  t.end();
+});
+
 tape('bin generates boundaries for given span size', t => {
   let b = bin({extent:[0, 100], span:10, maxbins:10, nice:false});
   t.equal(b.start, 0);

--- a/packages/vega-transforms/src/Bin.js
+++ b/packages/vega-transforms/src/Bin.js
@@ -62,8 +62,8 @@ inherits(Bin, Transform, {
           t[b0] = v;
           // maximum bin value (exclusive)
           // use convoluted math for better floating point agreement
-          // see https://github.com/vega/vega/issues/830
-          // infinite values propagate through this formula! #2227
+          // see vega/vega#830
+          // infinite values propagate through this formula! vega/vega#2227
           t[b1] = v == null ? null : start + step * (1 + (v - start) / step);
         }
       : t => t[b0] = bins(t)

--- a/packages/vega-transforms/src/Bin.js
+++ b/packages/vega-transforms/src/Bin.js
@@ -102,7 +102,7 @@ inherits(Bin, Transform, {
     };
 
     f.start = start;
-    f.stop = bins.stop;
+    f.stop = stop;
     f.step = step;
 
     return this.value = accessor(

--- a/packages/vega-transforms/test/bin-test.js
+++ b/packages/vega-transforms/test/bin-test.js
@@ -80,31 +80,13 @@ tape('Bin handles tail aggregation for last bin', t => {
       });
 
   df.run();
-  testBin(t, bin.value, [0, 29], 5);
+  testBin(t, bin.value, [0, 30], 5);
 
   // inspired by vega/vega#2181
   t.equal(bin.value({v:28}), 25);
   t.equal(bin.value({v:29}), 25);
   t.equal(bin.value({v:30}), 25);
   t.equal(bin.value({v:31}), Infinity);
-
-  t.end();
-});
-
-tape('Bin handles last value in edge case', t => {
-  var df = new vega.Dataflow(),
-      bin = df.add(Bin, {
-        field:   util.field('v'),
-        extent:  [-0.25, 0],
-        maxbins: 3,
-        nice:    true
-      });
-
-  df.run();
-  testBin(t, bin.value, [-0.30000000000000004, 0], 0.1);
-
-  t.equal(bin.value({v:-0.25}), -0.30000000000000004);
-  t.equal(bin.value({v:0}), -0.10000000000000003);
 
   t.end();
 });

--- a/packages/vega-transforms/test/bin-test.js
+++ b/packages/vega-transforms/test/bin-test.js
@@ -91,6 +91,24 @@ tape('Bin handles tail aggregation for last bin', t => {
   t.end();
 });
 
+tape('Bin handles last value in edge case', t => {
+  var df = new vega.Dataflow(),
+      bin = df.add(Bin, {
+        field:   util.field('v'),
+        extent:  [-0.25, 0],
+        maxbins: 3,
+        nice:    true
+      });
+
+  df.run();
+  testBin(t, bin.value, [-0.30000000000000004, 0], 0.1);
+
+  t.equal(bin.value({v:-0.25}), -0.30000000000000004);
+  t.equal(bin.value({v:0}), 0);
+
+  t.end();
+});
+
 tape('Bin supports point output', t => {
   const data = [{v: 5.5}];
 

--- a/packages/vega-transforms/test/bin-test.js
+++ b/packages/vega-transforms/test/bin-test.js
@@ -104,7 +104,7 @@ tape('Bin handles last value in edge case', t => {
   testBin(t, bin.value, [-0.30000000000000004, 0], 0.1);
 
   t.equal(bin.value({v:-0.25}), -0.30000000000000004);
-  t.equal(bin.value({v:0}), 0);
+  t.equal(bin.value({v:0}), -0.10000000000000003);
 
   t.end();
 });


### PR DESCRIPTION
Fixes #3966. It's not entirely correct since 0 should be in the bin before 0 but that's a floating point issue with a difficult underlying issue. This fix at least doesn't make bins stick out of the bounds anymore. 

<img width="232" alt="Screenshot 2024-09-05 at 16 47 20" src="https://github.com/user-attachments/assets/843690bc-99e6-44b1-b964-96e08b345998">

Improved example from https://github.com/vega/vega/issues/2181
<img width="465" alt="Screenshot 2024-09-05 at 16 52 48" src="https://github.com/user-attachments/assets/a93a5439-42b7-4b2d-823a-f3c6a18ab185">