### PR TITLE
fix: Typo in codegen expression

### DIFF
--- a/packages/vega-expression/src/codegen.js
+++ b/packages/vega-expression/src/codegen.js
@@ -109,7 +109,7 @@ export default function(opt) {
       for (const prop of n.properties) {
         const keyName = prop.key.name;
 
-        if (blockedPropertyNames.has(keyName)) {
+        if (forbiddenProperties.has(keyName)) {
           error('Illegal property: ' + keyName);
         }
       }


### PR DESCRIPTION
## Motivation

- `blockedPropertyNames` does not exist