### PR TITLE
chore: bump vega-selections to 6.1.2

### DIFF
--- a/packages/vega-selections/package.json
+++ b/packages/vega-selections/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vega-selections",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "description": "Vega expression functions for Vega-Lite selections.",
   "keywords": [
     "vega",


### PR DESCRIPTION
## Motivation

- Release vega-selections fix to NPM to repair the editor

## Next steps

- [x] Publish fix of vega-selections to NPM: https://www.npmjs.com/package/vega-selections/v/6.1.2
- [x]  Backport fix to v5 #4183 
- [ ] Update vega editor : https://github.com/vega/editor/pull/1545