### PR TITLE
docs: replace version in specs

### DIFF
--- a/docs/docs/marks/arc.vg.json
+++ b/docs/docs/marks/arc.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "width": 200,
   "height": 200,
   "padding": 5,

--- a/docs/docs/marks/area.vg.json
+++ b/docs/docs/marks/area.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "width": 400,
   "height": 200,
   "padding": 5,

--- a/docs/docs/marks/group.vg.json
+++ b/docs/docs/marks/group.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "width": 200,
   "height": 200,
   "padding": 5,

--- a/docs/docs/marks/image.vg.json
+++ b/docs/docs/marks/image.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "width": 200,
   "height": 200,
   "padding": 5,

--- a/docs/docs/marks/line.vg.json
+++ b/docs/docs/marks/line.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "width": 400,
   "height": 200,
   "padding": 5,

--- a/docs/docs/marks/path.vg.json
+++ b/docs/docs/marks/path.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "width": 200,
   "height": 200,
   "padding": 5,

--- a/docs/docs/marks/rect.vg.json
+++ b/docs/docs/marks/rect.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "width": 200,
   "height": 200,
   "padding": 5,

--- a/docs/docs/marks/rule.vg.json
+++ b/docs/docs/marks/rule.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "width": 200,
   "height": 200,
   "padding": 5,

--- a/docs/docs/marks/symbol.vg.json
+++ b/docs/docs/marks/symbol.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "width": 200,
   "height": 200,
   "padding": 5,

--- a/docs/docs/marks/text.vg.json
+++ b/docs/docs/marks/text.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "width": 200,
   "height": 200,
   "padding": 5,

--- a/docs/docs/marks/trail.vg.json
+++ b/docs/docs/marks/trail.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "width": 400,
   "height": 200,
   "padding": 5,

