### PR TITLE
chore: patch bump vega-functions 6.1.1

### DIFF
--- a/packages/vega-functions/package.json
+++ b/packages/vega-functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vega-functions",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "Custom functions for the Vega expression language.",
   "keywords": [
     "vega",


### PR DESCRIPTION
## Motivation

- Release stricter argument validation for `vega-functions` without installing from Github

## Changes

- Stricter modify function validation: https://github.com/vega/vega/commit/47afa04fbf9bce7410460393f9bbcb0fffe21a90

## Testing

- CI passing should be enough, no visual change

## Notes

- I'll use the npm package update [runbook](https://github.com/vega/vega/discussions/4171) after this merges