### PR TITLE
fix: null and empty string categories correct stacking behaviour

### DIFF
--- a/packages/vega-encode/src/Stack.js
+++ b/packages/vega-encode/src/Stack.js
@@ -110,7 +110,7 @@ function partition(data, groupby, sort, field) {
   } else {
     for (map={}, i=0, n=data.length; i<n; ++i) {
       t = data[i];
-      k = groupby.map(get);
+      k = JSON.stringify(groupby.map(get));
       g = map[k];
       if (!g) {
         map[k] = (g = []);


### PR DESCRIPTION
## PR description
closes vega/vega-lite#9428

`map[[null]]` and `map[[""]]` are equivalent which caused the grouping calculation to get messed up. Added JSON.stringify to differentiate the two.

![Screenshot 2024-12-10 at 01 46 11](https://github.com/user-attachments/assets/8ccd6baf-d4d1-4b2e-8dc7-5a78c176a8b2)

<details>
  <summary><h2>Checklist</h2></summary>

- [x] This PR is atomic (i.e., it fixes one issue at a time).
- [x] The title is a concise [semantic commit message](https://www.conventionalcommits.org/) (e.g. "fix: correctly handle undefined properties").
- [x] `yarn test` runs successfully