### PR TITLE
fix: preserve sign of frame bounds in Window transform

### DIFF
--- a/packages/vega-transforms/src/Window.js
+++ b/packages/vega-transforms/src/Window.js
@@ -118,13 +118,27 @@ function processPartition(list, state, cmp, _) {
   }
 }
 
+function clamp(x, lo, hi) {
+  return x < lo ? lo : x > hi ? hi : x;
+}
+
 function setWindow(w, f, i, n) {
   w.p0 = w.i0;
   w.p1 = w.i1;
-  w.i0 = f[0] == null ? 0 : Math.max(0, i - Math.abs(f[0]));
-  w.i1 = f[1] == null ? n : Math.min(n, i + Math.abs(f[1]) + 1);
+
+  // f[0]: start offset (inclusive). null => unbounded (0)
+  // Use the SIGNED offset relative to i.
+  const start = f[0] == null ? 0 : i + f[0];
+
+  // f[1]: end offset (inclusive in “row terms”), so we +1 for exclusive bound.
+  // null => unbounded (n)
+  const endExclusive = f[1] == null ? n : i + f[1] + 1;
+
+  w.i0 = clamp(start, 0, n);
+  w.i1 = clamp(endExclusive, 0, n);
   w.index = i;
 }
+
 
 // if frame type is 'range', adjust window for peer values
 function adjustRange(w, bisect) {


### PR DESCRIPTION
### Summary
This PR fixes incorrect handling of signed `frame` bounds in the `Window` transform. Previously, `Math.abs()` was applied to both elements of the `frame` array, causing negative offsets (e.g. `[null, -1]`) to be interpreted as positive. As a result, backward-looking windows incorrectly included the current and following rows instead of excluding the current row.


### Fix Details
- Updated `setWindow()` in `src/transforms/Window.js`:
  - Preserves the **sign** of `frame` offsets rather than taking the absolute value.
  - Maintains exclusive end semantics (`+1` for the upper bound).
  - Clamps computed window indices to the valid range `[0, n]`.
- Removed the use of `Math.abs()` that previously erased offset direction.
- Ensures `[null, -1]` now yields a window spanning from the start of the data up to (but not including) the current row.


### Testing
Updated `packages/vega-transforms/test/window-test.js` to include a new test block using **Tape** that verifies correct behavior for negative frame offsets:
- Added test: `tape('Window handles negative frame offsets correctly', ...)`
- This test confirms:
  - For `frame: [null, -1]`, each row’s sum is the cumulative total up to (but not including) the current row.
  - Expected results for input `[1, 2, 3, 4, 5]` → `[0, 1, 3, 6, 10]`.
  - The first row’s aggregate value is `undefined` internally (since the window is empty),
which is expected Vega behavior. The test normalizes this to `0` for easier numerical comparison.
- All existing tests remain unchanged and in-scope tests continue to pass.

Run all tests with:
```
npm test
```


### Motivation
This fix aligns Vega’s `Window` transform with standard SQL window semantics, where negative frame offsets represent preceding rows and positive offsets represent following rows. The corrected implementation ensures consistent, predictable cumulative and rolling window behavior and improves compatibility with Vega-Lite’s window frame specifications.


### Fixes
Fixes #3236


### ✅ Contributor Checklist
- ☑️Implemented code fix in `packages/vega-transforms/src/Window.js`
- ☑️Removed `Math.abs()` and preserved signed offsets
- ☑️Verified exclusive end semantics (`+1`) remain correct
- ☑️Added new test in `packages/vega-transforms/test/window-test.js` using Tape
- ☑️Verified `[null, -1]` frame correctly excludes the current row
- ☑️Confirmed all tests pass via `npm test`
- ☑️Commit message follows Conventional Commits (`fix:`)
- ☑️Linked issue **#3236** for traceability