### PR TITLE
fix(build): disable postinstall scripts when building branch previews

### DIFF
--- a/scripts/build-editor-preview.sh
+++ b/scripts/build-editor-preview.sh
@@ -21,7 +21,7 @@ echo "Installing vega editor"
 git clone https://github.com/vega/editor.git
 
 cd editor
-npm ci
+npm ci --ignore-scripts
 
 # HACK: Make sure we prefer the local version to the one from npm
 # Test if we can remove this after verifying that only 1 copy of every subpackage is used per repo


### PR DESCRIPTION
## Motivation

- Deploy previews stopped working after (X) for all builds
- Fixes #3925 

## Changes

- Add `--ignore-scripts` back to the build script

## Notes

- From the logs, found the build would break at the `postinstall` stage of the Vega editor
- Went back to the last known working config for build-editor-preview.sh, which was [here](https://github.com/vega/vega/blame/18a55af6207fb183510659bdec3922eddc9a6022/scripts/build-editor-preview.sh) , and found a flag was passed to yarn but dropped in the conversion to npm
- `NPM ci` is like npm install, except it goes straight to the lockfile, ignoring the contents of package.json for version resolution, making more more stable builds
- How the ignore-scripts flag works for `npm ci` ([doc](https://docs.npmjs.com/cli/v9/commands/npm-ci#ignore-scripts))