--- a/docs/docs/specification.md
+++ b/docs/docs/specification.md
@@ -11,7 +11,7 @@ Below is a basic outline of a Vega specification. Complete specifications includ
 {: .suppress-error}
 ```json
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A specification outline example.",
   "width": 500,
   "height": 200,

--- a/docs/docs/transforms/force.vg.json
+++ b/docs/docs/transforms/force.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "width": 400,
   "height": 275,
   "padding": 0,

--- a/docs/docs/transforms/geopath.vg.json
+++ b/docs/docs/transforms/geopath.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "width": 432,
   "height": 240,
   "autosize": "none",

--- a/docs/docs/transforms/geopoint.vg.json
+++ b/docs/docs/transforms/geopoint.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "width": 450,
   "height": 280,
   "autosize": "none",

--- a/docs/docs/transforms/geoshape.vg.json
+++ b/docs/docs/transforms/geoshape.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "width": 432,
   "height": 240,
   "autosize": "none",

--- a/docs/docs/transforms/graticule.vg.json
+++ b/docs/docs/transforms/graticule.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "width": 432,
   "height": 240,
   "autosize": "none",

--- a/docs/docs/transforms/linkpath.vg.json
+++ b/docs/docs/transforms/linkpath.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "width": 200,
   "height": 200,
   "autosize": "none",

--- a/docs/docs/transforms/nest.vg.json
+++ b/docs/docs/transforms/nest.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "width": 300,
   "height": 100,
   "padding": 5,

--- a/docs/docs/transforms/pack.vg.json
+++ b/docs/docs/transforms/pack.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "width": 200,
   "height": 100,
   "padding": 5,

--- a/docs/docs/transforms/partition.vg.json
+++ b/docs/docs/transforms/partition.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "width": 200,
   "height": 100,
   "padding": 5,

--- a/docs/docs/transforms/pie.vg.json
+++ b/docs/docs/transforms/pie.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "width": 200,
   "height": 200,
   "autosize": "none",

--- a/docs/docs/transforms/stack.vg.json
+++ b/docs/docs/transforms/stack.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "width": 300,
   "height": 200,
   "autosize": "none",

--- a/docs/docs/transforms/tree.vg.json
+++ b/docs/docs/transforms/tree.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "width": 200,
   "height": 100,
   "padding": 5,

--- a/docs/docs/transforms/treemap.vg.json
+++ b/docs/docs/transforms/treemap.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "width": 200,
   "height": 100,
   "padding": 5,

--- a/docs/docs/transforms/voronoi.vg.json
+++ b/docs/docs/transforms/voronoi.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "width": 500,
   "height": 200,
   "autosize": "none",

--- a/docs/docs/transforms/window.vg.json
+++ b/docs/docs/transforms/window.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "width": 500,
   "height": 150,
   "padding": 5,

--- a/docs/docs/transforms/wordcloud.vg.json
+++ b/docs/docs/transforms/wordcloud.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "name": "wordcloud",
   "width": 400,
   "height": 200,

--- a/docs/examples/airport-connections.vg.json
+++ b/docs/examples/airport-connections.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "Interactive map of U.S. airport connections in 2008.",
   "width": 900,
   "height": 560,

--- a/docs/examples/annual-precipitation.vg.json
+++ b/docs/examples/annual-precipitation.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A plot of 2016 annual global precipitation data from the NOAA Climate Forecast System (CFS) v2.",
   "width": 600,
   "height": 300,

--- a/docs/examples/annual-temperature.vg.json
+++ b/docs/examples/annual-temperature.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "Area charts showing average daily temperatures in Seattle for each hour of the day.",
   "width": 800,
   "padding": 5,

--- a/docs/examples/arc-diagram.vg.json
+++ b/docs/examples/arc-diagram.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "An arc diagram depicting character co-occurrence in the novel Les Misérables.",
   "width": 770,
   "padding": 5,

--- a/docs/examples/area-chart.vg.json
+++ b/docs/examples/area-chart.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A basic area chart example.",
   "width": 500,
   "height": 200,

--- a/docs/examples/bar-chart.vg.json
+++ b/docs/examples/bar-chart.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A basic bar chart example, with value labels shown upon pointer hover.",
   "width": 400,
   "height": 200,

--- a/docs/examples/bar-line-toggle.vg.json
+++ b/docs/examples/bar-line-toggle.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "An example of Vega visualization that automatically switches between a column chart and a line chart depending on the number of data points",
   "width": 800,
   "height": 400,

--- a/docs/examples/barley-trellis-plot.vg.json
+++ b/docs/examples/barley-trellis-plot.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A small multiples view of barley yields by site and variety.",
   "width": 200,
   "padding": 5,

--- a/docs/examples/beeswarm-plot.vg.json
+++ b/docs/examples/beeswarm-plot.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A beeswarm chart example that uses a force-directed layout to group items by category.",
   "width": 800,
   "height": 100,

--- a/docs/examples/binned-scatter-plot.vg.json
+++ b/docs/examples/binned-scatter-plot.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A binned scatter plot example showing aggregate counts per binned cell.",
   "width": 200,
   "height": 200,

--- a/docs/examples/box-plot.vg.json
+++ b/docs/examples/box-plot.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A box plot example showing aggregate statistics for penguin body mass.",
   "width": 500,
   "padding": 5,

--- a/docs/examples/brushing-scatter-plots.vg.json
+++ b/docs/examples/brushing-scatter-plots.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A scatter plot matrix of penguin data with interactive linked selections.",
   "padding": 10,
   "config": {

--- a/docs/examples/budget-forecasts.vg.json
+++ b/docs/examples/budget-forecasts.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A recreation of a New York Times chart showing U.S. budget forecasts versus reality.",
   "width": 700,
   "height": 400,

--- a/docs/examples/calendar-view.vg.json
+++ b/docs/examples/calendar-view.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A calendar visualization of daily changes to the S&P 500 since 2000.",
   "padding": 5,
 

--- a/docs/examples/circle-packing.vg.json
+++ b/docs/examples/circle-packing.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "An example of a circle packing layout for hierarchical data.",
   "width": 600,
   "height": 600,

--- a/docs/examples/clock.vg.json
+++ b/docs/examples/clock.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A circular clock visualization showing the current time.",
   "width": 400,
   "height": 400,

--- a/docs/examples/connected-scatter-plot.vg.json
+++ b/docs/examples/connected-scatter-plot.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "An example of a connected scatter plot, tracking changes in miles driven versus the price of gasoline.",
   "width": 800,
   "height": 500,

--- a/docs/examples/contour-plot.vg.json
+++ b/docs/examples/contour-plot.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A contour plot example, overlaying a density estimate on scatter plot points.",
   "width": 500,
   "height": 400,

--- a/docs/examples/county-unemployment.vg.json
+++ b/docs/examples/county-unemployment.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A choropleth map depicting U.S. unemployment rates by county in 2009.",
   "width": 960,
   "height": 500,

--- a/docs/examples/crossfilter-flights.vg.json
+++ b/docs/examples/crossfilter-flights.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "Interactive cross-filtering among histograms of flight statistics.",
   "width": 500,
   "padding": 5,

--- a/docs/examples/density-heatmaps.vg.json
+++ b/docs/examples/density-heatmaps.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A small multiples view of 2D density heatmaps of automobile statistics.",
   "width": 250,
   "height": 250,

--- a/docs/examples/distortion-comparison.vg.json
+++ b/docs/examples/distortion-comparison.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A map view comparing area distortions between two projections.",
   "width": 900,
   "height": 500,

--- a/docs/examples/donut-chart.vg.json
+++ b/docs/examples/donut-chart.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A basic donut chart example.",
   "width": 200,
   "height": 200,

--- a/docs/examples/dorling-cartogram.vg.json
+++ b/docs/examples/dorling-cartogram.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A Dorling cartogram depicting U.S. state obesity rates.",
   "width": 900,
   "height": 520,

--- a/docs/examples/dot-plot.vg.json
+++ b/docs/examples/dot-plot.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A dot plot example depicting the distribution of animal sleep times.",
   "width": 300,
   "padding": 5,

--- a/docs/examples/earthquakes-globe.vg.json
+++ b/docs/examples/earthquakes-globe.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "Rotating globe animation depicting earthquake locations. Background - pseudorandomly distributed 'stars'.",
   "width": 600,
   "height": 600,

--- a/docs/examples/earthquakes.vg.json
+++ b/docs/examples/earthquakes.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "An interactive globe depicting earthquake locations and magnitudes.",
   "padding": 10,
   "width": 450,

--- a/docs/examples/edge-bundling.vg.json
+++ b/docs/examples/edge-bundling.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A network diagram of software dependencies, with edges grouped via hierarchical edge bundling.",
   "padding": 5,
   "width": 720,

--- a/docs/examples/error-bars.vg.json
+++ b/docs/examples/error-bars.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A basic error bar visualization example.",
   "width": 500,
   "height": 160,

--- a/docs/examples/falkensee-population.vg.json
+++ b/docs/examples/falkensee-population.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "An annotated line chart of the population of Falkensee, Germany.",
   "width": 500,
   "height": 250,

--- a/docs/examples/flight-passengers.vg.json
+++ b/docs/examples/flight-passengers.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "Passenger Traffic at Seattle-Tacoma International Airport, Percentage Change from October 2019 to March 2020",
   "width": 500,
   "height": 250,

--- a/docs/examples/force-directed-layout.vg.json
+++ b/docs/examples/force-directed-layout.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A node-link diagram with force-directed layout, depicting character co-occurrence in the novel Les Misérables.",
   "width": 700,
   "height": 500,

--- a/docs/examples/global-development.vg.json
+++ b/docs/examples/global-development.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "An interactive scatter plot of global health statistics by country and year.",
   "width": 800,
   "height": 600,

--- a/docs/examples/grouped-bar-chart.vg.json
+++ b/docs/examples/grouped-bar-chart.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A basic grouped bar chart example.",
   "width": 300,
   "height": 240,

--- a/docs/examples/heatmap.vg.json
+++ b/docs/examples/heatmap.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A heatmap showing average daily temperatures in Seattle for each hour of the day.",
   "width": 800,
   "height": 500,

--- a/docs/examples/histogram-null-values.vg.json
+++ b/docs/examples/histogram-null-values.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A histogram of film ratings, modified to include null values.",
   "width": 400,
   "height": 200,

--- a/docs/examples/histogram.vg.json
+++ b/docs/examples/histogram.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "An interactive histogram for visualizing a univariate distribution.",
   "width": 500,
   "height": 100,

--- a/docs/examples/horizon-graph.vg.json
+++ b/docs/examples/horizon-graph.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A horizon graph, which preserves resolution by layering slices of an area chart.",
   "width": 500,
   "height": 100,

--- a/docs/examples/hypothetical-outcome-plots.vg.json
+++ b/docs/examples/hypothetical-outcome-plots.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A hypothetical outcome plot that uses animated samples to convey uncertainty.",
   "width": 300,
   "height": 200,

--- a/docs/examples/interactive-legend.vg.json
+++ b/docs/examples/interactive-legend.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A scatter plot example with interactive legend and x-axis.",
   "width": 200,
   "height": 200,

--- a/docs/examples/job-voyager.vg.json
+++ b/docs/examples/job-voyager.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A searchable, stacked area chart of U.S. occupations from 1850 to 2000.",
   "width": 800,
   "height": 500,

--- a/docs/examples/labeled-scatter-plot.vg.json
+++ b/docs/examples/labeled-scatter-plot.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A labeled scatter plot of films showing Rotten Tomatoes ratings versus IMDB ratings.",
   "padding": 5,
   "width": 800,

--- a/docs/examples/line-chart.vg.json
+++ b/docs/examples/line-chart.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A basic line chart example.",
   "width": 500,
   "height": 200,

--- a/docs/examples/loess-regression.vg.json
+++ b/docs/examples/loess-regression.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A scatter plot with trend line calculated via locally-weighted (loess) regression.",
   "padding": 5,
   "width": 500,

--- a/docs/examples/map-with-tooltip.vg.json
+++ b/docs/examples/map-with-tooltip.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "An example of a custom tooltip (on a map)",
   "width": 960,
   "height": 500,

--- a/docs/examples/nested-bar-chart.vg.json
+++ b/docs/examples/nested-bar-chart.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A nested bar chart example, with bars grouped by category.",
   "width": 300,
   "padding": 5,

--- a/docs/examples/overview-plus-detail.vg.json
+++ b/docs/examples/overview-plus-detail.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "Area charts of stock prices, with an interactive overview and filtered detail views.",
   "width": 720,
   "height": 480,

--- a/docs/examples/packed-bubble-chart.vg.json
+++ b/docs/examples/packed-bubble-chart.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A packed bubble chart.",
   "usermeta": {
     "author": "David Bacci",

--- a/docs/examples/pacman.vg.json
+++ b/docs/examples/pacman.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "An implementation of the classic video game Pacman.",
   "width":600,
   "height":600,

--- a/docs/examples/parallel-coordinates.vg.json
+++ b/docs/examples/parallel-coordinates.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "Parallel coordinates plot showing 7 dimensions of automobile statistics.",
   "width": 700,
   "height": 400,

--- a/docs/examples/pi-monte-carlo.vg.json
+++ b/docs/examples/pi-monte-carlo.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "Estimating the value of π via random sampling methods.",
   "autosize": "pad",
   "padding": 5,

--- a/docs/examples/pie-chart.vg.json
+++ b/docs/examples/pie-chart.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A basic pie chart example.",
   "width": 200,
   "height": 200,

--- a/docs/examples/platformer.vg.json
+++ b/docs/examples/platformer.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "width": 400,
   "height": 400,
   "description": "A simple platformer. WASD to move, shift to dash.",

--- a/docs/examples/population-pyramid.vg.json
+++ b/docs/examples/population-pyramid.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A population pyramid showing U.S. demographics from 1850 to 2000.",
   "height": 400,
   "padding": 5,

--- a/docs/examples/probability-density.vg.json
+++ b/docs/examples/probability-density.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "Area chart using density estimation to show a probability density or cumulative distribution.",
   "width": 500,
   "height": 100,

--- a/docs/examples/projections.vg.json
+++ b/docs/examples/projections.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A gallery of maps showcasing different cartographic projections.",
   "autosize": "pad",
 

--- a/docs/examples/quantile-dot-plot.vg.json
+++ b/docs/examples/quantile-dot-plot.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A quantile dot plot conveying the uncertainty of bus arrival times.",
   "width": 400,
   "height": 90,

--- a/docs/examples/quantile-quantile-plot.vg.json
+++ b/docs/examples/quantile-quantile-plot.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A quantile-quantile plot example, comparing distributions by quantile values.",
   "padding": 5,
 

--- a/docs/examples/radar-chart.vg.json
+++ b/docs/examples/radar-chart.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A radar chart example, showing multiple dimensions in a radial layout.",
   "width": 400,
   "height": 400,

--- a/docs/examples/radial-plot.vg.json
+++ b/docs/examples/radial-plot.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A basic radial plot that encodes two values as the angle and radius of an arc.",
   "width": 200,
   "height": 200,

--- a/docs/examples/radial-tree-layout.vg.json
+++ b/docs/examples/radial-tree-layout.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "An example of a radial layout for a node-link diagram of hierarchical data.",
   "width": 720,
   "height": 720,

--- a/docs/examples/regression.vg.json
+++ b/docs/examples/regression.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A scatter plot with trend line calculated via user-configurable regression methods.",
   "padding": 5,
   "width": 500,

--- a/docs/examples/reorderable-matrix.vg.json
+++ b/docs/examples/reorderable-matrix.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A re-orderable adjacency matrix depicting character co-occurrence in the novel Les Misérables.",
   "width": 770,
   "height": 770,

--- a/docs/examples/scatter-plot-null-values.vg.json
+++ b/docs/examples/scatter-plot-null-values.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A scatter plot of film statistics, with null values visualized along the axes.",
   "width": 450,
   "height": 450,

--- a/docs/examples/scatter-plot.vg.json
+++ b/docs/examples/scatter-plot.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A basic scatter plot example depicting automobile statistics.",
   "width": 200,
   "height": 200,

--- a/docs/examples/serpentine-timeline.vg.json
+++ b/docs/examples/serpentine-timeline.vg.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://vega.github.io/schema/vega/v5.json",
+    "$schema": "https://vega.github.io/schema/vega/v6.json",
     "description": "a serpentine timeline. The serpentine shape can be an option for instances where an oblong canvas is not ideal. The shape can be customized using many of the signals below. Input bindings have been included for demonstration purposes",
     "padding": 15,
     "width": 300,

--- a/docs/examples/stacked-area-chart.vg.json
+++ b/docs/examples/stacked-area-chart.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A basic stacked area chart example.",
   "width": 500,
   "height": 200,

--- a/docs/examples/stacked-bar-chart.vg.json
+++ b/docs/examples/stacked-bar-chart.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A basic stacked bar chart example.",
   "width": 500,
   "height": 200,

--- a/docs/examples/stock-index-chart.vg.json
+++ b/docs/examples/stock-index-chart.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "An interactive line chart of stock prices, with returns shown relative to a selected date.",
   "width": 650,
   "height": 300,

--- a/docs/examples/sunburst.vg.json
+++ b/docs/examples/sunburst.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "An example of a space-fulling radial layout for hierarchical data.",
   "width": 600,
   "height": 600,

--- a/docs/examples/table-scrollbar.vg.json
+++ b/docs/examples/table-scrollbar.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "An example of a simple table with a scrollbar",
   "width": 300,
   "height": 400,

--- a/docs/examples/time-units.vg.json
+++ b/docs/examples/time-units.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A bar chart of flight statistics, aggregated by the selected time unit.",
   "width": 600,
   "height": 300,

--- a/docs/examples/timelines.vg.json
+++ b/docs/examples/timelines.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A timeline visualization of the lives of the first five U.S. presidents.",
   "width": 500,
   "height": 80,

--- a/docs/examples/top-k-plot-with-others.vg.json
+++ b/docs/examples/top-k-plot-with-others.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A top-k bar chart ranking film directors by revenue, including an aggregate others category.",
   "width": 500,
   "height": 410,

--- a/docs/examples/top-k-plot.vg.json
+++ b/docs/examples/top-k-plot.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A top-k bar chart ranking film directors by revenue.",
   "width": 500,
   "height": 410,

--- a/docs/examples/tree-layout.vg.json
+++ b/docs/examples/tree-layout.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "An example of Cartesian layouts for a node-link diagram of hierarchical data.",
   "width": 600,
   "height": 1600,

--- a/docs/examples/treemap.vg.json
+++ b/docs/examples/treemap.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "An example of treemap layout for hierarchical data.",
   "width": 960,
   "height": 500,

--- a/docs/examples/u-district-cuisine.vg.json
+++ b/docs/examples/u-district-cuisine.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "Area charts showing the density of cuisine options in Seattle's U-District.",
   "width": 500,
   "height": 380,

--- a/docs/examples/violin-plot.vg.json
+++ b/docs/examples/violin-plot.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A violin plot example showing distributions for pengiun body mass.",
   "width": 500,
   "padding": 5,

--- a/docs/examples/volcano-contours.vg.json
+++ b/docs/examples/volcano-contours.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A contour plot of the Maungawhau volcano in New Zealand.",
   "width": 960,
   "autosize": "none",

--- a/docs/examples/warming-stripes.vg.json
+++ b/docs/examples/warming-stripes.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "Warming Stripes Chart. Originally designed by Ed Hawkins.",
   "usermeta": {
     "Author": "Andrzej Leszkiewicz",

--- a/docs/examples/watch.vg.json
+++ b/docs/examples/watch.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A watch face clock visualization showing the current time.",
   "width": 400,
   "height": 400,

--- a/docs/examples/weekly-temperature.vg.json
+++ b/docs/examples/weekly-temperature.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "Overlaid plots of weekly record, normal, actual, and forecasted temperatures.",
   "width": 250,
   "height": 200,

--- a/docs/examples/wheat-and-wages.vg.json
+++ b/docs/examples/wheat-and-wages.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A recreation of William Playfair's classic chart of wheat prices and wages.",
   "width": 900,
   "height": 465,

--- a/docs/examples/wheat-plot.vg.json
+++ b/docs/examples/wheat-plot.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A wheat plot example, which combines elements of dot plots and histograms.",
   "width": 500,
   "padding": 5,

--- a/docs/examples/wind-vectors.vg.json
+++ b/docs/examples/wind-vectors.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A flow map of wind direction and speed over northwest Europe.",
   "width": 800,
   "height": 600,

--- a/docs/examples/word-cloud.vg.json
+++ b/docs/examples/word-cloud.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A word cloud visualization depicting Vega research paper abstracts.",
   "width": 800,
   "height": 400,

--- a/docs/examples/world-map.vg.json
+++ b/docs/examples/world-map.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "A configurable map of countries of the world.",
   "width": 900,
   "height": 500,

--- a/docs/examples/zoomable-binned-plot.vg.json
+++ b/docs/examples/zoomable-binned-plot.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "An interactive scatter plot example with binned aggregation supporting pan and zoom.",
   "width": 500,
   "height": 300,

--- a/docs/examples/zoomable-circle-packing.vg.json
+++ b/docs/examples/zoomable-circle-packing.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "An example of a zoomable circle packing layout for hierarchical data.",
   "width": 600,
   "height": 600,

--- a/docs/examples/zoomable-scatter-plot.vg.json
+++ b/docs/examples/zoomable-scatter-plot.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "An interactive scatter plot example supporting pan and zoom.",
   "width": 500,
   "height": 300,

--- a/docs/examples/zoomable-world-map.vg.json
+++ b/docs/examples/zoomable-world-map.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "description": "An interactive world map supporting pan and zoom.",
   "width": 900,
   "height": 500,

--- a/docs/tutorials/airports/airports-all.vg.json
+++ b/docs/tutorials/airports/airports-all.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "width": 900,
   "height": 560,
   "padding": {"top": 0, "left": 0, "right": 0, "bottom": 0},

--- a/docs/tutorials/airports/airports-connect-all.vg.json
+++ b/docs/tutorials/airports/airports-connect-all.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "width": 900,
   "height": 560,
   "padding": {"top": 25, "left": 0, "right": 0, "bottom": 0},

--- a/docs/tutorials/airports/airports-connect-hover.vg.json
+++ b/docs/tutorials/airports/airports-connect-hover.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "width": 900,
   "height": 560,
   "padding": {"top": 25, "left": 0, "right": 0, "bottom": 0},

--- a/docs/tutorials/airports/airports-filtered.vg.json
+++ b/docs/tutorials/airports/airports-filtered.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "width": 900,
   "height": 560,
   "padding": {"top": 0, "left": 0, "right": 0, "bottom": 0},

--- a/docs/tutorials/airports/airports-hover.vg.json
+++ b/docs/tutorials/airports/airports-hover.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "width": 900,
   "height": 560,
   "padding": {"top": 25, "left": 0, "right": 0, "bottom": 0},

--- a/docs/tutorials/airports/airports-map.vg.json
+++ b/docs/tutorials/airports/airports-map.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "width": 900,
   "height": 560,
   "padding": {"top": 0, "left": 0, "right": 0, "bottom": 0},

--- a/docs/tutorials/airports/airports-size.vg.json
+++ b/docs/tutorials/airports/airports-size.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "width": 900,
   "height": 560,
   "padding": {"top": 25, "left": 0, "right": 0, "bottom": 0},

--- a/docs/tutorials/airports/airports-sized.vg.json
+++ b/docs/tutorials/airports/airports-sized.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "width": 900,
   "height": 560,
   "padding": {"top": 0, "left": 0, "right": 0, "bottom": 0},

--- a/docs/tutorials/airports/airports-sort.vg.json
+++ b/docs/tutorials/airports/airports-sort.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "width": 900,
   "height": 560,
   "padding": {"top": 25, "left": 0, "right": 0, "bottom": 0},

--- a/docs/tutorials/airports/airports-voronoi.vg.json
+++ b/docs/tutorials/airports/airports-voronoi.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "width": 900,
   "height": 560,
   "padding": {"top": 25, "left": 0, "right": 0, "bottom": 0},

--- a/docs/tutorials/airports/airports.vg.json
+++ b/docs/tutorials/airports/airports.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "width": 900,
   "height": 560,
   "padding": {"top": 25, "left": 0, "right": 0, "bottom": 0},

--- a/docs/tutorials/airports/index.md
+++ b/docs/tutorials/airports/index.md
@@ -69,7 +69,7 @@ Now let's get started building our visualization! We begin with a basic scaffold
 
 ```json
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "width": 900,
   "height": 560,
   "padding": {"top": 0, "left": 0, "right": 0, "bottom": 0},

--- a/docs/tutorials/bar-chart/bar-chart-axes.vg.json
+++ b/docs/tutorials/bar-chart/bar-chart-axes.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "width": 400,
   "height": 200,
   "padding": 5,

--- a/docs/tutorials/bar-chart/bar-chart.vg.json
+++ b/docs/tutorials/bar-chart/bar-chart.vg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
   "width": 400,
   "height": 200,
   "padding": 5,


### PR DESCRIPTION
v5 and v6 are compatible but just to be consistent, let's bump the version