### PR TITLE
Dwootton/add-bin-tresholds

### DIFF
--- a/packages/vega-transforms/test/bin-test.js
+++ b/packages/vega-transforms/test/bin-test.js
@@ -142,3 +142,145 @@ tape('Bin ignores invalid values', t => {
 
   t.end();
 });
+
+
+tape('Bin ignores invalid values', t => {
+  var df = new vega.Dataflow(),
+      extent = df.add([0, 10]),
+      step = df.add(10 / 20),
+      bin = df.add(Bin, {
+        field:  util.field('v'),
+        extent: extent,
+        step:   step,
+        nice:   false
+      });
+
+  df.run();
+
+  t.equal(bin.value({v: 0}), 0);
+  t.equal(bin.value({v: null}), null);
+  t.equal(bin.value({v: undefined}), null);
+  t.equal(bin.value({v: NaN}), NaN);
+  t.equal(bin.value({v: ''}), null);
+
+  t.end();
+});
+
+tape('Bin dynamic bins', t => {
+  var df = new vega.Dataflow(),
+      extent = df.add([0, 100]),
+      step = df.add(10),
+      bin = df.add(Bin, {
+        field: util.field('v'),
+        extent: extent,
+        step: step,
+        nice: false
+      });
+
+  df.run();
+
+  // Test dynamic bins
+  t.equal(bin.value({v: 5}), 0, 'Value 5 should fall into bin [0, 10)');
+  t.equal(bin.value({v: 25}), 20, 'Value 25 should fall into bin [20, 30)');
+  t.equal(bin.value({v: 95}), 90, 'Value 95 should fall into bin [90, 100)');
+
+  t.equal(bin.value({v: -5}), -Infinity, 'Value -5 should return -Infinity');
+  t.equal(bin.value({v: 105}), Infinity, 'Value 105 should return Infinity');
+
+  t.end();
+});
+
+tape('Bin custom thresholds', t => {
+  var df = new vega.Dataflow(),
+      thresholds = df.add([0, 10, 20, 50, 100]),
+      bin = df.add(Bin, {
+        field: util.field('v'),
+        thresholds: thresholds,
+        nice: false
+      });
+
+  df.run();
+
+  // Test values within thresholds
+  t.equal(bin.value({v: 5}), 0, 'Value 5 should fall into bin [0, 10)');
+  t.equal(bin.value({v: 15}), 10, 'Value 15 should fall into bin [10, 20)');
+  t.equal(bin.value({v: 70}), 50, 'Value 70 should fall into bin [50, 100)');
+
+  // Test out-of-bounds values
+  t.equal(bin.value({v: -5}), -Infinity, 'Value -5 should return -Infinity');
+  t.equal(bin.value({v: 150}), Infinity, 'Value 150 should return Infinity');
+
+  t.end();
+});
+
+tape('Bin edge cases', t => {
+  var df = new vega.Dataflow(),
+      thresholds = df.add([0, 10, 20, 50]),
+      bin = df.add(Bin, {
+        field: util.field('v'),
+        thresholds: thresholds,
+        nice: false
+      });
+
+  df.run();
+
+  // Test exact matches with thresholds
+  t.equal(bin.value({v: 0}), 0, 'Value 0 should fall into bin [0, 10)');
+
+  // the last bin should contain the max threshold value
+  t.equal(bin.value({v: 50}), 50, 'Value 50 should fall into bin [20,50]');
+
+  // Test out-of-bounds values
+  t.equal(bin.value({v: -10}), -Infinity, 'Value -10 should return -Infinity');
+  t.equal(bin.value({v: 100}), Infinity, 'Value 100 should return Infinity');
+
+  t.end();
+});
+
+tape('Bin mixed custom thresholds and dynamic bins', t => {
+  var df = new vega.Dataflow(),
+      extent = df.add([0, 50]),
+      step = df.add(10),
+      thresholds = df.add([0, 10, 20]),
+      bin = df.add(Bin, {
+        field: util.field('v'),
+        thresholds: thresholds,
+        extent: extent,
+        step: step,
+        nice: false
+      });
+
+  df.run();
+
+  // Test custom thresholds
+  t.equal(bin.value({v: 5}), 0, 'Value 5 should fall into bin [0, 10)');
+  t.equal(bin.value({v: 15}), 10, 'Value 15 should fall into bin [10, 20)');
+
+  // Test out-of-bounds values
+  t.equal(bin.value({v: -5}), -Infinity, 'Value -5 should return -Infinity');
+  t.equal(bin.value({v: 55}), Infinity, 'Value 55 should return Infinity');
+
+  t.end();
+});
+
+tape('Bin dynamic thresholds - irregular intervals', t => {
+  var df = new vega.Dataflow(),
+      thresholds = df.add([0, 5, 15, 50, 100]),
+      bin = df.add(Bin, {
+        field: util.field('v'),
+        thresholds: thresholds,
+        nice: false
+      });
+
+  df.run();
+
+  // Test values within thresholds
+  t.equal(bin.value({v: 3}), 0, 'Value 3 should fall into bin [0, 5)');
+  t.equal(bin.value({v: 7}), 5, 'Value 7 should fall into bin [5, 15)');
+  t.equal(bin.value({v: 20}), 15, 'Value 20 should fall into bin [15, 50)');
+
+  // Test value exceeding highest threshold
+  t.equal(bin.value({v: 150}), Infinity, 'Value 150 should fall into dynamically added bin [100, 150)');
+
+  t.end();
+});

--- a/packages/vega/test/specs-valid/overview-detail-bins.vg.json
+++ b/packages/vega/test/specs-valid/overview-detail-bins.vg.json
@@ -9,7 +9,7 @@
     },
     {
       "name": "source_0",
-      "url": "https://vega.github.io/vega-datasets/data/flights-5k.json",
+      "url": "data/flights-5k.json",
       "format": {"type": "json"},
       "transform": [
         {


### PR DESCRIPTION
Used to make thresholds an explicit parameter for Vega's bin transform. 

This is particularly useful when the bin thresholds one wants to set need to be customized via signals.

