### PR TITLE
fix(vega-scenegraph): svg paths containing a "z" (closepath) without a space separator parse correctly

### DIFF
--- a/packages/vega-scenegraph/src/path/parse.js
+++ b/packages/vega-scenegraph/src/path/parse.js
@@ -1,5 +1,5 @@
 const paramCounts = { m:2, l:2, h:1, v:1, z:0, c:6, s:4, q:4, t:2, a:7 };
-const commandPattern = /[mlhvzcsqta]([^mlhvzcsqta]+|$)/gi;
+const commandPattern = /[mlhvzcsqta]([^mlhvzcsqta]*)/gi;
 const numberPattern = /^[+-]?(([0-9]*\.[0-9]+)|([0-9]+\.)|([0-9]+))([eE][+-]?[0-9]+)?/;
 const spacePattern = /^((\s+,?\s*)|(,\s*))/;
 const flagPattern = /^[01]/;

--- a/packages/vega-scenegraph/test/path-test.js
+++ b/packages/vega-scenegraph/test/path-test.js
@@ -155,6 +155,25 @@ tape('pathParse should handle implicit m lineTo', t => {
   t.end();
 });
 
+tape('pathParse should handle Z followed by command without space', t => {
+  // Issue #4072: Z immediately followed by another command was being dropped
+  const s1 = 'M-1-1H1V1H-1ZM0-1 0 1';
+  const p1 = [['M',-1,-1], ['H',1], ['V',1], ['H',-1], ['Z'], ['M',0,-1], ['L',0,1]];
+  t.deepEqual(pathParse(s1), p1);
+
+  // Lowercase z should also work
+  const s2 = 'M0,0L10,10zL20,20';
+  const p2 = [['M',0,0], ['L',10,10], ['z'], ['L',20,20]];
+  t.deepEqual(pathParse(s2), p2);
+
+  // Multiple Z commands in sequence
+  const s3 = 'M0,0ZZM1,1';
+  const p3 = [['M',0,0], ['Z'], ['Z'], ['M',1,1]];
+  t.deepEqual(pathParse(s3), p3);
+
+  t.end();
+});
+
 tape('boundContext should calculate paths bounds', t => {
   for (let i=0; i<paths.length; ++i) {
     const p = pathParse(paths[i]);


### PR DESCRIPTION
## Motivation

- Reproduce @p-himik 's report: Fixes https://github.com/vega/vega/issues/4072
- Our SVG path converter was stricter than what the SVG spec actually permits

## Changes

- Adds a case where Z  (closepath) command is followed by another without whitespace separtion
- Fixes the bug by changing from `+` to `*` match for the matching regex (from 1 or more to 0 or more matches)

Using the spec in the original report with canvas parsing, we now close the shape correctly

<img width="1798" height="936" alt="image" src="https://github.com/user-attachments/assets/dc85abeb-6321-44ed-bd09-3dc3f1044ef0" />

## Testing

- First commit fails, second will pass (check Github actions)
- Visit https://55762c8f.vega-628.pages.dev/ and use the spec from the original bug report. It should look the same in Canvas and SVG modes

<details><summary>Details</summary>

```json
{
  "$schema": "https://vega.github.io/schema/vega/v6.json",
  "data": [
    {
      "name": "shapes",
      "values": [
        {"x": 0, "path": "M-1-1H1V1H-1Z"},
        {"x": 210, "path": "M-1-1H1V1H-1ZM0-1 0 1"}
      ]
    }
  ],
  "marks": [
    {
      "type": "path",
      "from": {"data": "shapes"},
      "encode": {
        "enter": {
          "path": {"field": "path"},
          "stroke": {"value": "black"},
          "x": {"field": "x"},
          "scaleX": {"value": 100},
          "scaleY": {"value": 100}
        }
      }
    }
  ]
}
```
</details> 


## Notes

 - Close path [spec](https://svgwg.org/specs/paths/#PathDataClosePathCommand) makes whitespace between draw commands optional

<img width="812" height="547" alt="image" src="https://github.com/user-attachments/assets/77beaecc-81d3-4724-bb57-026c006c3fbb" />
