### PR TITLE
feat(vega-encode): make integer `tickIndex` field on axis tick datum for use in label expressions

### DIFF
--- a/docs/docs/axes.md
+++ b/docs/docs/axes.md
@@ -136,6 +136,7 @@ Each axis tick, grid line, and label instance is backed by a data object with th
 - `label` - the string label
 - `value` - the data value
 - `index` - *fractional* tick index (`0` for the first tick and `1` for the last tick)
+- `tickIndex` - *integer* tick index (`0` for the first tick, incrementing by 1 for each subsequent tick)
 
 The following example shows how to set custom colors, thickness, text angle, and fonts. The `labels` encoding block also make legend labels responsive to input events, and changes the text color on mouse hover.
 

--- a/docs/docs/axes.md
+++ b/docs/docs/axes.md
@@ -136,7 +136,7 @@ Each axis tick, grid line, and label instance is backed by a data object with th
 - `label` - the string label
 - `value` - the data value
 - `index` - *fractional* tick index (`0` for the first tick and `1` for the last tick)
-- `tickIndex` - *integer* tick index (`0` for the first tick, incrementing by 1 for each subsequent tick)
+- `tickIndex` - *integer* tick index (`0` for the first tick, incrementing by 1 for each subsequent tick) {% include tag ver="6.3" %}
 
 The following example shows how to set custom colors, thickness, text angle, and fonts. The `labels` encoding block also make legend labels responsive to input events, and changes the text color on mouse hover.
 

