### PR TITLE
feat: Add base64 string encoder/decoder to `vega-expression` and `vega-interpreter`

### DIFF
--- a/docs/docs/expressions.md
+++ b/docs/docs/expressions.md
@@ -523,7 +523,7 @@ Returns an array containing an arithmetic sequence of numbers. If _step_ is omit
 Returns a section of _array_ between the _start_ and _end_ indices. If the _end_ argument is negative, it is treated as an offset from the end of the array (_length(array) + end_).
 
 <a name="sort" href="#sort">#</a>
-<b>sort</b>(<i>array</i>)<br/>
+<b>sort</b>(<i>array</i>)<br/>{% include tag ver="5.31" %}<br/>
 Sorts the array in natural order using [ascending from Vega Utils](https://vega.github.io/vega/docs/api/util/#ascending).
 
 <a name="span" href="#span">#</a>
@@ -622,7 +622,7 @@ Formats a (0-6) _weekday_ number as an abbreviated week day name, according to t
 <a name="format" href="#format">#</a>
 <b>format</b>(<i>value</i>, <i>specifier</i>)<br/>
 Formats a numeric _value_ as a string. The _specifier_ must be a valid [d3-format specifier](https://github.com/d3/d3-format/) (e.g., `format(value, ',.2f')`.
-Null values are formatted as `"null"`. 
+Null values are formatted as `"null"`.
 
 <a name="monthFormat" href="#monthFormat">#</a>
 <b>monthFormat</b>(<i>month</i>)<br/>
@@ -639,7 +639,7 @@ Returns a time format specifier string for the given time [_units_](../api/time/
 <a name="timeFormat" href="#timeFormat">#</a>
 <b>timeFormat</b>(<i>value</i>, <i>specifier</i>)<br/>
 Formats a datetime _value_ (either a `Date` object or timestamp) as a string, according to the local time. The _specifier_ must be a valid [d3-time-format specifier](https://github.com/d3/d3-time-format/) or [TimeMultiFormat object](../types/#TimeMultiFormat) {% include tag ver="5.8" %}. For example: `timeFormat(timestamp, '%A')`.
-Null values are formatted as `"null"`. 
+Null values are formatted as `"null"`.
 
 <a name="timeParse" href="#timeParse">#</a>
 <b>timeParse</b>(<i>string</i>, <i>specifier</i>)<br/>
@@ -648,7 +648,7 @@ Parses a _string_ value to a Date object, according to the local time. The _spec
 <a name="utcFormat" href="#utcFormat">#</a>
 <b>utcFormat</b>(<i>value</i>, <i>specifier</i>)<br/>
 Formats a datetime _value_ (either a `Date` object or timestamp) as a string, according to [UTC](https://en.wikipedia.org/wiki/Coordinated_Universal_Time) time. The _specifier_ must be a valid [d3-time-format specifier](https://github.com/d3/d3-time-format/) or [TimeMultiFormat object](../types/#TimeMultiFormat) {% include tag ver="5.8" %}. For example: `utcFormat(timestamp, '%A')`.
-Null values are formatted as `"null"`. 
+Null values are formatted as `"null"`.
 
 <a name="utcParse" href="#utcParse">#</a>
 <b>utcParse</b>(<i>value</i>, <i>specifier</i>)<br/>

--- a/docs/docs/expressions.md
+++ b/docs/docs/expressions.md
@@ -593,6 +593,15 @@ Truncates an input _string_ to a target _length_. The optional _align_ argument 
 <b>upper</b>(<i>string</i>)<br/>
 Transforms _string_ to upper-case letters.
 
+<a name="btoa" href="#btoa">#</a>
+<b>btoa</b>(<i>string</i>) {% include tag ver="5.3x" %}<br/>
+Creates a [Base64](https://developer.mozilla.org/en-US/docs/Glossary/Base64)-encoded [ASCII](https://developer.mozilla.org/en-US/docs/Glossary/ASCII) string. Same as JavaScript's [Window.btoa()](https://developer.mozilla.org/en-US/docs/Web/API/Window/btoa).
+
+<a name="atob" href="#atob">#</a>
+<b>atob</b>(<i>string</i>) {% include tag ver="5.3x" %}<br/>
+Decodes an [ASCII](https://developer.mozilla.org/en-US/docs/Glossary/ASCII) string that was encoded with [Base64](https://developer.mozilla.org/en-US/docs/Glossary/Base64). Same as JavaScript's [Window.atob()](https://developer.mozilla.org/en-US/docs/Web/API/Window/atob).
+
+
 [Back to Top](#reference)
 
 

--- a/packages/vega-expression/README.md
+++ b/packages/vega-expression/README.md
@@ -140,9 +140,11 @@ This package provides the following constants and functions:
 - [`split`](https://vega.github.io/vega/docs/expressions/#split)
 - [`substring`](https://vega.github.io/vega/docs/expressions/#substring)
 - [`trim`](https://vega.github.io/vega/docs/expressions/#trim)
+- [`atob`](https://vega.github.io/vega/docs/expressions/#atob)
+- [`btoa`](https://vega.github.io/vega/docs/expressions/#btoa)
+
 
 **RegExp Functions**
 
 - [`regexp`](https://vega.github.io/vega/docs/expressions/#regexp)
 - [`test`](https://vega.github.io/vega/docs/expressions/#test)
-

--- a/packages/vega-expression/src/functions.js
+++ b/packages/vega-expression/src/functions.js
@@ -86,6 +86,9 @@ export default function(codegen) {
     substring:   fn('substring', STRING),
     split:       fn('split', STRING),
     trim:        fn('trim', STRING, 0),
+    // base64 encode/decode
+    btoa:        'btoa',
+    atob:        'atob',
 
     // REGEXP functions
     regexp:  REGEXP,

--- a/packages/vega-expression/test/codegen-test.js
+++ b/packages/vega-expression/test/codegen-test.js
@@ -212,6 +212,8 @@ tape('Evaluate expressions with white list', t => {
   t.equal(evaluate('trim(" 123 ")'), ' 123 '.trim());
   t.equal(evaluate('parseFloat("3.14")'), parseFloat('3.14'));
   t.equal(evaluate('parseInt("42")'),parseInt('42'));
+  t.equal(evaluate('btoa("a")'),  btoa('a'));
+  t.equal(evaluate('atob("YQ==")'), atob('YQ=='));
 
   // should eval regular expression functions
   t.equal(evaluate('test(/ain/, "spain")'), /ain/.test('spain'));

--- a/packages/vega-interpreter/src/functions.js
+++ b/packages/vega-interpreter/src/functions.js
@@ -75,6 +75,11 @@ export default {
   split:        function() { return apply('split', arguments, String); },
   replace:      function() { return apply('replace', arguments, String); },
   trim:         x => String(x).trim(),
+  // Base64 encode/decode
+  // Convert binary string to base64-encoded ascii
+  btoa:         x => btoa(x),
+  // Convert base64-encoded ascii to binary string
+  atob:         x => atob(x),
 
   // regexp functions
   regexp:       RegExp,

--- a/packages/vega/test/scenegraphs/atob-btoa-test.json
+++ b/packages/vega/test/scenegraphs/atob-btoa-test.json
@@ -1,0 +1,329 @@
+{
+    "marktype": "group",
+    "name": "root",
+    "role": "frame",
+    "interactive": true,
+    "clip": false,
+    "items": [
+      {
+        "items": [
+          {
+            "marktype": "group",
+            "role": "axis",
+            "interactive": false,
+            "clip": false,
+            "items": [
+              {
+                "items": [
+                  {
+                    "marktype": "rule",
+                    "role": "axis-tick",
+                    "interactive": false,
+                    "clip": false,
+                    "items": [
+                      {
+                        "x": 10,
+                        "y": 0,
+                        "opacity": 1,
+                        "stroke": "#888",
+                        "strokeWidth": 1,
+                        "y2": 5
+                      },
+                      {
+                        "x": 30,
+                        "y": 0,
+                        "opacity": 1,
+                        "stroke": "#888",
+                        "strokeWidth": 1,
+                        "y2": 5
+                      },
+                      {
+                        "x": 50,
+                        "y": 0,
+                        "opacity": 1,
+                        "stroke": "#888",
+                        "strokeWidth": 1,
+                        "y2": 5
+                      }
+                    ],
+                    "zindex": 0
+                  },
+                  {
+                    "marktype": "text",
+                    "role": "axis-label",
+                    "interactive": false,
+                    "clip": false,
+                    "items": [
+                      {
+                        "x": 9.5,
+                        "y": 7,
+                        "align": "right",
+                        "baseline": "middle",
+                        "fill": "#000",
+                        "opacity": 1,
+                        "text": "A",
+                        "angle": 270,
+                        "limit": 180,
+                        "font": "sans-serif",
+                        "fontSize": 10
+                      },
+                      {
+                        "x": 29.5,
+                        "y": 7,
+                        "align": "right",
+                        "baseline": "middle",
+                        "fill": "#000",
+                        "opacity": 1,
+                        "text": "B",
+                        "angle": 270,
+                        "limit": 180,
+                        "font": "sans-serif",
+                        "fontSize": 10
+                      },
+                      {
+                        "x": 49.5,
+                        "y": 7,
+                        "align": "right",
+                        "baseline": "middle",
+                        "fill": "#000",
+                        "opacity": 1,
+                        "text": "C",
+                        "angle": 270,
+                        "limit": 180,
+                        "font": "sans-serif",
+                        "fontSize": 10
+                      }
+                    ],
+                    "zindex": 0
+                  },
+                  {
+                    "marktype": "rule",
+                    "role": "axis-domain",
+                    "interactive": false,
+                    "clip": false,
+                    "items": [
+                      {
+                        "x": 0,
+                        "y": 0,
+                        "opacity": 1,
+                        "stroke": "#888",
+                        "strokeWidth": 1,
+                        "x2": 60
+                      }
+                    ],
+                    "zindex": 0
+                  },
+                  {
+                    "marktype": "text",
+                    "role": "axis-title",
+                    "interactive": false,
+                    "clip": false,
+                    "items": [
+                      {
+                        "x": 30,
+                        "y": 19,
+                        "align": "center",
+                        "baseline": "top",
+                        "fill": "#000",
+                        "opacity": 1,
+                        "text": "identity",
+                        "angle": 0,
+                        "font": "sans-serif",
+                        "fontSize": 11,
+                        "fontWeight": "bold"
+                      }
+                    ],
+                    "zindex": 0
+                  }
+                ],
+                "x": 0.5,
+                "y": 60.5,
+                "orient": "bottom"
+              }
+            ],
+            "zindex": 0
+          },
+          {
+            "marktype": "group",
+            "role": "axis",
+            "interactive": false,
+            "clip": false,
+            "items": [
+              {
+                "items": [
+                  {
+                    "marktype": "rule",
+                    "role": "axis-tick",
+                    "interactive": false,
+                    "clip": false,
+                    "items": [
+                      {
+                        "x": 0,
+                        "y": 10,
+                        "opacity": 1,
+                        "stroke": "#888",
+                        "strokeWidth": 1,
+                        "x2": -5
+                      },
+                      {
+                        "x": 0,
+                        "y": 30,
+                        "opacity": 1,
+                        "stroke": "#888",
+                        "strokeWidth": 1,
+                        "x2": -5
+                      },
+                      {
+                        "x": 0,
+                        "y": 50,
+                        "opacity": 1,
+                        "stroke": "#888",
+                        "strokeWidth": 1,
+                        "x2": -5
+                      }
+                    ],
+                    "zindex": 0
+                  },
+                  {
+                    "marktype": "text",
+                    "role": "axis-label",
+                    "interactive": false,
+                    "clip": false,
+                    "items": [
+                      {
+                        "x": -7,
+                        "y": 9.5,
+                        "align": "right",
+                        "baseline": "middle",
+                        "fill": "#000",
+                        "opacity": 1,
+                        "text": "QQ==",
+                        "angle": 0,
+                        "limit": 180,
+                        "font": "sans-serif",
+                        "fontSize": 10
+                      },
+                      {
+                        "x": -7,
+                        "y": 29.5,
+                        "align": "right",
+                        "baseline": "middle",
+                        "fill": "#000",
+                        "opacity": 1,
+                        "text": "Qg==",
+                        "angle": 0,
+                        "limit": 180,
+                        "font": "sans-serif",
+                        "fontSize": 10
+                      },
+                      {
+                        "x": -7,
+                        "y": 49.5,
+                        "align": "right",
+                        "baseline": "middle",
+                        "fill": "#000",
+                        "opacity": 1,
+                        "text": "Qw==",
+                        "angle": 0,
+                        "limit": 180,
+                        "font": "sans-serif",
+                        "fontSize": 10
+                      }
+                    ],
+                    "zindex": 0
+                  },
+                  {
+                    "marktype": "rule",
+                    "role": "axis-domain",
+                    "interactive": false,
+                    "clip": false,
+                    "items": [
+                      {
+                        "x": 0,
+                        "y": 0,
+                        "opacity": 1,
+                        "stroke": "#888",
+                        "strokeWidth": 1,
+                        "y2": 60
+                      }
+                    ],
+                    "zindex": 0
+                  },
+                  {
+                    "marktype": "text",
+                    "role": "axis-title",
+                    "interactive": false,
+                    "clip": false,
+                    "items": [
+                      {
+                        "x": -43,
+                        "y": 30,
+                        "align": "center",
+                        "baseline": "bottom",
+                        "fill": "#000",
+                        "opacity": 1,
+                        "text": "encoded",
+                        "angle": -90,
+                        "font": "sans-serif",
+                        "fontSize": 11,
+                        "fontWeight": "bold"
+                      }
+                    ],
+                    "zindex": 0
+                  }
+                ],
+                "x": 0.5,
+                "y": 0.5,
+                "orient": "left"
+              }
+            ],
+            "zindex": 0
+          },
+          {
+            "marktype": "rect",
+            "name": "marks",
+            "role": "mark",
+            "interactive": true,
+            "clip": false,
+            "items": [
+              {
+                "x": 1,
+                "y": 1,
+                "width": 18,
+                "height": 18,
+                "fill": "#4c78a8",
+                "description": "identity: A; encoded: QQ==; a: A",
+                "ariaRoleDescription": "bar"
+              },
+              {
+                "x": 21,
+                "y": 21,
+                "width": 18,
+                "height": 18,
+                "fill": "#f58518",
+                "description": "identity: B; encoded: Qg==; a: B",
+                "ariaRoleDescription": "bar"
+              },
+              {
+                "x": 41,
+                "y": 41,
+                "width": 18,
+                "height": 18,
+                "fill": "#e45756",
+                "description": "identity: C; encoded: Qw==; a: C",
+                "ariaRoleDescription": "bar"
+              }
+            ],
+            "zindex": 0
+          }
+        ],
+        "x": 0,
+        "y": 0,
+        "width": 60,
+        "height": 60,
+        "fill": "transparent",
+        "stroke": "#ddd"
+      }
+    ],
+    "zindex": 0
+  }

--- a/packages/vega/test/specs-valid.json
+++ b/packages/vega/test/specs-valid.json
@@ -3,6 +3,7 @@
   "arc",
   "arc-diagram",
   "area",
+  "atob-btoa-test",
   "autosize-fit",
   "autosize-fit-x",
   "autosize-fit-y",

--- a/packages/vega/test/specs-valid/atob-btoa-test.vg.json
+++ b/packages/vega/test/specs-valid/atob-btoa-test.vg.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "background": "white",
+  "padding": 5,
+  "style": "cell",
+  "data": [
+    {
+      "name": "source_0",
+      "values": [{"a": "A", "b": 28}, {"a": "B", "b": 55}, {"a": "C", "b": 43}]
+    },
+    {
+      "name": "data_0",
+      "source": "source_0",
+      "transform": [
+        {"type": "formula", "expr": "atob(btoa(datum.a))", "as": "identity"},
+        {"type": "formula", "expr": "btoa(datum.a)", "as": "encoded"}
+      ]
+    }
+  ],
+  "signals": [
+    {"name": "x_step", "value": 20},
+    {
+      "name": "width",
+      "update": "bandspace(domain('x').length, 0.1, 0.05) * x_step"
+    },
+    {"name": "y_step", "value": 20},
+    {
+      "name": "height",
+      "update": "bandspace(domain('y').length, 0.1, 0.05) * y_step"
+    }
+  ],
+  "marks": [
+    {
+      "name": "marks",
+      "type": "rect",
+      "style": ["bar"],
+      "from": {"data": "data_0"},
+      "encode": {
+        "update": {
+          "fill": {"scale": "color", "field": "a"},
+          "ariaRoleDescription": {"value": "bar"},
+          "description": {
+            "signal": "\"identity: \" + (isValid(datum[\"identity\"]) ? datum[\"identity\"] : \"\"+datum[\"identity\"]) + \"; encoded: \" + (isValid(datum[\"encoded\"]) ? datum[\"encoded\"] : \"\"+datum[\"encoded\"]) + \"; a: \" + (isValid(datum[\"a\"]) ? datum[\"a\"] : \"\"+datum[\"a\"])"
+          },
+          "x": {"scale": "x", "field": "identity"},
+          "width": {"signal": "max(0.25, bandwidth('x'))"},
+          "y": {"scale": "y", "field": "encoded"},
+          "height": {"signal": "max(0.25, bandwidth('y'))"}
+        }
+      }
+    }
+  ],
+  "scales": [
+    {
+      "name": "x",
+      "type": "band",
+      "domain": {"data": "data_0", "field": "identity", "sort": true},
+      "range": {"step": {"signal": "x_step"}},
+      "paddingInner": 0.1,
+      "paddingOuter": 0.05
+    },
+    {
+      "name": "y",
+      "type": "band",
+      "domain": {"data": "data_0", "field": "encoded", "sort": true},
+      "range": {"step": {"signal": "y_step"}},
+      "paddingInner": 0.1,
+      "paddingOuter": 0.05
+    },
+    {
+      "name": "color",
+      "type": "ordinal",
+      "domain": {"data": "data_0", "field": "a", "sort": true},
+      "range": "category"
+    }
+  ],
+  "axes": [
+    {
+      "scale": "x",
+      "orient": "bottom",
+      "grid": false,
+      "title": "identity",
+      "labelAlign": "right",
+      "labelAngle": 270,
+      "labelBaseline": "middle",
+      "zindex": 0
+    },
+    {
+      "scale": "y",
+      "orient": "left",
+      "grid": false,
+      "title": "encoded",
+      "zindex": 0
+    }
+  ]
+}


### PR DESCRIPTION
## Motivation

- Allow users to modify SVG images that were Base64 encoded. This is useful in Vega-Lite environments where remote access to images was disabled, such as Deneb (PowerBI), so users are especially dependent on inline data definitions.
- See #3875 

## Testing

- Try test URL sandbox showing that images can be encoded/decoded [link](https://cameron-yick-feature-add-bas.vega-628.pages.dev/#/url/vega-lite/N4IgJAzgxgFgpgWwIYgFwhgF0wBwqgegIDc4BzJAOjIEtMYBXAI0poHsDp5kTykBaADZ04JAKyUAVhDYA7EABoQAEySYUqUMSSCGcCGgDaoDSACCikEzQAmABwBfBSbQgAQpeuoxYpy-QAwp5oACwAzA4Auk4gyABOANauTEhxlnCyUGzKNLJkaKAAngUgAGY0cILKrhlZynDVSpiFOHCusmwIuTogMQAeJeWV1eg09bKYdMVNLW3oHV2yPTFZgmxpmmUVVa4oM63tnd2CloLkGSOyDIKCDjGYcUiyEKXrCEagUDpQ12pzIGo2EwABRMTBsJDA1SYBgIShIACUCMsSAMo3Gk2avWcIC+gh+gj+yXBkOhsPhyKUqJqmWyDV60SAA)
  - Make sure it works with AND without vega-interpreter mode: https://github.com/vega/editor/issues/1460
- I did not unit test this change yet as the function is a core web API. However, if it would be useful to have at least 1 spec that uses both atob and btoa, I can add one. 

## Notes

- btoa / atob: check the status for node.js usage ( https://github.com/DefinitelyTyped/DefinitelyTyped/issues/65494 ) since the Node.js world prefers using `Buffer.from(` instead.
- Check why/if this is different from what we did for vega-functions in https://github.com/vega/vega/pull/3973
- To get the scenegraph for my test, I visited https://cameron-yick-feature-add-bas.vega-628.pages.dev/#/edited, used and used `VEGA_DEBUG.view` to get a sample scenegraph.