### PR TITLE
feat(vega-util): add signatures for all remaining type coercion to* utils

### DIFF
--- a/packages/vega-util/index.d.ts
+++ b/packages/vega-util/index.d.ts
@@ -43,10 +43,10 @@ export { default as isString } from './build/types/isString.js';
 
 // Type Coercion
 
-export function toBoolean(a: any): boolean;
-export function toDate(a: any, parser?: (_: any) => number): number;
-export function toNumber(a: any): number;
-export function toString(a: any): string;
+export { default as toBoolean } from './build/types/toBoolean.js';
+export { default as toDate } from './build/types/toDate.js';
+export { default as toNumber } from './build/types/toNumber.js';
+export { default as toString } from './build/types/toString.js';
 
 // Objects
 
@@ -103,7 +103,7 @@ export function peek(array: readonly any[]): any;
 
 export function span(array: readonly number[]): number;
 
-export function toSet<T>(array: readonly T[]): { [T: string]: true }
+export { default as toSet } from './build/types/toSet.js';
 
 export function visitArray(array: readonly any[] | undefined,
   filter: (any: any) => boolean | undefined,
@@ -155,4 +155,4 @@ export const Debug: number;
 
 export function logger(_?: number, method?: string, handler?: typeof log): LoggerInterface;
 export function log(method: 'error' | 'warn' | 'log', level: 'ERROR' | 'WARN'| 'INFO' | 'DEBUG', input: readonly any[]): void;
-export function error(msg: string): Error;
+export function error(msg: string): never;

--- a/packages/vega-util/src/toBoolean.js
+++ b/packages/vega-util/src/toBoolean.js
@@ -1,3 +1,8 @@
+/** Coerces a value to a boolean, matching Vega signal semantics.
+ * Strings like `'false'` or `'0'` map to `false`; `null` and empty strings map to `null`.
+ * @param {unknown} _ - Input value to coerce.
+ * @returns {boolean | null}
+ */
 export default function(_) {
   return _ == null || _ === '' ? null : !_ || _ === 'false' || _ === '0' ? false : !!_;
 }

--- a/packages/vega-util/src/toDate.js
+++ b/packages/vega-util/src/toDate.js
@@ -1,9 +1,15 @@
 import isDate from './isDate.js';
 import isNumber from './isNumber.js';
 
+/** @param {unknown} _ @returns {Date | number} */
 const defaultParser = _ =>
-  isNumber(_) ? _ : isDate(_) ? _ : Date.parse(_);
+  isNumber(_) ? _ : isDate(_) ? _ : Date.parse(/** @type {string} */(_));
 
+/** Coerces a value to a Date-like value using an optional parser.
+ * @param {unknown} _ - Input value to coerce.
+ * @param {(value: unknown) => Date | number} [parser] - Optional parser that receives the raw input.
+ * @returns {Date | number | null}
+ */
 export default function(_, parser) {
   parser = parser || defaultParser;
   return _ == null || _ === '' ? null : parser(_);

--- a/packages/vega-util/src/toNumber.js
+++ b/packages/vega-util/src/toNumber.js
@@ -1,3 +1,7 @@
+/** Coerces a value to a number, returning `null` for empty inputs.
+ * @param {unknown} _ - Input value to coerce.
+ * @returns {number | null}
+ */
 export default function(_) {
   return _ == null || _ === '' ? null : +_;
 }

--- a/packages/vega-util/src/toSet.js
+++ b/packages/vega-util/src/toSet.js
@@ -1,6 +1,11 @@
+/** @template T
+ * @param {readonly T[] | ArrayLike<T>} _ - Collection to convert.
+ * @returns {Record<string, true>}
+ */
 export default function(_) {
+  /** @type {Record<string, true>} */
   const s = {},
         n = _.length;
-  for (let i=0; i<n; ++i) s[_[i]] = true;
+  for (let i=0; i<n; ++i) s[_[i] + ''] = true;
   return s;
 }

--- a/packages/vega-util/src/toString.js
+++ b/packages/vega-util/src/toString.js
@@ -1,3 +1,7 @@
+/** Coerces a value to a string, returning `null` for empty inputs.
+ * @param {unknown} _ - Input value to coerce.
+ * @returns {string | null}
+ */
 export default function(_) {
   return _ == null || _ === '' ? null : _ + '';
 }

--- a/packages/vega-util/tsconfig.json
+++ b/packages/vega-util/tsconfig.json
@@ -10,6 +10,11 @@
   },
   "include": [
     "src/is*.js",
+    "src/toBoolean.js",
+    "src/toNumber.js",
+    "src/toString.js",
+    "src/toDate.js",
+    "src/toSet.js",
     "src/truncate.js",
     "src/pad.js",
     "src/repeat.js",


### PR DESCRIPTION
## Motivation

- Increase guardrails of codebase to make it possible to add new contributors / propose more ambitious features 
- Check the cost of adding types to vega without migrating the whole codebase at once
- Adding JSDoc param types allows us to ge type safety without having to switch to the typescript compiler (.ts files) yet
- Builds on https://github.com/vega/vega/pull/4185 / https://github.com/vega/vega/pull/4187  / https://github.com/vega/vega/issues/3971

## Changes

- Types/documents every `to*` helper in `packages/vega-util/src`
- Changes _some_ runtime behaviors + documents some surprises (i.e. toBoolean does not always return a Boolean)

## Testing

- Verified `npm run generate-types` and `npm run typecheck`; the rewritten helpers now use the same pipeline as the string utilities.
