### PR TITLE
chore: remove sourcemaps for bundled files

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -156,7 +156,6 @@ export default function(commandLineArgs) {
       output: bundleOutputs({
         file: pkg.jsdelivr,
         format: 'umd',
-        sourcemap: true,
         globals,
         name: 'vega'
       }),
@@ -171,7 +170,6 @@ export default function(commandLineArgs) {
       output: bundleOutputs({
         file: pkg.jsdelivr.replace('.min.js', '-core.min.js'),
         format: 'umd',
-        sourcemap: true,
         globals,
         name: 'vega'
       }),


### PR DESCRIPTION
They don't really help since we don't ship the sources in the package anyway. If you want sourcemaps, use ESM.

This change should make our packages smaller. See https://packagephobia.com/result?p=vega