### PR TITLE
fix: respect element offset when calculating point

### DIFF
--- a/packages/vega-scenegraph/src/util/point.js
+++ b/packages/vega-scenegraph/src/util/point.js
@@ -1,7 +1,78 @@
 export default function(event, el) {
   const rect = el.getBoundingClientRect();
-  return [
-    event.clientX - rect.left - (el.clientLeft || 0),
-    event.clientY - rect.top - (el.clientTop || 0)
-  ];
+  return mapPointToElementOffset(
+    [
+      event.clientX - rect.left - (el.clientLeft || 0),
+      event.clientY - rect.top - (el.clientTop || 0)
+    ],
+    el
+  );
+}
+
+function mapPointToElementOffset([x, y], el) {
+  const rect = el.getBoundingClientRect();
+  const [offsetWidth, offsetHeight] = getElementOffset(el);
+
+  const scaleX = offsetWidth ? rect.width / offsetWidth : 1;
+  const scaleY = offsetHeight ? rect.height / offsetHeight : 1;
+
+  return [x / scaleX, y / scaleY];
+}
+
+/**
+ * Retrieves the `offsetWidth` and `offsetHeight` of the given element.
+ * If not available, creates a container within the element to determine it.
+ *
+ * @param {Element} el - The target element.
+ * @returns {[offsetWidth: number, offsetHeight: number]} The element's offset.
+ */
+function getElementOffset(el) {
+  const offsetWidth = el.offsetWidth;
+  const offsetHeight = el.offsetHeight;
+  if (offsetWidth !== undefined && offsetHeight !== undefined) {
+    return [offsetWidth, offsetHeight];
+  }
+
+  let offsetTarget = el.querySelector(
+    '[data-offset-target-container]>[data-offset-target]'
+  );
+
+  if (!offsetTarget) {
+    el.style.position = 'relative';
+
+    const namespace = 'http://www.w3.org/2000/svg';
+
+    const offsetTargetContainer = document.createElementNS(
+      namespace,
+      'foreignObject'
+    );
+    offsetTargetContainer.setAttribute('x', '0');
+    offsetTargetContainer.setAttribute('width', '100%');
+    offsetTargetContainer.setAttribute('height', '100%');
+    offsetTargetContainer.setAttribute('data-offset-target-container', true);
+    Object.assign(offsetTargetContainer.style, {
+      position: 'absolute',
+      left: '0',
+      top: '0',
+      width: '100%',
+      height: '100%',
+      visibility: 'hidden',
+      pointerEvents: 'none'
+    });
+
+    offsetTarget = document.createElement('div');
+    offsetTarget.setAttribute('data-offset-target', true);
+    Object.assign(offsetTarget.style, {
+      position: 'absolute',
+      left: '0',
+      top: '0',
+      width: '100%',
+      height: '100%'
+    });
+
+    offsetTargetContainer.appendChild(offsetTarget);
+    el.appendChild(offsetTargetContainer);
+  }
+
+  return [offsetTarget.offsetWidth, offsetTarget.offsetHeight];
 }


### PR DESCRIPTION
## Motivation

- https://github.com/vega/vega/issues/3475
- https://github.com/vega/vega/issues/3600

## Changes

Added a function to map element points to the correct element offset, addressing interaction issues caused by scale transformations.

| Before | After |
| ---	| ---	|
| <video src="https://github.com/user-attachments/assets/a25616aa-9a40-47e8-8e2c-1fc854f03575">  |  <video src="https://github.com/user-attachments/assets/439cdc39-b200-4142-94d1-7604d8559fa1"> |

## Testing

This works locally when testing on:
- Firefox 132.0b7 (64-bit)
- Safari 17.6 (19618.3.11.11.5)
- Chrome Chrome 129.0.6668.91 (Official Build) (arm64)

Uses test spec:
- [layout-splom](https://github.com/vega/vega/blob/fb2e60274071033b4c427410ef43375b6f314cf2/packages/vega/test/scenegraphs/layout-splom.json)

## Notes

This fix addresses mouse signal distortion from the scaled root Vega element. It’s designed as a minimal-impact solution, allowing rescaling while preserving mouse interactions with minimal changes to the codebase.

**Concerns:**
- Potential for unknown edge cases.
- This issue might be better addressed by leveraging existing mechanisms (e.g., during renderer initialization).
