### PR TITLE
test: replace `flights-5k.json` external reference

### DIFF
--- a/packages/vega-typings/tests/spec/valid/overview-detail-bins.ts
+++ b/packages/vega-typings/tests/spec/valid/overview-detail-bins.ts
@@ -11,7 +11,7 @@ export const spec: Spec = {
     },
     {
       name: 'source_0',
-      url: 'https://vega.github.io/vega-datasets/data/flights-5k.json',
+      url: 'data/flights-5k.json',
       format: { type: 'json' },
       transform: [
         {

--- a/packages/vega/test/specs-valid/overview-detail-bins.vg.json
+++ b/packages/vega/test/specs-valid/overview-detail-bins.vg.json
@@ -9,7 +9,7 @@
     },
     {
       "name": "source_0",
-      "url": "https://vega.github.io/vega-datasets/data/flights-5k.json",
+      "url": "data/flights-5k.json",
       "format": {"type": "json"},
       "transform": [
         {


### PR DESCRIPTION
This PR resolves a previous issue with one of our tests referencing an external dataset in vega_datasets. I've updated the spec to reference the same dataset but as a local copy such that the test doesn't fail if the external dataset gets updated.