### PR TITLE
fix(vega-selections): fix docstring / function argument validation

### DIFF
--- a/packages/vega-selections/src/selectionTuples.js
+++ b/packages/vega-selections/src/selectionTuples.js
@@ -1,11 +1,11 @@
 import {extend} from 'vega-util';
 import {$selectionId, SelectionId, getter} from './util.js';
-import { error, isArray, isString } from 'vega-util';
+import { error, isArray, isObject } from 'vega-util';
 
 /**
  * Maps an array of scene graph items to an array of selection tuples.
- * @param {string} name  - The name of the dataset representing the selection.
- * @param {string} base  - The base object that generated tuples extend.
+ * @param {array} array - Input scene graph items
+ * @param {object} base - The base object that generated tuples extend.
  *
  * @returns {array} An array of selection entries for the given unit.
  */
@@ -14,8 +14,8 @@ export function selectionTuples(array, base) {
   if (!isArray(array)) {
     error('First argument to selectionTuples must be an array.');
   }
-  if (!isString(base)) {
-    error('Second argument to selectionTuples must be a string.');
+  if (!isObject(base)) {
+    error('Second argument to selectionTuples must be an object.');
   }
 
   return array.map(x => extend(


### PR DESCRIPTION
## Motivation

- Noticed while fixing lasso that these depend on vlSelectionTuples accepting a non-string second arg

## Changes

- Updated stale docstring
- Change argument validation to represent the actual types consumed by this function

## Testing

- https://vega.github.io/editor/#/examples/vega-lite/interactive_1d_geo_brush is currently broken (check the logs tab)
- The branch preview isn't loading the local version of vega-selections for some reason, that may have to be sorted in a separate PR


```
{
  "$schema": "https://vega.github.io/schema/vega-lite/v6.json",
  "width": 500,
  "height": 300,
  "projection": {"type": "albersUsa"},
  "layer": [
    {
      "data": {
        "url": "https://vega.github.io/editor/data/us-10m.json",
        "format": {"type": "topojson", "feature": "states"}
      },
      "mark": {"type": "geoshape", "fill": "lightgray", "stroke": "white"}
    },
    {
      "data": {"url": "https://vega.github.io/editor/data/airports.csv"},
      "transform": [
        {"filter": "datum.state !== 'PR' && datum.state !== 'VI'"}
      ],
      "params": [
        {
          "name": "brush",
          "select": {"type": "interval", "encodings": ["latitude"]},
          "value": {"latitude": [45, 51.5]}
        }
      ],
      "mark": "circle",
      "encoding": {
        "longitude": {"field": "longitude", "type": "quantitative"},
        "latitude": {"field": "latitude", "type": "quantitative"},
        "color": {
          "condition": {"param": "brush", "empty": false, "value": "goldenrod"},
          "value": "steelblue"
        },
        "size": {"value": 10}
      }
    }
  ]
}

```
