### PR TITLE
feat: add sort function to `vega-functions` (and `vega-interpreter`)

### DIFF
--- a/docs/docs/expressions.md
+++ b/docs/docs/expressions.md
@@ -522,6 +522,10 @@ Returns an array containing an arithmetic sequence of numbers. If _step_ is omit
 <b>slice</b>(<i>array</i>, <i>start</i>[, <i>end</i>])<br/>
 Returns a section of _array_ between the _start_ and _end_ indices. If the _end_ argument is negative, it is treated as an offset from the end of the array (_length(array) + end_).
 
+<a name="sort" href="#sort">#</a>
+<b>sort</b>(<i>array</i>)<br/>
+Sorts the array in natural order using [ascending from Vega Utils](https://vega.github.io/vega/docs/api/util/#ascending).
+
 <a name="span" href="#span">#</a>
 <b>span</b>(<i>array</i>)<br/>
 Returns the span of _array_: the difference between the last and first elements, or _array[array.length-1] - array[0]_.

--- a/package.json
+++ b/package.json
@@ -59,5 +59,8 @@
   "engines": {
     "node": ">=18.18.0"
   },
-  "packageManager": "yarn@1.22.19"
+  "packageManager": "yarn@1.22.19",
+  "volta": {
+    "node": "20.17.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -59,8 +59,5 @@
   "engines": {
     "node": ">=18.18.0"
   },
-  "packageManager": "yarn@1.22.19",
-  "volta": {
-    "node": "20.17.0"
-  }
+  "packageManager": "yarn@1.22.19"
 }

--- a/packages/vega-expression/README.md
+++ b/packages/vega-expression/README.md
@@ -128,6 +128,7 @@ This package provides the following constants and functions:
 - [`lastindexof`](https://vega.github.io/vega/docs/expressions/#lastindexof)
 - [`reverse`](https://vega.github.io/vega/docs/expressions/#reverse)
 - [`slice`](https://vega.github.io/vega/docs/expressions/#slice)
+- [`sort`](https://vega.github.io/vega/docs/expressions/#sort)
 
 **String Functions**
 

--- a/packages/vega-functions/index.js
+++ b/packages/vega-functions/index.js
@@ -65,7 +65,8 @@ export {
   lastindexof,
   replace,
   reverse,
-  slice
+  slice,
+  sort
 } from './src/functions/sequence';
 
 export {

--- a/packages/vega-functions/src/codegen.js
+++ b/packages/vega-functions/src/codegen.js
@@ -149,7 +149,8 @@ import {
   lastindexof,
   replace,
   reverse,
-  slice
+  slice,
+  sort
 } from './functions/sequence';
 
 import {
@@ -234,6 +235,7 @@ export const functionContext = {
   lastindexof,
   replace,
   reverse,
+  sort,
   slice,
   flush,
   lerp,

--- a/packages/vega-functions/src/functions/sequence.js
+++ b/packages/vega-functions/src/functions/sequence.js
@@ -1,4 +1,4 @@
-import {error, isArray, isFunction, isString} from 'vega-util';
+import { ascending, error, isArray, isFunction, isString } from 'vega-util';
 
 function array(seq) {
   return isArray(seq) || ArrayBuffer.isView(seq) ? seq : null;
@@ -30,4 +30,7 @@ export function replace(str, pattern, repl) {
 }
 export function reverse(seq) {
   return array(seq).slice().reverse();
+}
+export function sort(seq) {
+  return array(seq).slice().sort(ascending);
 }

--- a/packages/vega-functions/test/sequence-test.js
+++ b/packages/vega-functions/test/sequence-test.js
@@ -5,7 +5,8 @@ var tape = require('tape'),
       lastindexof,
       replace,
       reverse,
-      slice
+      slice,
+      sort
     } = require('../');
 
 tape('indexof finds first index', t => {
@@ -49,5 +50,15 @@ tape('join combines elements into a string', t => {
   t.deepEqual(join([1, 2, 3]), [1, 2, 3].join());
   t.deepEqual(join([1, 2, 3], ', '), [1, 2, 3].join(', '));
   t.throws(() => join({join: v => v + 1}, 1));
+  t.end();
+});
+
+tape('sort handles strings, numbers, dates, and missing data in ascending order', t => {
+  t.deepEqual(sort([3, 1, 2]), [1, 2, 3]);
+  t.deepEqual(sort(['c', 'a', 'b']), ['a', 'b', 'c']);
+  t.deepEqual(sort([2, null, 1]), [null, 1, 2]);
+  t.deepEqual(sort([2, undefined, 1]), [1, 2, undefined]);
+  t.deepEqual(sort([1, NaN, 2]), [NaN, 1, 2]);
+  t.deepEqual(sort([new Date('2019-01-01'), new Date('2018-01-01')]), [new Date('2018-01-01'), new Date('2019-01-01')]);
   t.end();
 });

--- a/packages/vega-interpreter/package.json
+++ b/packages/vega-interpreter/package.json
@@ -22,6 +22,9 @@
     "test": "TZ=America/Los_Angeles tape 'test/**/*-test.js'",
     "prepublishOnly": "yarn test && yarn build"
   },
+  "dependencies": {
+    "vega-util": "^1.17.2"
+  },
   "devDependencies": {
     "vega": "*"
   }

--- a/packages/vega-interpreter/src/functions.js
+++ b/packages/vega-interpreter/src/functions.js
@@ -1,3 +1,5 @@
+import { ascending } from "vega-util";
+
 const slice = Array.prototype.slice;
 
 const apply = (m, args, cast) => {
@@ -62,8 +64,7 @@ export default {
   lastindexof:  function() { return apply('lastIndexOf', arguments); },
   slice:        function() { return apply('slice', arguments); },
   reverse:      x => x.slice().reverse(),
-  sort:         x => x.slice().sort(),
-  sortNumeric:  x => x.slice().sort((a, b) => a - b),
+  sort:         x => x.slice().sort(ascending),
 
   // string functions
   parseFloat:   parseFloat,

--- a/packages/vega-interpreter/src/functions.js
+++ b/packages/vega-interpreter/src/functions.js
@@ -1,4 +1,4 @@
-import { ascending } from "vega-util";
+import { ascending } from 'vega-util';
 
 const slice = Array.prototype.slice;
 

--- a/packages/vega-interpreter/src/functions.js
+++ b/packages/vega-interpreter/src/functions.js
@@ -62,6 +62,8 @@ export default {
   lastindexof:  function() { return apply('lastIndexOf', arguments); },
   slice:        function() { return apply('slice', arguments); },
   reverse:      x => x.slice().reverse(),
+  sort:         x => x.slice().sort(),
+  sortNumeric:  x => x.slice().sort((a, b) => a - b),
 
   // string functions
   parseFloat:   parseFloat,


### PR DESCRIPTION
## Motivation

This PR tests a [fix](https://github.com/vega/vega/pull/3962#issuecomment-2362682733) for https://github.com/vega/vega/pull/3962 , with the goal of adding a `sort` function to the default set of Vega functions in the expression language.


## Changes

- Includes @domoritz and @joelostblom's doc and `vega-interpreter` commits from https://github.com/vega/vega/pull/3962, rebased against latest `main`
- Added + tests sort in `vega-functions`: https://github.com/vega/vega/pull/3973/commits/5e6190d84a0fb9aff2a33b0ca7658b5b5f4208b2#diff-328f6311e6ab7be84b1167d9ca245bea77f0ae6e078ffcd4b71bb7b2340e810b

## Testing

- This worked locally when using `yarn link vega`
- This is also working in the [Cloudflare preview](https://cameron-yick-sort-functions.vega-628.pages.dev/#/url/vega/N4IgJAzgxgFgpgWwIYgFwhgF0wBwqgegIDc4BzJAOjIEtMYBXAI0poHsDp5kTykSArJQBWENgDsQAGhBMkUANZkATmwbiAJmhAB3GHTjSQOJBo01xZNAJk6aG+mgBMABhkRMATwA2h9FDhvbyMNJEwUVABtUHEkBD8QMQZlAIB9FyNiJG8GOAg0aJAIkABBIyZnAA4AXwBdaqkYuITQ8PSjJJSEzrSMmUxlJHEIADM2ZQQC0C8cBLGJhm8UGTgADxxlbTFlTAAKSIByEYOpAAIDpBPzzCuDpgPagEojJHz0TDzMEDq69xoyWLeN6FWLxbSeVIeOA4TLZXLOFwNJpg9Dwf5YIwMHCtBJyTQQEwBXYaNjICy7A6eA6PSi+Sz0M4ARjOLkoAkepwAVKcIVCYb8QMhlApgciEkKRUYZgkPqsvu4vL4CiBZV9ajIRqpJqhQK1inr2g0QHBxFA2Bo-KAsTi0KARjQgraQFkcrilopvjILdBlDQcJh2JIdYl-oDtAAdFWfVCnSOnADUp12NAgADVsvZiWEGAhIpGPh5I09TgB+U6tHN5qOFkC1U4xyOR+MV3P5z5F55G1ZOiCh7LaOwOGBGBCLL6oVkCI2eHtQbIJGcamiBLTvT6eoreUNOl3w-wmj6bI1yCCBCyW51w8X2DRK6r3gXQeeikCghdSzyzbQ4NgWeUgEkySDXUwn1UD2iXFdtALf9tnHAZciNQZLAvPkez7YJ0F5D5+SNEwzAsKwJzZAUkFWPIpkSOclSwoxxmXcRxxAXwRn-FR7DQEZslPfo6Bo6t-wALwsC1uwnH4gA) 

Uses test spec JSON:

```
{
  "$schema": "https://vega.github.io/schema/vega/v5.json",
  "background": "white",
  "padding": 5,
  "width": 20,
  "style": "cell",
  "data": [
    {"name": "source_0", "values": [{"a": "A", "b": 28}]},
    {
      "name": "data_0",
      "source": "source_0",
      "transform": [
        {"type": "formula", "expr": "sort(['f', 'a', 't', 'b'])", "as": "test"}
      ]
    }
  ],
  "signals": [
    {"name": "y_step", "value": 20},
    {
      "name": "height",
      "update": "bandspace(domain('y').length, 1, 0.5) * y_step"
    }
  ],
  "marks": [
   
  ],
  "scales": [
    {
      "name": "y",
      "type": "point",
      "domain": {"data": "data_0", "field": "test", "sort": true},
      "range": {"step": {"signal": "y_step"}},
      "padding": 0.5
    }
  ],
  "axes": [
    {
      "scale": "y",
      "orient": "left",
      "grid": false,
      "title": "test",
      "zindex": 0
    }
  ]
}
```