### PR TITLE
chore: bump vega-interpreter to 2.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19285,7 +19285,7 @@
       }
     },
     "packages/vega-interpreter": {
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "vega-util": "^2.1.0"

--- a/packages/vega-interpreter/package.json
+++ b/packages/vega-interpreter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vega-interpreter",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "CSP-compliant interpreter for Vega expressions.",
   "keywords": [
     "vega",


### PR DESCRIPTION
## Motivation

Followup to https://github.com/vega/vega/pull/4134 which includes the fix for https://github.com/vega/vega/commit/3d9691aa9ec597ee9a831e8294351f5a2dafa85e and https://github.com/vega/vega/pull/4138