### PR TITLE
docs: Fix example data in us-state-capitals.json, move ND Capital to correct location

### DIFF
--- a/docs/data/us-state-capitals.json
+++ b/docs/data/us-state-capitals.json
@@ -32,7 +32,7 @@
   {"lon":-105.964575, "lat":35.667231, "state":"New Mexico", "city":"Santa Fe"},
   {"lon":-73.781339, "lat":42.659829, "state":"New York", "city":"Albany"},
   {"lon":-78.638, "lat":35.771, "state":"North Carolina", "city":"Raleigh"},
-  {"lon":-100.779004, "lat":48.813343, "state":"North Dakota", "city":"Bismarck"},
+  {"lon":-100.782868, "lat":46.819173, "state":"North Dakota", "city":"Bismarck"},
   {"lon":-83.000647, "lat":39.962245, "state":"Ohio", "city":"Columbus"},
   {"lon":-97.534994, "lat":35.482309, "state":"Oklahoma", "city":"Oklahoma City"},
   {"lon":-123.029159, "lat":44.931109, "state":"Oregon", "city":"Salem"},


### PR DESCRIPTION
Fix North Dakota Capital (Bismarck) Location.

The current location is too far north in a random field (what are the odds!): https://www.google.com/maps/place/48%C2%B048'48.0%22N+100%C2%B046'44.4%22W/@48.8133465,-100.7815789,673m/data=!3m2!1e3!4b1!4m4!3m3!8m2!3d48.813343!4d-100.779004?entry=ttu&g_ep=EgoyMDI0MTAyMS4xIKXMDSoASAFQAw%3D%3D

The proposed location is by the capitol building in Bismarck.:
https://www.google.com/maps/place/46%C2%B049'09.0%22N+100%C2%B046'58.3%22W/@46.8191766,-100.7854429,700m/data=!3m2!1e3!4b1!4m4!3m3!8m2!3d46.819173!4d-100.782868?entry=ttu&g_ep=EgoyMDI0MTAyMS4xIKXMDSoASAFQAw%3D%3D