### PR TITLE
feat: align label to start of chart

### DIFF
--- a/packages/vega-typings/types/spec/config.d.ts
+++ b/packages/vega-typings/types/spec/config.d.ts
@@ -9,7 +9,6 @@ import {
   Orientation,
   Padding,
   RangeScheme,
-  StringValue,
   SymbolShape,
   TextBaseline
 } from '../index.js';
@@ -598,7 +597,7 @@ export interface BaseLegendLayout {
   /**
    * The reference frame for the anchor position, one of `"group"` (the default, to anchor relative to the group width or height) or `"bounds"` (to anchor relative to the full bounding box).
    */
-  frame?: TitleFrame | StringValue;
+  frame?: TitleFrame;
 
   /**
    * A flag to center legends within a shared orient group.

--- a/packages/vega-typings/types/spec/config.d.ts
+++ b/packages/vega-typings/types/spec/config.d.ts
@@ -9,6 +9,7 @@ import {
   Orientation,
   Padding,
   RangeScheme,
+  StringValue,
   SymbolShape,
   TextBaseline
 } from '../index.js';
@@ -29,7 +30,7 @@ import { BaseLegend } from './legend.js';
 import { Locale } from './locale.js';
 import { BaseProjection } from './projection.js';
 import { InitSignal, NewSignal, SignalRef } from './signal.js';
-import { BaseTitle, TitleAnchor } from './title.js';
+import { BaseTitle, TitleAnchor, TitleFrame } from './title.js';
 
 export type KeepSignal<T> = T extends SignalRef ? SignalRef : never;
 
@@ -593,6 +594,11 @@ export interface BaseLegendLayout {
    * The bounds calculation to use for legend orient group layout.
    */
   bounds?: LayoutBounds;
+
+  /**
+   * The reference frame for the anchor position, one of `"group"` (the default, to anchor relative to the group width or height) or `"bounds"` (to anchor relative to the full bounding box).
+   */
+  frame?: TitleFrame | StringValue;
 
   /**
    * A flag to center legends within a shared orient group.

--- a/packages/vega-view-transforms/src/constants.js
+++ b/packages/vega-view-transforms/src/constants.js
@@ -16,6 +16,7 @@ export const X = 'x';
 export const Y = 'y';
 
 export const Group = 'group';
+export const Bounds = "bounds";
 
 export const AxisRole = 'axis';
 export const TitleRole = 'title';

--- a/packages/vega-view-transforms/src/constants.js
+++ b/packages/vega-view-transforms/src/constants.js
@@ -44,5 +44,8 @@ export const All = 'all';
 export const Each = 'each';
 export const Flush = 'flush';
 
+export const Axis = "axis";
+export const Chart = "chart";
+
 export const Column = 'column';
 export const Row = 'row';

--- a/packages/vega-view-transforms/src/constants.js
+++ b/packages/vega-view-transforms/src/constants.js
@@ -16,7 +16,7 @@ export const X = 'x';
 export const Y = 'y';
 
 export const Group = 'group';
-export const Bounds = "bounds";
+export const Bounds = 'bounds';
 
 export const AxisRole = 'axis';
 export const TitleRole = 'title';
@@ -44,9 +44,6 @@ export const None = 'none';
 export const All = 'all';
 export const Each = 'each';
 export const Flush = 'flush';
-
-export const Axis = "axis";
-export const Chart = "chart";
 
 export const Column = 'column';
 export const Row = 'row';

--- a/packages/vega-view-transforms/src/layout/legend.js
+++ b/packages/vega-view-transforms/src/layout/legend.js
@@ -1,9 +1,9 @@
+import { boundStroke, multiLineOffset } from 'vega-scenegraph';
 import {
   Bottom, BottomLeft, BottomRight, Each, End, Flush, Left, Middle,
   None, Right, Start, Symbols, Top,
   TopLeft, TopRight
 } from '../constants.js';
-import {boundStroke, multiLineOffset} from 'vega-scenegraph';
 
 // utility for looking up legend layout configuration
 function lookup(config, orient) {
@@ -26,6 +26,7 @@ export function legendParams(g, orient, config, xb, yb, w, h) {
   const _ = lookup(config, orient),
         offset = offsets(g, _('offset', 0)),
         anchor = _('anchor', Start),
+        container = _('container', false),
         mult = anchor === End ? 1 : anchor === Middle ? 0.5 : 0;
 
   const p = {
@@ -53,13 +54,15 @@ export function legendParams(g, orient, config, xb, yb, w, h) {
     case Top:
       p.anchor = {
         y: Math.floor(yb.y1) - offset, row: End,
-        x: mult * (w || yb.width() + 2 * yb.x1), column: anchor
+        x: anchor === Start && container ? xb.x1 : mult * (w || yb.width() + 2 * yb.x1),
+        column: anchor
       };
       break;
     case Bottom:
       p.anchor = {
         y: Math.ceil(yb.y2) + offset,
-        x: mult * (w || yb.width() + 2 * yb.x1), column: anchor
+        x: anchor === Start && container ? xb.x1 : mult * (w || yb.width() + 2 * yb.x1),
+        column: anchor
       };
       break;
     case TopLeft:

--- a/packages/vega-view-transforms/src/layout/legend.js
+++ b/packages/vega-view-transforms/src/layout/legend.js
@@ -1,6 +1,6 @@
 import { boundStroke, multiLineOffset } from 'vega-scenegraph';
 import {
-  Bounds, Bottom, BottomLeft, BottomRight, Each, End, Flush,
+  Bottom, BottomLeft, BottomRight, Bounds, Each, End, Flush,
   Group, Left, Middle, None, Right, Start, Symbols, Top,
   TopLeft, TopRight
 } from '../constants.js';

--- a/packages/vega-view-transforms/src/layout/legend.js
+++ b/packages/vega-view-transforms/src/layout/legend.js
@@ -1,7 +1,7 @@
 import { boundStroke, multiLineOffset } from 'vega-scenegraph';
 import {
-  Bottom, BottomLeft, BottomRight, Each, End, Flush, Left, Middle,
-  None, Right, Start, Symbols, Top,
+  Axis, Bottom, BottomLeft, BottomRight, Chart, Each, End, Flush,
+  Left, Middle, None, Right, Start, Symbols, Top,
   TopLeft, TopRight
 } from '../constants.js';
 
@@ -26,7 +26,7 @@ export function legendParams(g, orient, config, xb, yb, w, h) {
   const _ = lookup(config, orient),
         offset = offsets(g, _('offset', 0)),
         anchor = _('anchor', Start),
-        container = _('container', false),
+        align = _('align', Axis),
         mult = anchor === End ? 1 : anchor === Middle ? 0.5 : 0;
 
   const p = {
@@ -54,14 +54,14 @@ export function legendParams(g, orient, config, xb, yb, w, h) {
     case Top:
       p.anchor = {
         y: Math.floor(yb.y1) - offset, row: End,
-        x: anchor === Start && container ? xb.x1 : mult * (w || yb.width() + 2 * yb.x1),
+        x: anchor === Start && align === Chart ? xb.x1 : mult * (w || yb.width() + 2 * yb.x1),
         column: anchor
       };
       break;
     case Bottom:
       p.anchor = {
         y: Math.ceil(yb.y2) + offset,
-        x: anchor === Start && container ? xb.x1 : mult * (w || yb.width() + 2 * yb.x1),
+        x: anchor === Start && align === Chart ? xb.x1 : mult * (w || yb.width() + 2 * yb.x1),
         column: anchor
       };
       break;

--- a/packages/vega-view-transforms/src/layout/legend.js
+++ b/packages/vega-view-transforms/src/layout/legend.js
@@ -1,7 +1,7 @@
 import { boundStroke, multiLineOffset } from 'vega-scenegraph';
 import {
-  Axis, Bottom, BottomLeft, BottomRight, Chart, Each, End, Flush,
-  Left, Middle, None, Right, Start, Symbols, Top,
+  Bounds, Bottom, BottomLeft, BottomRight, Each, End, Flush,
+  Group, Left, Middle, None, Right, Start, Symbols, Top,
   TopLeft, TopRight
 } from '../constants.js';
 
@@ -26,7 +26,7 @@ export function legendParams(g, orient, config, xb, yb, w, h) {
   const _ = lookup(config, orient),
         offset = offsets(g, _('offset', 0)),
         anchor = _('anchor', Start),
-        align = _('align', Axis),
+        frame = _('frame', Group),
         mult = anchor === End ? 1 : anchor === Middle ? 0.5 : 0;
 
   const p = {
@@ -54,14 +54,14 @@ export function legendParams(g, orient, config, xb, yb, w, h) {
     case Top:
       p.anchor = {
         y: Math.floor(yb.y1) - offset, row: End,
-        x: anchor === Start && align === Chart ? xb.x1 : mult * (w || yb.width() + 2 * yb.x1),
+        x: anchor === Start && frame === Bounds ? xb.x1 : mult * (w || yb.width() + 2 * yb.x1),
         column: anchor
       };
       break;
     case Bottom:
       p.anchor = {
         y: Math.ceil(yb.y2) + offset,
-        x: anchor === Start && align === Chart ? xb.x1 : mult * (w || yb.width() + 2 * yb.x1),
+        x: anchor === Start && frame === Bounds ? xb.x1 : mult * (w || yb.width() + 2 * yb.x1),
         column: anchor
       };
       break;

--- a/packages/vega/test/scenegraphs/scatter-plot-guides.json
+++ b/packages/vega/test/scenegraphs/scatter-plot-guides.json
@@ -4681,7 +4681,7 @@
                               ],
                               "x": 0,
                               "y": 0,
-                              "width": 62,
+                              "width": 38,
                               "height": 11,
                               "opacity": 1
                             },
@@ -4730,9 +4730,9 @@
                                   "zindex": 0
                                 }
                               ],
-                              "x": 0,
-                              "y": 14,
-                              "width": 62,
+                              "x": 49,
+                              "y": 0,
+                              "width": 54,
                               "height": 11,
                               "opacity": 1
                             },
@@ -4781,8 +4781,8 @@
                                   "zindex": 0
                                 }
                               ],
-                              "x": 0,
-                              "y": 28,
+                              "x": 114,
+                              "y": 0,
                               "width": 62,
                               "height": 11,
                               "opacity": 1
@@ -4822,11 +4822,11 @@
                   "zindex": 0
                 }
               ],
-              "x": 418,
-              "y": 0,
-              "width": 62,
-              "height": 55,
-              "orient": "right"
+              "x": -39,
+              "y": -45,
+              "width": 176,
+              "height": 27,
+              "orient": "top"
             }
           ],
           "zindex": 0

--- a/packages/vega/test/specs-valid/scatter-plot-guides.vg.json
+++ b/packages/vega/test/specs-valid/scatter-plot-guides.vg.json
@@ -157,7 +157,7 @@
   "config": {
     "legend": {
       "layout": {
-        "align": "chart"
+        "frame": "group"
       }
     }
   },

--- a/packages/vega/test/specs-valid/scatter-plot-guides.vg.json
+++ b/packages/vega/test/specs-valid/scatter-plot-guides.vg.json
@@ -157,7 +157,7 @@
   "config": {
     "legend": {
       "layout": {
-        "top": { "container": true }
+        "align": "chart"
       }
     }
   },

--- a/packages/vega/test/specs-valid/scatter-plot-guides.vg.json
+++ b/packages/vega/test/specs-valid/scatter-plot-guides.vg.json
@@ -157,7 +157,7 @@
   "config": {
     "legend": {
       "layout": {
-        "frame": "group"
+        "frame": "bounds"
       }
     }
   },

--- a/packages/vega/test/specs-valid/scatter-plot-guides.vg.json
+++ b/packages/vega/test/specs-valid/scatter-plot-guides.vg.json
@@ -154,10 +154,20 @@
     }
   ],
 
+  "config": {
+    "legend": {
+      "layout": {
+        "top": { "container": true }
+      }
+    }
+  },
+
   "legends": [
     {
       "stroke": "color",
       "title": "Origin",
+      "direction": "horizontal",
+      "orient": "top",
       "encode": {
         "symbols": {
           "name": "legendSymbol",


### PR DESCRIPTION
Addresses https://github.com/vega/vega/issues/3903

Added a property named `frame` similar to that of `title` which takes the value of `group` or `bounds` to align the legend to the chart when `orient` is either `top` or `bottom`. 

With `orient: top`, `anchor:start` and  `frame: group` (default)
<img width="462" alt="image" src="https://github.com/user-attachments/assets/c7c8aa79-239c-40c9-bfee-f83afcb6ba8d" />


With `orient: top`, `anchor:start` and  `frame: bounds`
<img width="465" alt="image" src="https://github.com/user-attachments/assets/1260feab-f327-4b41-b9ed-f683b241c664" />


With `orient: top`, `anchor:end` and  `frame: bounds` and axes Y `orient:right`
<img width="463" alt="image" src="https://github.com/user-attachments/assets/05e3f25c-6fe8-4281-a707-73cede0d2337" />

