### PR TITLE
docs: remove update of dist1 signal that was based on dist2 signal in Zoomable Scatter Plot Example

### DIFF
--- a/docs/examples/zoomable-scatter-plot.vg.json
+++ b/docs/examples/zoomable-scatter-plot.vg.json
@@ -123,10 +123,6 @@
         {
           "events": {"type": "touchstart", "filter": "event.touches.length===2"},
           "update": "pinchDistance(event)"
-        },
-        {
-          "events": {"signal": "dist2"},
-          "update": "dist2"
         }
       ]
     },


### PR DESCRIPTION
Based on unsatisfactory zoom-pinch interaction for the [Zoomable Scatter Plot Example](https://vega.github.io/vega/examples/zoomable-scatter-plot/) I've tried removing, what seems to me to be, an erroneous update of dist1 that was based on dist2.
This seems to have solved the problem, for me at least, on Android and Linux with various touch capable screens.
Mouse button and wheel, and single touch pan interactions continue to work as expected.

I could open a bug report and then make this Pull Request to fix it, but I'll combine the two steps by reporting the bug here:

- [x] Check for duplicate issues. Please file separate requests as separate issues on GitHub.

No applicable search results for "touch".

- [x] Describe how to reproduce the bug.

**Steps to Reproduce**
- Point a mobile browser, e.g. Firefox on Android, at [Zoomable Scatter Plot Example](https://vega.github.io/vega/examples/zoomable-scatter-plot/)
- Use a two finger pinch zoom on the live chart.

**Result**
The chart may or may not zoom a tiny fraction.

**Expected Result**
The chart should zoom quite smoothly based on the spread of the two fingers.

- [x] Use the latest Vega version, if possible. Always indicate which version you are using.

I assume the live [vega.github.io](https://vega.github.io) site is using the latest (stable?) Vega version,
but the page source just says \<script src="[/vega/vega.min.js](https://vega.github.io/vega/vega.min.js)"\>\</script\>

- [x] Include error messages or gifs/screenshots of problematic behavior, if applicable.

No error messages.
Capturing a gif with touchpoints is beyond my pay grade. Sorry.

- [x] Provide an example specification and accessible data. Try to provide the simplest specification that reproduces the problem. 

- Go to the Vega Editor for the [Zoomable Scatter Plot Example](https://vega.github.io/editor/#/examples/vega/zoomable-scatter-plot).
- Do a two-finger Pinch-Zoom on the chart with the current code to see the behavior.
- Then paste the following corrected Vega JSON specification into the left panel of the Vega editor, and try the Pinch-Zoom again.

```json
{
  "$schema": "https://vega.github.io/schema/vega/v6.json",
  "description": "An interactive scatter plot example supporting pan and zoom.",
  "width": 500,
  "height": 300,
  "padding": {
    "top":    10,
    "left":   40,
    "bottom": 20,
    "right":  10
  },
  "autosize": "none",

  "config": {
    "axis": {
      "domain": false,
      "tickSize": 3,
      "tickColor": "#888",
      "labelFont": "Monaco, Courier New"
    }
  },

  "signals": [
    {
      "name": "margin",
      "value": 20
    },
    {
      "name": "hover",
      "on": [
        {"events": "*:pointerover", "encode": "hover"},
        {"events": "*:pointerout",  "encode": "leave"},
        {"events": "*:pointerdown", "encode": "select"},
        {"events": "*:pointerup",   "encode": "release"}
      ]
    },
    {
      "name": "xoffset",
      "update": "-(height + padding.bottom)"
    },
    {
      "name": "yoffset",
      "update": "-(width + padding.left)"
    },
    { "name": "xrange", "update": "[0, width]" },
    { "name": "yrange", "update": "[height, 0]" },

    {
      "name": "down", "value": null,
      "on": [
        {"events": "touchend", "update": "null"},
        {"events": "pointerdown, touchstart", "update": "xy()"}
      ]
    },
    {
      "name": "xcur", "value": null,
      "on": [
        {
          "events": "pointerdown, touchstart, touchend",
          "update": "slice(xdom)"
        }
      ]
    },
    {
      "name": "ycur", "value": null,
      "on": [
        {
          "events": "pointerdown, touchstart, touchend",
          "update": "slice(ydom)"
        }
      ]
    },
    {
      "name": "delta", "value": [0, 0],
      "on": [
        {
          "events": [
            {
              "source": "window", "type": "pointermove", "consume": true,
              "between": [{"type": "pointerdown"}, {"source": "window", "type": "pointerup"}]
            },
            {
              "type": "touchmove", "consume": true,
              "filter": "event.touches.length === 1"
            }
          ],
          "update": "down ? [down[0]-x(), y()-down[1]] : [0,0]"
        }
      ]
    },

    {
      "name": "anchor", "value": [0, 0],
      "on": [
        {
          "events": "wheel",
          "update": "[invert('xscale', x()), invert('yscale', y())]"
        },
        {
          "events": {"type": "touchstart", "filter": "event.touches.length===2"},
          "update": "[(xdom[0] + xdom[1]) / 2, (ydom[0] + ydom[1]) / 2]"
        }
      ]
    },
    {
      "name": "zoom", "value": 1,
      "on": [
        {
          "events": "wheel!",
          "force": true,
          "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
        },
        {
          "events": {"signal": "dist2"},
          "force": true,
          "update": "dist1 / dist2"
        }
      ]
    },
    {
      "name": "dist1", "value": 0,
      "on": [
        {
          "events": {"type": "touchstart", "filter": "event.touches.length===2"},
          "update": "pinchDistance(event)"
        }
      ]
    },
    {
      "name": "dist2", "value": 0,
      "on": [{
        "events": {"type": "touchmove", "consume": true, "filter": "event.touches.length===2"},
        "update": "pinchDistance(event)"
      }]
    },

    {
      "name": "xdom", "update": "slice(xext)",
      "on": [
        {
          "events": {"signal": "delta"},
          "update": "[xcur[0] + span(xcur) * delta[0] / width, xcur[1] + span(xcur) * delta[0] / width]"
        },
        {
          "events": {"signal": "zoom"},
          "update": "[anchor[0] + (xdom[0] - anchor[0]) * zoom, anchor[0] + (xdom[1] - anchor[0]) * zoom]"
        }
      ]
    },
    {
      "name": "ydom", "update": "slice(yext)",
      "on": [
        {
          "events": {"signal": "delta"},
          "update": "[ycur[0] + span(ycur) * delta[1] / height, ycur[1] + span(ycur) * delta[1] / height]"
        },
        {
          "events": {"signal": "zoom"},
          "update": "[anchor[1] + (ydom[0] - anchor[1]) * zoom, anchor[1] + (ydom[1] - anchor[1]) * zoom]"
        }
      ]
    },
    {
      "name": "size",
      "update": "clamp(20 / span(xdom), 1, 1000)"
    }
  ],

  "data": [
    {
      "name": "points",
      "url": "data/normal-2d.json",
      "transform": [
        { "type": "extent", "field": "u", "signal": "xext" },
        { "type": "extent", "field": "v", "signal": "yext" }
      ]
    }
  ],

  "scales": [
    {
      "name": "xscale", "zero": false,
      "domain": {"signal": "xdom"},
      "range": {"signal": "xrange"}
    },
    {
      "name": "yscale", "zero": false,
      "domain": {"signal": "ydom"},
      "range": {"signal": "yrange"}
    }
  ],

  "axes": [
    {
      "scale": "xscale",
      "orient": "top",
      "offset": {"signal": "xoffset"}
    },
    {
      "scale": "yscale",
      "orient": "right",
      "offset": {"signal": "yoffset"}
    }
  ],

  "marks": [
    {
      "type": "symbol",
      "from": {"data": "points"},
      "clip": true,
      "encode": {
        "enter": {
          "fillOpacity": {"value": 0.6},
          "fill": {"value": "steelblue"}
        },
        "update": {
          "x": {"scale": "xscale", "field": "u"},
          "y": {"scale": "yscale", "field": "v"},
          "size": {"signal": "size"}
        },
        "hover":   { "fill": {"value": "firebrick"} },
        "leave":   { "fill": {"value": "steelblue"} },
        "select":  { "size": {"signal": "size", "mult": 5} },
        "release": { "size": {"signal": "size"} }
      }
    }
  ]
}

```