### PR TITLE
fix: replace all problematic Unicode characters

### DIFF
--- a/packages/vega-util/src/stringValue.js
+++ b/packages/vega-util/src/stringValue.js
@@ -6,7 +6,7 @@ export default function $(x) {
   return isArray(x) ? `[${x.map(v => v === null ? 'null' : $(v))}]`
     : isObject(x) || isString(x) ?
       // Output valid JSON and JS source strings.
-      // See http://timelessrepo.com/json-isnt-a-javascript-subset
-      JSON.stringify(x).replace('\u2028','\\u2028').replace('\u2029', '\\u2029')
+      // See https://github.com/judofyr/timeless/blob/master/posts/json-isnt-a-javascript-subset.md
+      JSON.stringify(x).replaceAll('\u2028','\\u2028').replaceAll('\u2029', '\\u2029')
     : x;
 }

--- a/packages/vega-util/test/stringValue-test.js
+++ b/packages/vega-util/test/stringValue-test.js
@@ -28,7 +28,7 @@ tape('stringValue maps values', t => {
   t.equal(JSON.stringify(x), vega.stringValue(x));
 
   // should handle quotes in strings
-  let tests = ["'hello'", '"hello"'];
+  const tests = ["'hello'", '"hello"'];
   tests.forEach(s => {
     t.equal(s, eval(vega.stringValue(s)));
   });
@@ -37,15 +37,9 @@ tape('stringValue maps values', t => {
   const a = [123, 'hello', null];
   t.equal(JSON.stringify(a), vega.stringValue(a));
 
-  // should handle special characters in strings
-  tests = ['\ntest', // newline
-    '\u0000',
-    '\u2028', // line separator
-    '\u2029' // paragraph separator
-  ];
-  tests.forEach(s => {
-    t.equal(s, eval(vega.stringValue(s)));
-  });
+  // should replace all instances of problematic Unicode characters
+  // \n = newline, \u0000 = null char, \u2028 = line separator, \u2029 = paragraph separator
+  t.equal(vega.stringValue('\n \u0000 \u2028 \u2029 \u2029'), '"\\n \\u0000 \\u2028 \\u2029 \\u2029"');
 
   t.end();
 });


### PR DESCRIPTION
This PR makes sure all problematic Unicode character are escaped in the `stringValue` util, not just the first occurrence.

Tests are updated as well as the link in the comment.

See also this [vega-lite PR](https://github.com/vega/vega-lite/pull/9683).