### PR TITLE
fix(update security deps) - https://github.com/vega/vega/issues/4211

### DIFF
--- a/packages/vega-parser/package.json
+++ b/packages/vega-parser/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "vega-dataflow": "^5.7.8",
     "vega-event-selector": "^3.0.1",
-    "vega-functions": "^5.18.1",
+    "vega-functions": "^6.1.1",
     "vega-scale": "^7.4.3",
     "vega-util": "^1.17.4"
   }

--- a/packages/vega-view/package.json
+++ b/packages/vega-view/package.json
@@ -25,7 +25,7 @@
     "d3-timer": "^3.0.1",
     "vega-dataflow": "^5.7.8",
     "vega-format": "^1.1.4",
-    "vega-functions": "^5.18.1",
+    "vega-functions": "^6.1.1",
     "vega-runtime": "^6.2.2",
     "vega-scenegraph": "^4.13.2",
     "vega-util": "^1.17.4"

--- a/packages/vega/package.json
+++ b/packages/vega/package.json
@@ -36,7 +36,7 @@
     "vega-expression": "~5.2.1",
     "vega-force": "~4.2.3",
     "vega-format": "~1.1.4",
-    "vega-functions": "~5.18.1",
+    "vega-functions": "~6.1.1",
     "vega-geo": "~4.4.4",
     "vega-hierarchy": "~4.1.4",
     "vega-label": "~1.3.2",


### PR DESCRIPTION
Backward support for vega v5.
https://github.com/advisories/GHSA-m9rg-mr6g-75gm

Related: https://github.com/vega/vega/issues/4211