--- a/packages/vega-encode/src/AxisTicks.js
+++ b/packages/vega-encode/src/AxisTicks.js
@@ -42,6 +42,7 @@ inherits(AxisTicks, Transform, {
     ticks = values.map((value, i) =>
       ingest({
         index: i / (values.length - 1 || 1),
+        tickIndex: i,
         value: value,
         label: format(value)
       })
@@ -52,6 +53,7 @@ inherits(AxisTicks, Transform, {
       // this is used to generate axes with 'binned' domains
       ticks.push(ingest({
         index: -1,
+        tickIndex: -1,
         extra: {value: ticks[0].value},
         label: ''
       }));

--- a/packages/vega-encode/test/axis-ticks-test.js
+++ b/packages/vega-encode/test/axis-ticks-test.js
@@ -1,0 +1,71 @@
+import tape from 'tape';
+import { Dataflow } from 'vega-dataflow';
+import * as vs from 'vega-scale';
+import { axisticks, scale } from '../index.js';
+
+/**
+ * Build a linear scale node and an axisticks node backed by it, then run the
+ * dataflow.  Returns the array of tick datum objects from axisticks.value.
+ *
+ * `tickParams` is merged into the axisticks parameter object, so callers can
+ * pass `values`, `extra`, etc.  The scale always covers [0, 10].
+ */
+function makeTicks(tickParams) {
+  var df = new Dataflow(),
+      s  = df.add(scale, { type: vs.Linear, domain: [0, 10], range: [0, 500], zero: false }),
+      t  = df.add(axisticks, { scale: s, ...tickParams });
+  df.run();
+  return t.value;
+}
+
+tape('AxisTicks tickIndex is sequential integers starting at 0', t => {
+  // Explicit values give deterministic tick count regardless of d3 heuristics.
+  var ticks = makeTicks({ values: [0, 2, 4, 6, 8, 10] });
+
+  t.equal(ticks.length, 6, 'produces 6 ticks');
+  ticks.forEach((d, i) => {
+    t.equal(d.tickIndex, i, `tick ${i} has tickIndex ${i}`);
+  });
+
+  t.end();
+});
+
+tape('AxisTicks fractional index field retains existing semantics', t => {
+  var ticks = makeTicks({ values: [0, 5, 10] });
+
+  t.equal(ticks.length, 3);
+  t.equal(ticks[0].index, 0,   'first tick index is 0');
+  t.equal(ticks[1].index, 0.5, 'middle tick index is 0.5');
+  t.equal(ticks[2].index, 1,   'last tick index is 1');
+
+  // tickIndex must not disturb the fractional index contract
+  t.equal(ticks[0].tickIndex, 0, 'first tickIndex is 0');
+  t.equal(ticks[1].tickIndex, 1, 'second tickIndex is 1');
+  t.equal(ticks[2].tickIndex, 2, 'third tickIndex is 2');
+
+  t.end();
+});
+
+tape('AxisTicks extra (binned-domain sentinel) tick gets tickIndex -1', t => {
+  var ticks = makeTicks({ values: [0, 5, 10], extra: true });
+
+  // Regular ticks come first; the sentinel is appended at the end.
+  t.equal(ticks.length, 4, 'produces 3 regular ticks + 1 extra tick');
+
+  var extra = ticks[ticks.length - 1];
+  t.equal(extra.index, -1,     'extra tick has index -1');
+  t.equal(extra.tickIndex, -1, 'extra tick has tickIndex -1');
+  t.ok(extra.extra,            'extra tick has extra flag set');
+
+  t.end();
+});
+
+tape('AxisTicks single tick avoids division-by-zero', t => {
+  var ticks = makeTicks({ values: [5] });
+
+  t.equal(ticks.length, 1);
+  t.equal(ticks[0].index,     0, 'single tick index is 0 (not NaN)');
+  t.equal(ticks[0].tickIndex, 0, 'single tick tickIndex is 0');
+
+  t.end();
+});


### PR DESCRIPTION
Fixes #4238

## Motivation

- See issue #4238 -> We'd like for people to be able to stagger the placement of tick lines
- The existing `datum.index` field is normalized to `[0, 1]` . Without knowing the total tick count, users cannot recover the integer position needed for parity checks, making automated label staggering impossible for quantitative axes.

## Changes

<img width="2312" height="1232" alt="image" src="https://github.com/user-attachments/assets/a8635165-f6be-4d61-81b8-ac3c7ebdadbf" />


- `packages/vega-encode/src/AxisTicks.js`: Adds `tickIndex: i` (0-based integer) to each regular tick datum alongside the existing fractional `index`. The binned-domain sentinel tick also gets `tickIndex: -1` to mirror its existing `index: -1` convention.
- `packages/vega-encode/test/axis-ticks-test.js` (new): Tests cover sequential integer indices, backward-compatible fractional `index` semantics, the extra sentinel tick, and the single-tick edge case.
- `docs/docs/axes.md`: Documents `tickIndex` in the custom encoding datum fields section alongside `index`.

## QA Instructions

Paste this spec into the [Vega sandbox for this PR](https://cameron-yick-integer-shift-s.vega-628.pages.dev/#/url/vega/N4IgJAzgxgFgpgWwIYgFwhgF0wBwqgegIDc4BzJAOjIEtMYBXAI0poHsDp5kTykSArJQBWENgDsQAGhAB3GgBN6aACwAGNTPg0yWNAEYBmkAqSYUqANqhxSBHDQhzTADYOZxJC4ZwIaayAAHmjGAJ5oAEwAHAC+UqDBqPphaAICcQmRKagqAMwZQWi52QCc+gWJ6jLhqFHl8YWoRtWp+Q2JAGzZ+iUVaADs2VH9fbXZAhGjJdkqse0GGi2oESoxALrrMtBevv42dg7owTKYoTiHIC404nBIAE7SJmzI12igpuaOzm6PAGY0cBcCkcwTiIDuSHEZAu8iUMBABVs9kc4ROZwuVxu90eCmeSFeqHeZgsTiQrncIH+gOB6HCYIhUIu2l0mEeAC84Hc2GhMHcfJsQMg7gBrPxWUCnc6OTEU35chBvEzEr5kn5guDiKBsBSHUAazCcxWJUDbH5HP4AoEghFLE1QHYoi3Ux1giC8tjC3UgTzeC5uuCA1w+G0gN1cz0AdUUykJ3q8weWMSTAqQgV24pAbDuAPErPQTDY2Gej1NF2OIA1Wp1ipcZMBYtADBwHy9ChqAQNbscHwYCEomBoUGFAElxDrAgACACkE4iE4AvPOJ-pHj6ExE1AU14d0htkw0szm85c4L9WVt7WaQHSNkA) to check if staggered labels work with `datum.tickIndex`:

```json
{
    "$schema": "https://vega.github.io/schema/vega/v5.json",
    "width": 400,
    "height": 150,
    "data": [
      {
        "name": "table",
        "values": [
          {"x": 0, "y": 28}, {"x": 10, "y": 55}, {"x": 20, "y": 43},
          {"x": 30, "y": 91}, {"x": 40, "y": 81}, {"x": 50, "y": 53},
          {"x": 60, "y": 19}, {"x": 70, "y": 87}, {"x": 80, "y": 52},
          {"x": 90, "y": 48}, {"x": 100, "y": 24}
        ]
      }
    ],
    "scales": [
      {"name": "x", "type": "linear", "domain": {"data": "table", "field": "x"}, "range":
  "width"},
      {"name": "y", "type": "linear", "domain": {"data": "table", "field": "y"}, "range":
  "height", "zero": true}
    ],
    "marks": [
      {
        "type": "line",
        "from": {"data": "table"},
        "encode": {
          "enter": {
            "x": {"scale": "x", "field": "x"},
            "y": {"scale": "y", "field": "y"},
            "stroke": {"value": "steelblue"},
            "strokeWidth": {"value": 2}
          }
        }
      }
    ],
    "axes": [
      {
        "orient": "bottom",
        "scale": "x",
        "encode": {
          "labels": {
            "update": {
              "dy": [
                {"test": "datum.tickIndex % 2 == 1", "value": 20},
                {"value": 5}
              ]
            }
          }
        }
      },
      {"orient": "left", "scale": "y"}
    ]
  }
```

1. Confirm odd-indexed tick labels are offset downward by 20px, even-indexed by 5px.
2. Confirm `datum.index` still ranges `0`-`1` (inspect via a `text` signal if needed).
3. Change the domain to `[0, 179]` . Confirm staggering still works correctly without any ad-hoc scale factor.

Thanks @blerner for checking to see if this works with vertical ticks + other scale types:

https://github.com/vega/vega/issues/4238#issuecomment-4106538675

## Blast Radius

- Changes are isolated to `packages/vega-encode/src/AxisTicks.js`
- No existing callers modified; no behavior change for specs that do not reference `tickIndex`

## AI Use

- Claude Code (Sonnet 4.6) wrote the implementation and tests; I drove the design and reviewed.