### PR TITLE
fix(vega-typings, vega-util): tighten NumericValueRef and fix mergeConfig signature

### DIFF
--- a/packages/vega-typings/tests/spec/invalid/encode.ts
+++ b/packages/vega-typings/tests/spec/invalid/encode.ts
@@ -1,0 +1,17 @@
+import { NumericValueRef } from 'vega';
+
+let numRef: NumericValueRef;
+
+// An empty object is not a valid numeric value ref — there is no base value
+// @ts-expect-error
+numRef = {};
+
+// Modifier-only objects are not valid — a base value (field/signal/value/offset/etc.) is required
+// @ts-expect-error
+numRef = { mult: 2 };
+
+// @ts-expect-error
+numRef = { exponent: 2 };
+
+// @ts-expect-error
+numRef = { round: true };

--- a/packages/vega-typings/tests/spec/valid/encode.ts
+++ b/packages/vega-typings/tests/spec/valid/encode.ts
@@ -1,0 +1,47 @@
+import { Config, NumericValueRef, ProductionRule, ColorValueRef } from 'vega';
+import { mergeConfig } from 'vega';
+
+// --- NumericValueRef: all valid base forms ---
+
+const r1: NumericValueRef = { field: 'x' };
+const r2: NumericValueRef = { signal: 'mySignal' };
+const r3: NumericValueRef = { value: 5 };
+const r4: NumericValueRef = { scale: 'xscale', field: 'x' };
+const r5: NumericValueRef = { scale: 'xscale', band: 1 };
+const r6: NumericValueRef = { scale: 'xscale', range: 0 };
+
+// The offset-only base case: valid per the schema's required:["offset"] branch
+const r7: NumericValueRef = { offset: 5 };
+const r8: NumericValueRef = { offset: 5, mult: 2 };
+
+// Modifiers combined with a base value
+const r9: NumericValueRef = { field: 'x', mult: 2, offset: 5, round: true };
+const r10: NumericValueRef = { scale: 'xscale', signal: 'label.x', band: 0.5 };
+
+// --- ProductionRule: single value form ---
+
+const pr1: ProductionRule<NumericValueRef> = { field: 'x' };
+const pr2: ProductionRule<NumericValueRef> = { value: 0 };
+
+// --- ProductionRule: array form with test predicates ---
+
+const pr3: ProductionRule<NumericValueRef> = [
+  { test: 'datum.x > 0', scale: 'xscale', field: 'x' },
+  { value: 0 },
+];
+
+const pr4: ProductionRule<ColorValueRef> = [
+  { test: 'datum.selected', value: 'red' },
+  { test: 'datum.hovered', scale: 'colorScale', field: 'category' },
+  { value: 'gray' },
+];
+
+// --- mergeConfig: accepts vega-typings Config without requiring index signature ---
+
+declare const configA: Config;
+declare const configB: Config;
+declare const partialConfig: Partial<Config>;
+
+const merged1: Config = mergeConfig(configA, configB);
+const merged2: Config = mergeConfig(partialConfig, configA);
+const merged3: Config = mergeConfig(configA, partialConfig, configB);

--- a/packages/vega-typings/types/spec/encode.d.ts
+++ b/packages/vega-typings/types/spec/encode.d.ts
@@ -47,7 +47,7 @@ export type ScaledValueRef<T> =
       range: number | boolean;
     };
 
