### PR TITLE
feat: Add encodeURIComponent to vega-interpreter

### DIFF
--- a/docs/docs/expressions.md
+++ b/docs/docs/expressions.md
@@ -601,8 +601,8 @@ Creates a [Base64](https://developer.mozilla.org/en-US/docs/Glossary/Base64)-enc
 <b>atob</b>(<i>string</i>) {% include tag ver="5.32.0" %}<br/>
 Decodes an [ASCII](https://developer.mozilla.org/en-US/docs/Glossary/ASCII) string that was encoded with [Base64](https://developer.mozilla.org/en-US/docs/Glossary/Base64). Same as JavaScript's [Window.atob()](https://developer.mozilla.org/en-US/docs/Web/API/Window/atob).
 
-<a name="encodeUriComponent" href="#encodeUriComponent">#</a>
-<b>encodeUriComponent</b>(<i>string</i>)<br/>
+<a name="encodeURIComponent" href="#encodeURIComponent">#</a>
+<b>encodeURIComponent</b>(<i>string</i>)<br/>
 Encodes a URI component by replacing each instance of certain characters with UTF-8 encoding. Same as JavaScript's [encodeURIComponent()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent).
 
 

--- a/packages/vega-expression/README.md
+++ b/packages/vega-expression/README.md
@@ -142,6 +142,7 @@ This package provides the following constants and functions:
 - [`trim`](https://vega.github.io/vega/docs/expressions/#trim)
 - [`atob`](https://vega.github.io/vega/docs/expressions/#atob)
 - [`btoa`](https://vega.github.io/vega/docs/expressions/#btoa)
+- [`encodeURIComponent`](https://vega.github.io/vega/docs/expressions/#encodeURIComponent)
 
 
 **RegExp Functions**

--- a/packages/vega-expression/src/functions.js
+++ b/packages/vega-expression/src/functions.js
@@ -90,7 +90,7 @@ export default function(codegen) {
     btoa:        'btoa',
     atob:        'atob',
     // URI encoding
-    encodeUriComponent: 'encodeURIComponent',
+    encodeURIComponent: 'encodeURIComponent',
 
     // REGEXP functions
     regexp:  REGEXP,

--- a/packages/vega-expression/test/codegen-test.js
+++ b/packages/vega-expression/test/codegen-test.js
@@ -214,8 +214,8 @@ tape('Evaluate expressions with white list', t => {
   t.equal(evaluate('parseInt("42")'),parseInt('42'));
   t.equal(evaluate('btoa("a")'),  btoa('a'));
   t.equal(evaluate('atob("YQ==")'), atob('YQ=='));
-  t.equal(evaluate('encodeUriComponent("hello world")'), encodeURIComponent('hello world'));
-  t.equal(evaluate('encodeUriComponent("a=b&c=d")'), encodeURIComponent('a=b&c=d'));
+  t.equal(evaluate('encodeURIComponent("hello world")'), encodeURIComponent('hello world'));
+  t.equal(evaluate('encodeURIComponent("a=b&c=d")'), encodeURIComponent('a=b&c=d'));
 
   // should eval regular expression functions
   t.equal(evaluate('test(/ain/, "spain")'), /ain/.test('spain'));

--- a/packages/vega-interpreter/src/functions.js
+++ b/packages/vega-interpreter/src/functions.js
@@ -82,6 +82,8 @@ export default {
   btoa:         x => btoa(x),
   // Convert base64-encoded ascii to binary string
   atob:         x => atob(x),
+  // URI encoding
+  encodeURIComponent: x => encodeURIComponent(x),
 
   // regexp functions
   regexp:       RegExp,

--- a/packages/vega/test/scenegraphs/encode-uri-component-test.json
+++ b/packages/vega/test/scenegraphs/encode-uri-component-test.json
@@ -1,0 +1,329 @@
+{
+  "marktype": "group",
+  "name": "root",
+  "role": "frame",
+  "interactive": true,
+  "clip": false,
+  "items": [
+    {
+      "items": [
+        {
+          "marktype": "group",
+          "role": "axis",
+          "interactive": false,
+          "clip": false,
+          "items": [
+            {
+              "items": [
+                {
+                  "marktype": "rule",
+                  "role": "axis-tick",
+                  "interactive": false,
+                  "clip": false,
+                  "items": [
+                    {
+                      "x": 10,
+                      "y": 0,
+                      "opacity": 1,
+                      "stroke": "#888",
+                      "strokeWidth": 1,
+                      "y2": 5
+                    },
+                    {
+                      "x": 30,
+                      "y": 0,
+                      "opacity": 1,
+                      "stroke": "#888",
+                      "strokeWidth": 1,
+                      "y2": 5
+                    },
+                    {
+                      "x": 50,
+                      "y": 0,
+                      "opacity": 1,
+                      "stroke": "#888",
+                      "strokeWidth": 1,
+                      "y2": 5
+                    }
+                  ],
+                  "zindex": 0
+                },
+                {
+                  "marktype": "text",
+                  "role": "axis-label",
+                  "interactive": false,
+                  "clip": false,
+                  "items": [
+                    {
+                      "x": 9.5,
+                      "y": 7,
+                      "align": "right",
+                      "baseline": "middle",
+                      "fill": "#000",
+                      "opacity": 1,
+                      "text": "a=b&c=d",
+                      "angle": 270,
+                      "limit": 180,
+                      "font": "sans-serif",
+                      "fontSize": 10
+                    },
+                    {
+                      "x": 29.5,
+                      "y": 7,
+                      "align": "right",
+                      "baseline": "middle",
+                      "fill": "#000",
+                      "opacity": 1,
+                      "text": "foo?bar",
+                      "angle": 270,
+                      "limit": 180,
+                      "font": "sans-serif",
+                      "fontSize": 10
+                    },
+                    {
+                      "x": 49.5,
+                      "y": 7,
+                      "align": "right",
+                      "baseline": "middle",
+                      "fill": "#000",
+                      "opacity": 1,
+                      "text": "hello world",
+                      "angle": 270,
+                      "limit": 180,
+                      "font": "sans-serif",
+                      "fontSize": 10
+                    }
+                  ],
+                  "zindex": 0
+                },
+                {
+                  "marktype": "rule",
+                  "role": "axis-domain",
+                  "interactive": false,
+                  "clip": false,
+                  "items": [
+                    {
+                      "x": 0,
+                      "y": 0,
+                      "opacity": 1,
+                      "stroke": "#888",
+                      "strokeWidth": 1,
+                      "x2": 60
+                    }
+                  ],
+                  "zindex": 0
+                },
+                {
+                  "marktype": "text",
+                  "role": "axis-title",
+                  "interactive": false,
+                  "clip": false,
+                  "items": [
+                    {
+                      "x": 30,
+                      "y": 99,
+                      "align": "center",
+                      "baseline": "top",
+                      "fill": "#000",
+                      "opacity": 1,
+                      "text": "original",
+                      "angle": 0,
+                      "font": "sans-serif",
+                      "fontSize": 11,
+                      "fontWeight": "bold"
+                    }
+                  ],
+                  "zindex": 0
+                }
+              ],
+              "x": 0.5,
+              "y": 60.5,
+              "orient": "bottom"
+            }
+          ],
+          "zindex": 0
+        },
+        {
+          "marktype": "group",
+          "role": "axis",
+          "interactive": false,
+          "clip": false,
+          "items": [
+            {
+              "items": [
+                {
+                  "marktype": "rule",
+                  "role": "axis-tick",
+                  "interactive": false,
+                  "clip": false,
+                  "items": [
+                    {
+                      "x": 0,
+                      "y": 10,
+                      "opacity": 1,
+                      "stroke": "#888",
+                      "strokeWidth": 1,
+                      "x2": -5
+                    },
+                    {
+                      "x": 0,
+                      "y": 30,
+                      "opacity": 1,
+                      "stroke": "#888",
+                      "strokeWidth": 1,
+                      "x2": -5
+                    },
+                    {
+                      "x": 0,
+                      "y": 50,
+                      "opacity": 1,
+                      "stroke": "#888",
+                      "strokeWidth": 1,
+                      "x2": -5
+                    }
+                  ],
+                  "zindex": 0
+                },
+                {
+                  "marktype": "text",
+                  "role": "axis-label",
+                  "interactive": false,
+                  "clip": false,
+                  "items": [
+                    {
+                      "x": -7,
+                      "y": 9.5,
+                      "align": "right",
+                      "baseline": "middle",
+                      "fill": "#000",
+                      "opacity": 1,
+                      "text": "a%3Db%26c%3Dd",
+                      "angle": 0,
+                      "limit": 180,
+                      "font": "sans-serif",
+                      "fontSize": 10
+                    },
+                    {
+                      "x": -7,
+                      "y": 29.5,
+                      "align": "right",
+                      "baseline": "middle",
+                      "fill": "#000",
+                      "opacity": 1,
+                      "text": "foo%3Fbar",
+                      "angle": 0,
+                      "limit": 180,
+                      "font": "sans-serif",
+                      "fontSize": 10
+                    },
+                    {
+                      "x": -7,
+                      "y": 49.5,
+                      "align": "right",
+                      "baseline": "middle",
+                      "fill": "#000",
+                      "opacity": 1,
+                      "text": "hello%20world",
+                      "angle": 0,
+                      "limit": 180,
+                      "font": "sans-serif",
+                      "fontSize": 10
+                    }
+                  ],
+                  "zindex": 0
+                },
+                {
+                  "marktype": "rule",
+                  "role": "axis-domain",
+                  "interactive": false,
+                  "clip": false,
+                  "items": [
+                    {
+                      "x": 0,
+                      "y": 0,
+                      "opacity": 1,
+                      "stroke": "#888",
+                      "strokeWidth": 1,
+                      "y2": 60
+                    }
+                  ],
+                  "zindex": 0
+                },
+                {
+                  "marktype": "text",
+                  "role": "axis-title",
+                  "interactive": false,
+                  "clip": false,
+                  "items": [
+                    {
+                      "x": -115,
+                      "y": 30,
+                      "align": "center",
+                      "baseline": "bottom",
+                      "fill": "#000",
+                      "opacity": 1,
+                      "text": "encoded",
+                      "angle": -90,
+                      "font": "sans-serif",
+                      "fontSize": 11,
+                      "fontWeight": "bold"
+                    }
+                  ],
+                  "zindex": 0
+                }
+              ],
+              "x": 0.5,
+              "y": 0.5,
+              "orient": "left"
+            }
+          ],
+          "zindex": 0
+        },
+        {
+          "marktype": "rect",
+          "name": "marks",
+          "role": "mark",
+          "interactive": true,
+          "clip": false,
+          "items": [
+            {
+              "x": 41,
+              "y": 41,
+              "width": 18,
+              "height": 18,
+              "fill": "#e45756",
+              "description": "original: hello world; encoded: hello%20world",
+              "ariaRoleDescription": "bar"
+            },
+            {
+              "x": 1,
+              "y": 1,
+              "width": 18,
+              "height": 18,
+              "fill": "#4c78a8",
+              "description": "original: a=b&c=d; encoded: a%3Db%26c%3Dd",
+              "ariaRoleDescription": "bar"
+            },
+            {
+              "x": 21,
+              "y": 21,
+              "width": 18,
+              "height": 18,
+              "fill": "#f58518",
+              "description": "original: foo?bar; encoded: foo%3Fbar",
+              "ariaRoleDescription": "bar"
+            }
+          ],
+          "zindex": 0
+        }
+      ],
+      "x": 0,
+      "y": 0,
+      "width": 60,
+      "height": 60,
+      "fill": "transparent",
+      "stroke": "#ddd"
+    }
+  ],
+  "zindex": 0
+}

--- a/packages/vega/test/specs-valid.json
+++ b/packages/vega/test/specs-valid.json
@@ -30,6 +30,7 @@
   "driving",
   "dynamic-format",
   "dynamic-url",
+  "encode-uri-component-test",
   "error",
   "falkensee",
   "flush-axis-labels",

--- a/packages/vega/test/specs-valid/encode-uri-component-test.vg.json
+++ b/packages/vega/test/specs-valid/encode-uri-component-test.vg.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://vega.github.io/schema/vega/v6.json",
+  "background": "white",
+  "padding": 5,
+  "style": "cell",
+  "data": [
+    {
+      "name": "source_0",
+      "values": [{"a": "hello world", "b": 28}, {"a": "a=b&c=d", "b": 55}, {"a": "foo?bar", "b": 43}]
+    },
+    {
+      "name": "data_0",
+      "source": "source_0",
+      "transform": [
+        {"type": "formula", "expr": "encodeURIComponent(datum.a)", "as": "encoded"}
+      ]
+    }
+  ],
+  "signals": [
+    {"name": "x_step", "value": 20},
+    {
+      "name": "width",
+      "update": "bandspace(domain('x').length, 0.1, 0.05) * x_step"
+    },
+    {"name": "y_step", "value": 20},
+    {
+      "name": "height",
+      "update": "bandspace(domain('y').length, 0.1, 0.05) * y_step"
+    }
+  ],
+  "marks": [
+    {
+      "name": "marks",
+      "type": "rect",
+      "style": ["bar"],
+      "from": {"data": "data_0"},
+      "encode": {
+        "update": {
+          "fill": {"scale": "color", "field": "a"},
+          "ariaRoleDescription": {"value": "bar"},
+          "description": {
+            "signal": "\"original: \" + (isValid(datum[\"a\"]) ? datum[\"a\"] : \"\"+datum[\"a\"]) + \"; encoded: \" + (isValid(datum[\"encoded\"]) ? datum[\"encoded\"] : \"\"+datum[\"encoded\"])"
+          },
+          "x": {"scale": "x", "field": "a"},
+          "width": {"signal": "max(0.25, bandwidth('x'))"},
+          "y": {"scale": "y", "field": "encoded"},
+          "height": {"signal": "max(0.25, bandwidth('y'))"}
+        }
+      }
+    }
+  ],
+  "scales": [
+    {
+      "name": "x",
+      "type": "band",
+      "domain": {"data": "data_0", "field": "a", "sort": true},
+      "range": {"step": {"signal": "x_step"}},
+      "paddingInner": 0.1,
+      "paddingOuter": 0.05
+    },
+    {
+      "name": "y",
+      "type": "band",
+      "domain": {"data": "data_0", "field": "encoded", "sort": true},
+      "range": {"step": {"signal": "y_step"}},
+      "paddingInner": 0.1,
+      "paddingOuter": 0.05
+    },
+    {
+      "name": "color",
+      "type": "ordinal",
+      "domain": {"data": "data_0", "field": "a", "sort": true},
+      "range": "category"
+    }
+  ],
+  "axes": [
+    {
+      "scale": "x",
+      "orient": "bottom",
+      "grid": false,
+      "title": "original",
+      "labelAlign": "right",
+      "labelAngle": 270,
+      "labelBaseline": "middle",
+      "zindex": 0
+    },
+    {
+      "scale": "y",
+      "orient": "left",
+      "grid": false,
+      "title": "encoded",
+      "zindex": 0
+    }
+  ]
+}


### PR DESCRIPTION
Addressing comments from https://github.com/vega/vega/pull/4148#issuecomment-359450507
Thanks @hydrosquall for pointing this out.

This also adds the function to vega-interpreter.

Fixes #4103 (again)

Also note: I changed the case to exactly match the native `encodeURIComponent`.