### PR TITLE
docs(vega-expression): Add release number to docs for  base64 encode/decode (atob, btoa)

### DIFF
--- a/docs/docs/expressions.md
+++ b/docs/docs/expressions.md
@@ -594,11 +594,11 @@ Truncates an input _string_ to a target _length_. The optional _align_ argument 
 Transforms _string_ to upper-case letters.
 
 <a name="btoa" href="#btoa">#</a>
-<b>btoa</b>(<i>string</i>) {% include tag ver="5.3x" %}<br/>
+<b>btoa</b>(<i>string</i>) {% include tag ver="5.32.0" %}<br/>
 Creates a [Base64](https://developer.mozilla.org/en-US/docs/Glossary/Base64)-encoded [ASCII](https://developer.mozilla.org/en-US/docs/Glossary/ASCII) string. Same as JavaScript's [Window.btoa()](https://developer.mozilla.org/en-US/docs/Web/API/Window/btoa).
 
 <a name="atob" href="#atob">#</a>
-<b>atob</b>(<i>string</i>) {% include tag ver="5.3x" %}<br/>
+<b>atob</b>(<i>string</i>) {% include tag ver="5.32.0" %}<br/>
 Decodes an [ASCII](https://developer.mozilla.org/en-US/docs/Glossary/ASCII) string that was encoded with [Base64](https://developer.mozilla.org/en-US/docs/Glossary/Base64). Same as JavaScript's [Window.atob()](https://developer.mozilla.org/en-US/docs/Web/API/Window/atob).
 
 


### PR DESCRIPTION
## Motivation

- When https://github.com/vega/vega/pull/4009 was released, we didn't know the version number it would be used. Now we do!

## Changes

- Replace 5.3x placeholder with 5.32.0, which is the correct version where https://github.com/vega/vega/releases/tag/v5.32.0 was made available