-export type NumericValueRef = (ScaledValueRef<number> | {}) & {
+export type NumericValueRef = (ScaledValueRef<number> | { offset: number | NumericValueRef }) & {
   exponent?: number | NumericValueRef;
   mult?: number | NumericValueRef;
   offset?: number | NumericValueRef;

--- a/packages/vega-typings/types/spec/encode.d.ts
+++ b/packages/vega-typings/types/spec/encode.d.ts
@@ -47,6 +47,7 @@ export type ScaledValueRef<T> =
       range: number | boolean;
     };
 
+// `{ offset }` matches the JSON Schema `required:["offset"]` branch; `offset` in the intersection allows modifiers on other base forms.
 export type NumericValueRef = (ScaledValueRef<number> | { offset: number | NumericValueRef }) & {
   exponent?: number | NumericValueRef;
   mult?: number | NumericValueRef;

--- a/packages/vega-util/src/mergeConfig.ts
+++ b/packages/vega-util/src/mergeConfig.ts
@@ -44,6 +44,9 @@ type RecurseStrategy = Record<string, unknown> | boolean | null;
  * Accepts any object type (including vega-typings `Config`) and returns the same type.
  */
 export function mergeConfig<T extends object>(...configs: Partial<T>[]): T {
+  // vega-typings Config has no index signature, so T is not assignable to VegaConfig
+  // without a cast. The merge logic only reads string-keyed properties and never
+  // introduces values outside of what was already present in T.
   return mergeConfigInternal(...(configs as unknown as Partial<VegaConfig>[]))  as unknown as T;
 }
 

--- a/packages/vega-util/src/mergeConfig.ts
+++ b/packages/vega-util/src/mergeConfig.ts
@@ -21,22 +21,33 @@ interface ConfigObject {
 /** A signal object with a required name property; compatible with vega-typings InitSignal | NewSignal. */
 interface NamedSignal {
   name: string;
-  [key: string]: ConfigValue;
 }
 
-/** Represents top-level Vega configuration object; compatible with vega-typings Config. */
-interface VegaConfig extends ConfigObject {
+/**
+ * Internal top-level Vega configuration object used for merging.
+ * Does not extend ConfigObject directly so that signals can be typed as NamedSignal[]
+ * without requiring every signal property to conform to ConfigValue.
+ */
+interface VegaConfig {
   signals?: NamedSignal[];
+  [key: string]: NamedSignal[] | ConfigValue | undefined;
 }
 
 /** Internal type used to determine which properties should be recursively merged. Currently only supports legend layout and style blocks */
 type RecurseStrategy = Record<string, unknown> | boolean | null;
 
 
-/** Merges Vega config objects. Signals merged by name (source takes precedence),
+/**
+ * Merges Vega config objects. Signals merged by name (source takes precedence),
  * legend.layout recursively merged, style fully recursive, others shallow.
- * Return type is compatible with vega-typings Config. */
-export function mergeConfig(...configs: Partial<VegaConfig>[]): VegaConfig {
+ *
+ * Accepts any object type (including vega-typings `Config`) and returns the same type.
+ */
+export function mergeConfig<T extends object>(...configs: Partial<T>[]): T {
+  return mergeConfigInternal(...(configs as unknown as Partial<VegaConfig>[]))  as unknown as T;
+}
+
+function mergeConfigInternal(...configs: Partial<VegaConfig>[]): VegaConfig {
   return configs.reduce((out, source) => {
     for (const key in source) {
       if (key === 'signals') {
@@ -52,7 +63,7 @@ export function mergeConfig(...configs: Partial<VegaConfig>[]): VegaConfig {
         const r: RecurseStrategy = key === 'legend' ? {layout: 1}
           : key === 'style' ? true
           : null;
-        writeConfig(out, key, source[key], r);
+        writeConfig(out as unknown as ConfigObject, key, source[key] as ConfigValue, r);
       }
     }
     return out;


### PR DESCRIPTION
## Motivation

- `vega-util` and `vega-typings` types for the Config object are currently incompatible
- Draft in #4278

### Changes

Two related type correctness fixes:

1. vega-typings: Replace '| {}' in NumericValueRef with '| { offset: number | NumericValueRef }'

   The '| {}' escape hatch made NumericValueRef accept any object (including '{}',
   '{ mult: 2 }', etc.) which the JSON schema would reject. The schema's anyOf has
   a 'required: ["offset"]' branch for standalone offset-only refs; this replaces
   the overly broad '{}' with the precise shape that branch represents.

   Valid patterns still accepted: { field }, { signal }, { value }, { scale, band },
   { offset: 5 }, { field, mult, offset } etc.
   Now correctly rejected: {}, { mult: 2 }, { round: true } (modifier-only, no base)

2. vega-util: Make mergeConfig generic and decouple VegaConfig from ConfigObject

   The previous VegaConfig extended ConfigObject ([k: string]: ConfigValue), which
   forced callers to provide index-signature-bearing types. vega-typings Config does
   not have a top-level index signature, so mergeConfig(configA, configB) failed TS.

   The root issues (per @flying-sheep's feedback in https://github.com/vega/vega/issues/4278
   - NamedSignal had [k: string]: ConfigValue, but NewSignal/InitSignal properties like 'on: OnEvent[]' and 'bind: Binding' contain types outside ConfigValue (e.g. EventTarget, Stream), so the constraint was both wrong and unsatisfiable
   - VegaConfig extending ConfigObject propagated the index signature requirement to callers

## Testing

- CI passing should be enough, this only modifies types.