### PR TITLE
build: switch tsconfig module resolution to Bundler

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
       "es2022",
       "dom"
     ],
-    "moduleResolution": "Node",
+    "moduleResolution": "Bundler",
     "noImplicitAny": true,
     "noImplicitThis": true,
     "strictNullChecks": true,


### PR DESCRIPTION
I had to do this for things to work locally, because of this error message:

```
tsconfig.json:3:3 - error TS5107: Option 'moduleResolution=node10' is deprecated and will stop functioning in TypeScript 7.0. Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
```

It seems possible to also silence it, so feel free to change to that if it is more appropriate.