### PR TITLE
build: bump lockfile for 5.33.1 release

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -8186,7 +8186,7 @@ stop-iteration-iterator@^1.0.0:
   dependencies:
     internal-slot "^1.0.4"
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -8203,15 +8203,6 @@ string-width@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -8295,7 +8286,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -8308,13 +8299,6 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   integrity sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==
   dependencies:
     ansi-regex "^2.0.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -9031,81 +9015,6 @@ vega-datasets@^2.8.1:
   resolved "https://registry.yarnpkg.com/vega-datasets/-/vega-datasets-2.8.1.tgz#a38202efff1bc763c3120954f55a7d1c9758af3f"
   integrity sha512-RxFyrlIH3xWzHtBDxp2vsFNCxuzNNfAtEvyufFX25UczIORyNi1T336NbM62g67k4KbDkeXzWEZHwr71qQKF8w==
 
-vega-functions@~5.17.0:
-  version "5.17.0"
-  resolved "https://registry.yarnpkg.com/vega-functions/-/vega-functions-5.17.0.tgz#6b1477c4f5e5a4a0c58ddf667d6952f8d61333a7"
-  integrity sha512-EoGvdCtv1Y4M/hLy83Kf0HTs4qInUfrBoanrnhbguzRl00rx7orjcv+bNZFHbCe4HkfVpbOnTrYmz3K2ivaOLw==
-  dependencies:
-    d3-array "^3.2.2"
-    d3-color "^3.1.0"
-    d3-geo "^3.1.0"
-    vega-dataflow "^5.7.7"
-    vega-expression "^5.2.0"
-    vega-scale "^7.4.2"
-    vega-scenegraph "^4.13.1"
-    vega-selections "^5.6.0"
-    vega-statistics "^1.9.0"
-    vega-time "^2.1.3"
-    vega-util "^1.17.3"
-
-vega-parser@~6.5.0:
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/vega-parser/-/vega-parser-6.5.0.tgz#d1427b1a921fbd25b0888659bbe9c099b317522b"
-  integrity sha512-dPxFKn6IlDyWi6CgHGGv8htSPBAyLHWlJNNGD17eMXh+Kjn4hupSNOIboRcYb8gL5HYt1tYwS6oYZXK84Bc4tg==
-  dependencies:
-    vega-dataflow "^5.7.7"
-    vega-event-selector "^3.0.1"
-    vega-functions "^5.17.0"
-    vega-scale "^7.4.2"
-    vega-util "^1.17.3"
-
-vega-view@~5.15.0:
-  version "5.15.0"
-  resolved "https://registry.yarnpkg.com/vega-view/-/vega-view-5.15.0.tgz#f21023438ffc4574a22e3a84f7e73f9a50ede531"
-  integrity sha512-bm8STHPsI8BjVu2gYlWU8KEVOA2JyTzdtb9cJj8NW6HpN72UxTYsg5y22u9vfcLYjzjmolrlr0756VXR0uI1Cg==
-  dependencies:
-    d3-array "^3.2.2"
-    d3-timer "^3.0.1"
-    vega-dataflow "^5.7.7"
-    vega-format "^1.1.3"
-    vega-functions "^5.17.0"
-    vega-runtime "^6.2.1"
-    vega-scenegraph "^4.13.1"
-    vega-util "^1.17.3"
-
-vega@5.32.0:
-  version "5.32.0"
-  resolved "https://registry.yarnpkg.com/vega/-/vega-5.32.0.tgz#a826eb0a8d429e5b715d3e69c565a73d747a02ed"
-  integrity sha512-jANt/5+SpV7b7owB5u8+M1TZ/TrF1fK6WlcvKDW38tH3Gb6hM1nzIhv10E41w3GBmwF29BU/qH2ruNkaYKjI5g==
-  dependencies:
-    vega-crossfilter "~4.1.3"
-    vega-dataflow "~5.7.7"
-    vega-encode "~4.10.2"
-    vega-event-selector "~3.0.1"
-    vega-expression "~5.2.0"
-    vega-force "~4.2.2"
-    vega-format "~1.1.3"
-    vega-functions "~5.17.0"
-    vega-geo "~4.4.3"
-    vega-hierarchy "~4.1.3"
-    vega-label "~1.3.1"
-    vega-loader "~4.5.3"
-    vega-parser "~6.5.0"
-    vega-projection "~1.6.2"
-    vega-regression "~1.3.1"
-    vega-runtime "~6.2.1"
-    vega-scale "~7.4.2"
-    vega-scenegraph "~4.13.1"
-    vega-statistics "~1.9.0"
-    vega-time "~2.1.3"
-    vega-transforms "~4.12.1"
-    vega-typings "~1.5.0"
-    vega-util "~1.17.2"
-    vega-view "~5.15.0"
-    vega-view-transforms "~4.6.1"
-    vega-voronoi "~4.2.4"
-    vega-wordcloud "~4.1.6"
-
 verror@1.10.0:
   version "1.10.0"
   resolved "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz"
@@ -9289,7 +9198,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -9302,15 +9211,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
## Motivation

- Prepare 5.33.1 release
- Followup on comment to update the lockfile: https://github.com/vega/vega/pull/4147#issuecomment-3366408303

## Changes

- Ran `yarn install` in the repository root using node `20.15.1` and yarn `1.22.19`