### PR TITLE
fix: axis "description" not overriding default aria-label

### DIFF
--- a/packages/vega-scenegraph/src/util/aria.js
+++ b/packages/vega-scenegraph/src/util/aria.js
@@ -100,12 +100,11 @@ function ariaMark(mark) {
 
 function ariaGuide(mark, opt) {
   try {
-    const item = mark.items[0],
-          caption = opt.caption || (() => '');
+    const caption = opt.caption || (() => '');
     return bundle(
       opt.role || GRAPHICS_SYMBOL,
       opt.desc,
-      item.description || caption(item)
+      mark.description || caption(mark)
     );
   } catch (err) {
     return null;


### PR DESCRIPTION
## PR description
closes vega/vega-lite#9432

Issue rose because `mark.items[0]` didn't contain the `description` that was provided, so it defaulted to the aria attribute generators. The description was present in `mark.description` instead.



<details>
  <summary><h2>Checklist</h2></summary>

- [x] This PR is atomic (i.e., it fixes one issue at a time).
- [x] The title is a concise [semantic commit message](https://www.conventionalcommits.org/) (e.g. "fix: correctly handle undefined properties").
- [x] `yarn test` runs successfully