### PR TITLE
docs: Add Security Advisory Policy for `vega`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,4 +22,15 @@ The Vega project consists of a number of packages, organized into a single [mono
 
 For an overview of all packages, see the [vega `/packages` folder](/packages).
 
-To setup a development environment follow the [Build Instructions in README.md](https://github.com/vega/vega/#Build-Instructions). We use [Yarn workspaces](https://yarnpkg.com/lang/en/docs/workspaces/) and [lerna](https://github.com/lerna/lerna) to manage the monorepo packages.
+To setup a development environment follow the [Build Instructions in README.md](#build-instructions). We use [Yarn workspaces](https://yarnpkg.com/lang/en/docs/workspaces/) and [lerna](https://github.com/lerna/lerna) to manage the monorepo packages.
+
+## Build Instructions
+
+For a basic setup allowing you to build Vega and run examples:
+
+- Clone `https://github.com/vega/vega`.
+- Run `yarn` to install dependencies for all packages. If you don't have yarn installed, see https://yarnpkg.com/en/docs/install. We use [Yarn workspaces](https://yarnpkg.com/lang/en/docs/workspaces/) to manage multiple packages within this [monorepo](https://en.wikipedia.org/wiki/Monorepo).
+- Once installation is complete, run `yarn test` to run test cases, or run `yarn build` to build output files for all packages.
+- After running either `yarn test` or `yarn build`, run `yarn serve` to launch a local web server &mdash; your default browser will open and you can browse to the `"test"` folder to view test specifications.
+
+This repository includes the Vega website and documentation in the `docs` folder. To launch the website locally, first run `bundle install` in the `docs` folder to install the necessary Jekyll libraries. Afterwards, use `yarn docs` to build the documentation and launch a local webserver. After launching, you can open [`http://127.0.0.1:4000/vega/`](http://127.0.0.1:4000/vega/) to see the website.

--- a/README.md
+++ b/README.md
@@ -4,23 +4,14 @@
 <img src="https://vega.github.io/vega/assets/banner.png" alt="Vega Examples" width="900"></img>
 </a>
 
-**Vega** is a *visualization grammar*, a declarative format for creating, saving, and sharing interactive visualization designs. With Vega you can describe data visualizations in a JSON format, and generate interactive views using either HTML5 Canvas or SVG.
+**Vega** is a *visualization grammar*, a declarative format for creating, saving, and sharing interactive visualization designs. With Vega you can describe data visualizations in a JSON format, and generate interactive views using HTML5 Canvas or SVG.
 
-For documentation, tutorials, and examples, see the [Vega website](https://vega.github.io/vega). For a description of changes between Vega 2 and later versions, please refer to the [Vega Porting Guide](https://vega.github.io/vega/docs/porting-guide/).
+For [documentation](https://vega.github.io/vega/docs/), [tutorials](https://vega.github.io/vega/tutorials/), and [examples](https://vega.github.io/vega/examples/), see the [Vega website](https://vega.github.io/vega). For a description of changes between Vega 2 and later versions, please refer to the [Vega Porting Guide](https://vega.github.io/vega/docs/porting-guide/).
 
-## Build Instructions
-
-For a basic setup allowing you to build Vega and run examples:
-
-- Clone `https://github.com/vega/vega`.
-- Run `yarn` to install dependencies for all packages. If you don't have yarn installed, see https://yarnpkg.com/en/docs/install. We use [Yarn workspaces](https://yarnpkg.com/lang/en/docs/workspaces/) to manage multiple packages within this [monorepo](https://en.wikipedia.org/wiki/Monorepo).
-- Once installation is complete, run `yarn test` to run test cases, or run `yarn build` to build output files for all packages.
-- After running either `yarn test` or `yarn build`, run `yarn serve` to launch a local web server &mdash; your default browser will open and you can browse to the `"test"` folder to view test specifications.
-
-This repository includes the Vega website and documentation in the `docs` folder. To launch the website locally, first run `bundle install` in the `docs` folder to install the necessary Jekyll libraries. Afterwards, use `yarn docs` to build the documentation and launch a local webserver. After launching, you can open [`http://127.0.0.1:4000/vega/`](http://127.0.0.1:4000/vega/) to see the website.
+Try using Vega in the online [Vega Editor](https://vega.github.io/editor/#/examples/vega/bar-chart).
 
 ## Internet Explorer Support
-For backwards compatibility, Vega includes a [babel-ified](https://babeljs.io/) IE-compatible version of the code in the `packages/vega/build-es5` directory. Older browser would also require several polyfill libraries:
+For backwards compatibility, Vega includes a [babel-ified](https://babeljs.io/) IE-compatible version of the code in the `packages/vega/build-es5` directory. Older browsers also require these polyfill libraries:
 
 ```html
 <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/7.4.4/polyfill.min.js"></script>
@@ -35,3 +26,7 @@ Interested in contributing to Vega? Please see our [contribution and development
 Looking for support, or interested in sharing examples and tips? Post to the [Vega discussion forum](https://groups.google.com/forum/#!forum/vega-js) or join the [Vega slack organization](https://bit.ly/join-vega-slack-2020)! We also have examples available as [Observable notebooks](https://observablehq.com/@vega).
 
 If you're curious about system performance, see some [in-browser benchmarks](https://observablehq.com/@vega/vega-performance-tests). Read about future plans in [our roadmap](https://github.com/orgs/vega/projects/9/views/3?pane=info).
+
+## Security
+
+Please see our [guidelines](./SECURITY.md) for reporting vulnerabilities.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,12 +10,11 @@ To report a security issue privately, please use the GitHub Security Advisory ["
 
 A Vega maintainer will send a response indicating next steps in handling your report. After the initial reply, the team will keep you informed of the progress towards a fix and announcement, and may ask for additional information or guidance.
 
-You can also report a vulnerability through the [npm contact form](https://www.npmjs.com/support) by selecting "I'm reporting a security vulnerability".
 
-## Preferred Languages
+## Further reading
 
-We prefer communications to be in English.
+To learn more about security measures in Vega, see our docs on
 
-## Learning More About Security
-
-To learn more about security measures in Vega, see the documentation on using an expression [`interpreter`](https://vega.github.io/vega/usage/interpreter/) for [Content Security Policy (CSP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) compliance, or [`loader`](https://github.com/vega/vega/tree/main/packages/vega-loader) for opening network or filesystem resources.
+- Using an expression [`interpreter`](https://vega.github.io/vega/usage/interpreter/) for [Content Security Policy (CSP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) compliance, or
+- Use a [`loader`](https://github.com/vega/vega/tree/main/packages/vega-loader) for opening network or filesystem resources.
+- Organization-wide security [guidelines](https://github.com/vega/.github/blob/main/SECURITY.md)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security
+
+The Vega team and community take security bugs in Vega seriously. We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
+
+## Reporting Security Issues
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+To report a security issue privately, please use the GitHub Security Advisory ["Report a Vulnerability"](https://github.com/vega/vega/security/advisories/new) tab.
+
+A Vega maintainer will send a response indicating next steps in handling your report. After the initial reply, the team will keep you informed of the progress towards a fix and announcement, and may ask for additional information or guidance.
+
+You can also report a vulnerability through the [npm contact form](https://www.npmjs.com/support) by selecting "I'm reporting a security vulnerability".
+
+## Preferred Languages
+
+We prefer communications to be in English.
+
+## Learning More About Security
+
+To learn more about security measures in Vega, see the documentation on using an expression [`interpreter`](https://vega.github.io/vega/usage/interpreter/) for [Content Security Policy (CSP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) compliance, or [`loader`](https://github.com/vega/vega/tree/main/packages/vega-loader) for opening network or filesystem resources.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,13 +8,4 @@ The Vega team and community take security bugs in Vega seriously. We appreciate 
 
 To report a security issue privately, please use the GitHub Security Advisory ["Report a Vulnerability"](https://github.com/vega/vega/security/advisories/new) tab.
 
-A Vega maintainer will send a response indicating next steps in handling your report. After the initial reply, the team will keep you informed of the progress towards a fix and announcement, and may ask for additional information or guidance.
-
-
-## Further reading
-
-To learn more about security measures in Vega, see our docs on
-
-- Using an expression [`interpreter`](https://vega.github.io/vega/usage/interpreter/) for [Content Security Policy (CSP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) compliance, or
-- Use a [`loader`](https://github.com/vega/vega/tree/main/packages/vega-loader) for opening network or filesystem resources.
-- Organization-wide security [guidelines](https://github.com/vega/.github/blob/main/SECURITY.md)
+See the Vega organization-wide [guidelines](https://github.com/vega/.github/blob/main/SECURITY.md) for more information on security policy and protections.


### PR DESCRIPTION
## Motivation

- Make it easy for researchers and engineers to have a safe path to reporting security vulnerabilities
- Keep Vega and its dependents (Vega-lite, altair, etc) secure

## Changes

- Add a `SECURITY.md` ([Security Policy](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository)), following a slack discussion in the Maintainers channel. This is based on
  - Electron https://github.com/electron/electron/blob/main/SECURITY.md
  - Microsoft: https://github.com/microsoft/.github/blob/main/SECURITY.md
- While linking this file from the homepage, I noticed we could make the `Vega` README a bit more like the `Vega-Lite` one (shorter and with more direct docs links). I can revert these changes if preferred, I figured it didn't hurt to propose them.