### PR TITLE
chore(vega-util): type all type checking functions

### DIFF
--- a/packages/vega-util/index.d.ts
+++ b/packages/vega-util/index.d.ts
@@ -31,16 +31,15 @@ export function falsy(): false;
 
 // Type Checkers
 
-export function isArray<T>(a: any | T[]): a is T[];
-export function isArray<T>(a: any | readonly T[]): a is readonly T[];
-export function isBoolean(a: any): a is boolean;
-export function isDate(a: any): a is Date;
-export function isFunction(a: any): a is Function;
-export function isIterable(a: any): boolean;
-export function isNumber(a: any): a is number;
-export function isObject(a: any): a is object;
-export function isRegExp(a: any): a is RegExp;
-export function isString(a: any): a is string;
+export { default as isArray } from './build/types/isArray.js';
+export { default as isBoolean } from './build/types/isBoolean.js';
+export { default as isDate } from './build/types/isDate.js';
+export { default as isFunction } from './build/types/isFunction.js';
+export { default as isIterable } from './build/types/isIterable.js';
+export { default as isNumber } from './build/types/isNumber.js';
+export { default as isObject } from './build/types/isObject.js';
+export { default as isRegExp } from './build/types/isRegExp.js';
+export { default as isString } from './build/types/isString.js';
 
 // Type Coercion
 

--- a/packages/vega-util/src/isArray.js
+++ b/packages/vega-util/src/isArray.js
@@ -1,1 +1,9 @@
-export default Array.isArray;
+/**
+ * Return whether the provided value is an array.
+ * @template T
+ * @param {unknown} value
+ * @returns {value is readonly T[]}
+ */
+const isArray = Array.isArray;
+
+export default isArray;

--- a/packages/vega-util/src/isBoolean.js
+++ b/packages/vega-util/src/isBoolean.js
@@ -1,3 +1,8 @@
-export default function(_) {
-  return typeof _ === 'boolean';
+/**
+ * Determine if the value is a boolean primitive.
+ * @param {unknown} value
+ * @returns {value is boolean}
+ */
+export default function isBoolean(value) {
+  return typeof value === 'boolean';
 }

--- a/packages/vega-util/src/isDate.js
+++ b/packages/vega-util/src/isDate.js
@@ -1,3 +1,8 @@
-export default function(_) {
-  return Object.prototype.toString.call(_) === '[object Date]';
+/**
+ * Check if the value is an actual Date object.
+ * @param {unknown} value
+ * @returns {value is Date}
+ */
+export default function isDate(value) {
+  return Object.prototype.toString.call(value) === '[object Date]';
 }

--- a/packages/vega-util/src/isFunction.js
+++ b/packages/vega-util/src/isFunction.js
@@ -1,3 +1,8 @@
-export default function(_) {
-  return typeof _ === 'function';
+/**
+ * Verify that the value is a function-like object.
+ * @param {unknown} value
+ * @returns {value is Function}
+ */
+export default function isFunction(value) {
+  return typeof value === 'function';
 }

--- a/packages/vega-util/src/isIterable.js
+++ b/packages/vega-util/src/isIterable.js
@@ -1,5 +1,10 @@
 import isFunction from './isFunction.js';
 
-export default function(_) {
-  return _ && isFunction(_[Symbol.iterator]);
+/**
+ * Test if the value exposes the iterator protocol via `Symbol.iterator`.
+ * @param {{ [Symbol.iterator]?: unknown } | null | undefined} value
+ * @returns {boolean}
+ */
+export default function isIterable(value) {
+  return value != null && isFunction(value[Symbol.iterator]);
 }

--- a/packages/vega-util/src/isNumber.js
+++ b/packages/vega-util/src/isNumber.js
@@ -1,3 +1,8 @@
-export default function(_) {
-  return typeof _ === 'number';
+/**
+ * Identify if the value is a number primitive.
+ * @param {unknown} value
+ * @returns {value is number}
+ */
+export default function isNumber(value) {
+  return typeof value === 'number';
 }

--- a/packages/vega-util/src/isRegExp.js
+++ b/packages/vega-util/src/isRegExp.js
@@ -1,3 +1,8 @@
-export default function(_) {
-  return Object.prototype.toString.call(_) === '[object RegExp]';
+/**
+ * Confirm whether the value is a `RegExp` object.
+ * @param {unknown} value
+ * @returns {value is RegExp}
+ */
+export default function isRegExp(value) {
+  return Object.prototype.toString.call(value) === '[object RegExp]';
 }

--- a/packages/vega-util/tsconfig.json
+++ b/packages/vega-util/tsconfig.json
@@ -9,10 +9,11 @@
     "outDir": "build/types"
   },
   "include": [
-      "src/truncate.js",
-      "src/pad.js",
-      "src/repeat.js",
-      "src/splitAccessPath.js",
-      "src/stringValue.js"
-    ]
+    "src/is*.js",
+    "src/truncate.js",
+    "src/pad.js",
+    "src/repeat.js",
+    "src/splitAccessPath.js",
+    "src/stringValue.js"
+  ]
 }


### PR DESCRIPTION
## Motivation

- Increase guardrails of codebase to make it possible to add new contributors / propose more ambitious features 
- Check the cost of adding types to vega without migrating the whole codebase at once
- Adding JSDoc param types allows us to ge type safety without having to switch to the typescript compiler (.ts files) yet
- Builds on https://github.com/vega/vega/pull/4185 / https://github.com/vega/vega/issues/3971

## Changes

- Documented every `is*` helper in `packages/vega-util/src` with JSDoc guards and kept the `Array.isArray` wrapper for the templated signature.
- Extended `packages/vega-util/tsconfig.json` to include `src/is*.js`, regenerated `build/types`, and rewired `packages/vega-util/index.d.ts` to export all generated declarations.

## Testing


- Verified `npm run generate-types` and `npm run typecheck`; the rewritten helpers now use the same pipeline as the string utilities.
