### PR TITLE
fix(build): symlink nested node_modules to local packages in vega editor branch preview

### DIFF
--- a/scripts/build-editor-preview.sh
+++ b/scripts/build-editor-preview.sh
@@ -7,11 +7,7 @@ echo "Installing Vega"
 
 # Link every package to make sure the editor uses the local version
 for package in packages/*; do
-  if [ -d "$package" ]; then
-    cd $package
-    npm link
-    cd ../..
-  fi
+  [ -d "$package" ] && (cd "$package" && npm link)
 done
 
 # Build - assumes lerna handles the topological sort
@@ -23,29 +19,78 @@ git clone https://github.com/vega/editor.git
 cd editor
 npm ci --ignore-scripts
 
-# HACK: Make sure we prefer the local version to the one from npm
-# Test if we can remove this after verifying that only 1 copy of every subpackage is used per repo
+# Link direct dependencies using npm link (works for top-level deps)
 for package in ../packages/*; do
-  if [ -d "$package" ]; then
-    package_name=$(basename $package)
-    npm link $package_name
-  fi
+  [ -d "$package" ] && npm link "$(basename "$package")"
 done
 
+# Replace nested node_modules copies with symlinks to local packages
+# This handles transitive dependencies that npm link doesn't reach
+echo "Symlinking nested dependencies to local packages"
+node -e "
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const packagesDir = '../packages';
+const localPackages = new Map();
+
+// Build map of local package names to their paths
+for (const name of fs.readdirSync(packagesDir)) {
+  const pkgPath = path.join(packagesDir, name);
+  const pkgJsonPath = path.join(pkgPath, 'package.json');
+  if (fs.statSync(pkgPath).isDirectory() && fs.existsSync(pkgJsonPath)) {
+    const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
+    localPackages.set(pkg.name, path.resolve(pkgPath));
+  }
+}
+
+// Find all nested node_modules that contain our packages and replace with symlinks
+function findAndReplace(dir, depth = 0) {
+  if (depth > 10) return; // Prevent infinite recursion
+
+  const nodeModules = path.join(dir, 'node_modules');
+  if (!fs.existsSync(nodeModules)) return;
+
+  for (const entry of fs.readdirSync(nodeModules)) {
+    const entryPath = path.join(nodeModules, entry);
+
+    // Handle scoped packages
+    if (entry.startsWith('@') && fs.statSync(entryPath).isDirectory()) {
+      for (const scopedEntry of fs.readdirSync(entryPath)) {
+        const scopedName = entry + '/' + scopedEntry;
+        const scopedPath = path.join(entryPath, scopedEntry);
+        if (localPackages.has(scopedName) && !fs.lstatSync(scopedPath).isSymbolicLink()) {
+          console.log('  Replacing:', path.relative('.', scopedPath));
+          fs.rmSync(scopedPath, { recursive: true });
+          fs.symlinkSync(localPackages.get(scopedName), scopedPath);
+        }
+      }
+      continue;
+    }
+
+    // Regular packages
+    if (localPackages.has(entry) && fs.statSync(entryPath).isDirectory()) {
+      if (!fs.lstatSync(entryPath).isSymbolicLink()) {
+        console.log('  Replacing:', path.relative('.', entryPath));
+        fs.rmSync(entryPath, { recursive: true });
+        fs.symlinkSync(localPackages.get(entry), entryPath);
+      }
+    } else if (fs.statSync(entryPath).isDirectory() && !fs.lstatSync(entryPath).isSymbolicLink()) {
+      // Recurse into non-symlinked directories
+      findAndReplace(entryPath, depth + 1);
+    }
+  }
+}
+
+findAndReplace('.');
+console.log('Done symlinking nested dependencies');
+"
+
 echo "Creating stub index.json for vega and vega-lite library"
-
-mkdir -p public/spec/vega-lite
-mkdir -p public/spec/vega
-touch public/spec/vega-lite/index.json
-touch public/spec/vega/index.json
-
-cat <<EOF > public/spec/vega-lite/index.json
-{}
-EOF
-
-cat <<EOF > public/spec/vega/index.json
-{}
-EOF
+mkdir -p public/spec/{vega,vega-lite}
+echo '{}' > public/spec/vega/index.json
+echo '{}' > public/spec/vega-lite/index.json
 
 # Build the editor site in the dist folder
 # Build options for disabling sourcemaps/adjusting minification if we go over the 25MB limit on cloudflare


### PR DESCRIPTION
## Motivation

- When working on https://github.com/vega/vega/pull/4231 , crossfilter changes weren't being picked up in the editor preview . It appeared [vega-cli](https://github.com/vega/editor/blob/1dfd932dbcce381f709b9f2d5690fd76c197bcf4/package.json#L73) version of vega-crossfilter was overriding our updates. Making this change fixes it.

## Changes

- Make it so nested dependencies reference the draft branch version of Vega (and subdependencies) instead of published version

## Testing

- Confirm that the branch preview still builds: https://github.com/vega/vega/runs/62151920572
