### PR TITLE
fix: adjust order of ObjectExpression evaluation in `vega-interpreter`

### DIFF
--- a/packages/vega-interpreter/src/interpret.js
+++ b/packages/vega-interpreter/src/interpret.js
@@ -73,12 +73,12 @@ const Visitors = {
   ObjectExpression: ($, n) => n.properties.reduce((o, p) => {
     $.memberDepth += 1;
     const k = $(p.key);
-    const v = $(p.value);
     $.memberDepth -= 1;
+    const v = $(p.value);
     if (DisallowedObjectProperties.has(k)) {      // eslint-disable-next-line no-console
       console.error(`Prevented interpretation of property "${k}" which could lead to insecure code execution`);
     } else if (DisallowedMethods.has(v)) { // eslint-disable-next-line no-console
-      console.error(`Prevented interpretation of method "${v}" which could lead to insecure code execution`);
+      console.error(`Prevented interpretation of method "${k}" which could lead to insecure code execution`);
     } else {
       o[k] = v;
     }


### PR DESCRIPTION
## Motivation

- Fix regression in CI  in vega-interpreter https://github.com/vega/vega/pull/4137

## Testing

- CI passing the unit test job should be sufficient

## Notes

- This works because `memberDepth` needs to be decremented BEFORE we read the value of `$(p.value)`, as was the case before: https://github.com/vega/vega/blame/7971816ab479571c65981991e84480ae3b557660/packages/vega-interpreter/src/interpret.js