### PR TITLE
fix: correct data year citation in dorling-cartogram example

### DIFF
--- a/docs/examples/dorling-cartogram.md
+++ b/docs/examples/dorling-cartogram.md
@@ -6,6 +6,6 @@ spec: dorling-cartogram
 image: /examples/img/dorling-cartogram.png
 ---
 
-A Dorling cartogram is a thematic map that uses sized circles to represent a quantity of interest per geographic region. This example visualizes the ratio of obese adults (BMI >= 30) by U.S. state in 2008. A redundant encoding uses both circle area and fill color to convey the obesity rate. Vega's [force](../../docs/transforms/force) transform and [geoCentroid](../../docs/expressions/#geoCentroid) expression function are used to compute the layout.
+A Dorling cartogram is a thematic map that uses sized circles to represent a quantity of interest per geographic region. This example visualizes the ratio of obese adults (BMI >= 30) by U.S. state in 1995. A redundant encoding uses both circle area and fill color to convey the obesity rate. Vega's [force](../../docs/transforms/force) transform and [geoCentroid](../../docs/expressions/#geoCentroid) expression function are used to compute the layout.
 
 {% include example spec=page.spec %}


### PR DESCRIPTION
The obesity rates shown in the example match CDC data from 1995, not the currently cited year. Obesity rates were far higher in 2008 [1] [2]. LIkely a misreading of original source, which contained 1995-2008 data [3].

Related to vega/vega-datasets@ca1d569

[1]: https://www.cdc.gov/mmwr/preview/mmwrhtml/mm5728a1.htm
[2]: https://stacks.cdc.gov/view/cdc/81474/cdc_81474_DS1.pdf
[3]: https://mbostock.github.io/protovis/ex/us_stats.js

![image](https://github.com/user-attachments/assets/0650aad5-50c9-4719-88c0-1b29b9dd9758)

![image](https://github.com/user-attachments/assets/42512035-5142-45f9-8763-c81bff6a7643)
