### PR TITLE
fix(vega-crossfilter): The "max" interval for crossfilter transform should be exclusive, not inclusive

### DIFF
--- a/packages/vega-crossfilter/src/SortedIndex.js
+++ b/packages/vega-crossfilter/src/SortedIndex.js
@@ -1,5 +1,5 @@
 import {array32} from './arrays.js';
-import {bisectLeft, bisectRight, permute} from 'd3-array';
+import {bisectLeft, permute} from 'd3-array';
 
 /**
  * Maintains a list of values, sorted by key.
@@ -78,7 +78,7 @@ export default function SortedIndex() {
     }
     return [
       bisectLeft(array, range[0], 0, n),
-      bisectRight(array, range[1], 0, n)
+      bisectLeft(array, range[1], 0, n)
     ];
   }
 

--- a/packages/vega-crossfilter/test/crossfilter-test.js
+++ b/packages/vega-crossfilter/test/crossfilter-test.js
@@ -31,14 +31,14 @@ tape('Crossfilter filters tuples', t => {
   t.equal(on.value.length, 4);
 
   // -- update single query
-  df.update(r2, [1,2]).run();
+  df.update(r2, [1,3]).run();
   t.equal(o1.value.length, 4);
   t.equal(o2.value.length, 2);
   t.equal(on.value.length, 2);
 
   // -- update multiple queries
-  df.update(r1, [1,3])
-    .update(r2, [3,4])
+  df.update(r1, [1,4])
+    .update(r2, [3,5])
     .run();
   t.equal(o1.value.length, 3);
   t.equal(o2.value.length, 2);
@@ -101,8 +101,8 @@ tape('Crossfilter consolidates after remove', t => {
   var a = field('a'),
       b = field('b'),
       df = new Dataflow(),
-      r1 = df.add([0, 3]),
-      r2 = df.add([0, 3]),
+      r1 = df.add([0, 4]),
+      r2 = df.add([0, 4]),
       c0 = df.add(Collect),
       cf = df.add(CrossFilter, {fields:[a,b], query:[r1,r2], pulse:c0});
 


### PR DESCRIPTION
## Motivation

- Fix #4007

Documents that range filtering should use exclusive max bound per docs. 
Currently fails: range [2,4) includes 4 when it should have excluded it

## Changes

- First test demonstrates the bug
- Second commit updates implementation + other tests

This is a breaking change from past _actual_ behavior, but it's aligns to _documented_   expected behavior in the public docs.

## QA

- Check if the new behavior is what we want  , or if the issue was that the docs were wrong
- Use @danmarshall 's test spec in the sandbox - we [confirmed](https://github.com/vega/vega/issues/4007#issuecomment-3836565301) this fixes it

```json
{
  "$schema": "https://vega.github.io/schema/vega/v5.json",
  "description": "Minimal crossfilter example",
  "signals": [],
  "data": [
    {
      "name": "source",
      "values": [
        {"x": 1, "y": 28},
        {"x": 2, "y": 43},
        {"x": 3, "y": 81},
        {"x": 4, "y": 19},
        {"x": 5, "y": 65},
        {"x": 6, "y": 37},
        {"x": 7, "y": 60},
        {"x": 8, "y": 75}
      ]
    },
    {
      "name": "filtered",
      "source": "source",
      "transform": [
        {
          "type": "crossfilter",
          "signal": "xfilter",
          "fields": ["x"],
          "query": [[3, 6]]
        },
        {"type": "resolvefilter", "filter": {"signal": "xfilter"}, "ignore": 0},
        {"type": "collect", "sort": {"field": ["x"]}}
      ]
    }
  ]
}
```

## Meta

- Testing feasibility of using an agent to generate reliable fixes for well-contained, testable issues from the backlog. I'm verifying each line of any patches before submitting them.
- The default tests Opus comes up with are too verbose / possibly overfit - it takes some coaxing to match the local code style, but it's possible.