### PR TITLE
chore: bump vega-selections@6.1.1

### DIFF
--- a/packages/vega-selections/package.json
+++ b/packages/vega-selections/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vega-selections",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "Vega expression functions for Vega-Lite selections.",
   "keywords": [
     "vega",

--- a/packages/vega-selections/src/selectionTuples.js
+++ b/packages/vega-selections/src/selectionTuples.js
@@ -1,6 +1,6 @@
 import {extend} from 'vega-util';
 import {$selectionId, SelectionId, getter} from './util.js';
-import { error, isString, isArray } from 'vega-util';
+import { error, isArray, isString } from 'vega-util';
 
 /**
  * Maps an array of scene graph items to an array of selection tuples.


### PR DESCRIPTION
## Motivation

- Release new version of vega-selections
- Fix import order (currently breaking linting)

## Testing

- CI passing should be enough

## Notes

- I didn't bump all the (grand)dependencies of vega-selections, since Vega's immediate deps for this package show allow patch updates to be installed without extra action on our part.