### PR TITLE
fix(preview): Use parcel `2.12.0` for building PR previews

### DIFF
--- a/scripts/build-editor-preview.sh
+++ b/scripts/build-editor-preview.sh
@@ -22,6 +22,8 @@ git clone https://github.com/vega/editor.git
 
 cd editor
 yarn --frozen-lockfile --ignore-scripts
+# Parcel 2.13.0 and later break the preview build when run in CI.
+yarn add parcel@2.12.0 @parcel/resolver-glob@2.12.0 @parcel/transformer-inline-string@2.12.0
 
 # HACK: Make sure we prefer the local version to the one from npm
 # Test if we can remove this after verifying that only 1 copy of every subpackage is used per repo


### PR DESCRIPTION
## Motivation

- Same as https://github.com/vega/editor/pull/1475, but rolling back a minor version further back (`2.12.0`)
- Restore service to #3924 

## Testing

- Check if the cloudflare preview passes! (it does: https://cameron-yick-test-reduce-par.vega-628.pages.dev/ )