### PR TITLE
feat(vega-typings): add Typescript Types for `vega-loader`

### DIFF
--- a/packages/vega-typings/types/runtime/index.d.ts
+++ b/packages/vega-typings/types/runtime/index.d.ts
@@ -32,7 +32,7 @@ type BaseLoaderOptions = {
   /** Allows caller to explicitly set loading mode (local or network request). File mode only applies to server-side rendering. */
   mode: 'file' | 'http';
   /** Default protocol for protocol-relative URIs, defaults to HTTP */
-  defaultProtocol: string;
+  defaultProtocol: 'file' | 'http' | string;
   /** browser `target` attribute for hyperlinks. Only used when sanitizing URI values for use as hyperlink */
   target: string;
   /** browser `rel` attribute for hyperlinks. Only used when sanitizing URI values for use as hyperlink */
@@ -49,7 +49,7 @@ type BaseLoaderOptions = {
 /**
  * Informs loader which context the URI will be used in.
  */
-type OptionsWithContext =
+type LoaderOptionsWithContext =
   | (Partial<BaseLoaderOptions> & {
       /**
        * Describes context in which the URI will be used.
@@ -74,8 +74,8 @@ type OptionsWithContext =
  * https://github.com/vega/vega/tree/main/packages/vega-loader
  */
 export interface Loader {
-  load: (uri: string, options?: OptionsWithContext) => Promise<string>;
-  sanitize: (uri: string, options: OptionsWithContext) => Promise<{ href: string }>;
+  load: (uri: string, options?: LoaderOptionsWithContext) => Promise<string>;
+  sanitize: (uri: string, options: LoaderOptionsWithContext) => Promise<{ href: string }>;
   http: (uri: string, options: Partial<RequestInit>) => Promise<string>;
   file: (filename: string) => Promise<string>;
 }

--- a/packages/vega-typings/types/runtime/index.d.ts
+++ b/packages/vega-typings/types/runtime/index.d.ts
@@ -25,10 +25,58 @@ export function timeFormatLocale(definition: object): void;
 // Parser
 export function parse(spec: Spec, config?: Config, opt?: { ast?: boolean }): Runtime;
 
+/** Types documented in vega-loader's README.md */
+type BaseLoaderOptions = {
+  /** Base URL prefix prepended to provided URI */
+  baseUrl: string;
+  /** Allows caller to explicitly set loading mode (local or network request). File mode only applies to server-side rendering. */
+  mode: 'file' | 'http';
+  /** Default protocol for protocol-relative URIs, defaults to HTTP */
+  defaultProtocol: string;
+  /** browser `target` attribute for hyperlinks. Only used when sanitizing URI values for use as hyperlink */
+  target: string;
+  /** browser `rel` attribute for hyperlinks. Only used when sanitizing URI values for use as hyperlink */
+  rel: string;
+  /** http request parameters passed to underlying [fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) */
+  http: RequestInit;
+  /**
+   * Specify a [crossOrigin](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image) attribute for images. Only used when sanitizing URI values with option context: "image"
+   * If this property is defined and maps to a value of `null` or `undefined`, then a `no-cors` fetch will be performed for the `Image`. This property can be used to override Vega's default behavior of using `crossOrigin="anonymous"`, which allows images loaded from a different host to be included in exported visualization images (and thereby avoid "tainted canvas errors"), so long as the server provides permission via proper CORS headers.
+   */
+  crossOrigin: 'anonymous' | 'use-credentials' | '' | undefined;
+};
+
+/**
+ * Informs loader which context the URI will be used in.
+ */
+type OptionsWithContext =
+  | (Partial<BaseLoaderOptions> & {
+      /**
+       * Describes context in which the URI will be used.
+       */
+      context: 'href' | 'image';
+    })
+  | {
+      /**
+       * context:dataflow is used when loader is used for getting data into vega-dataflow
+       * https://vega.github.io/vega/docs/data/
+       */
+      context: 'dataflow';
+      /**
+       * File formats supported by vega-loader
+       * https://vega.github.io/vega-lite/docs/data.html#format
+       */
+      response: 'json' | 'csv' | 'tsv' | 'dsv' | 'topojson';
+    };
+
+/**
+ * Loader object is used for loading data, images, and links (hrefs) from a Uniform Resource Identifier (URI)
+ * https://github.com/vega/vega/tree/main/packages/vega-loader
+ */
 export interface Loader {
-  load: (uri: string, options?: any) => Promise<string>;
-  sanitize: (uri: string, options: any) => Promise<{ href: string }>;
-  http: (uri: string, options: any) => Promise<string>;
+  load: (uri: string, options?: OptionsWithContext) => Promise<string>;
+  sanitize: (uri: string, options: OptionsWithContext) => Promise<{ href: string }>;
+  http: (uri: string, options: Partial<RequestInit>) => Promise<string>;
   file: (filename: string) => Promise<string>;
 }
 


### PR DESCRIPTION
## Motivation

- I was learning about `vega-loader`, and decided to move the information from the [README](https://github.com/vega/vega/blob/main/packages/vega-loader/README.md) to the typings file. 
- This removes 3 `any` types from `Loader` too!

## Changes

- This should have no runtime impact, it only updates Typescript definitions in `vega-typings`
- Note: `vega-loader`'s README does not mention that `sanitize` takes in `context` and `response` as additional options - this is something I noticed from `console.log`'ing the output of the options.  For now I only document that in the Typescript types. 
   - I could update the README for vega-loader as well if we want consumers to know about this, or leave it out if this is supposed to be an internal implementation detail. 