### PR TITLE
chore: add homepage and bugs metadata to vega-time package.json

### DIFF
--- a/packages/vega-time/package.json
+++ b/packages/vega-time/package.json
@@ -14,6 +14,10 @@
     "name": "Vega",
     "url": "https://vega.github.io"
   },
+  "homepage": "https://github.com/vega/vega/tree/main/packages/vega-time#readme",
+  "bugs": {
+    "url": "https://github.com/vega/vega/issues"
+  },
   "exports": {
     "default": "./build/vega-time.js"
   },


### PR DESCRIPTION
## Summary

Adds standard npm `homepage` and `bugs` metadata fields to `packages/vega-time/package.json`.

### Changes
- Added `homepage`: `https://github.com/vega/vega/tree/main/packages/vega-time#readme`
- Added `bugs.url`: `https://github.com/vega/vega/issues`

### Why
The published npm package currently exposes `repository` and `license` metadata, but lacks standard `homepage` and `bugs` fields. Package consumers can find the repository, but npm metadata does not provide a package README homepage or issue tracker URL.

### Verification
- `python3 -m json.tool packages/vega-time/package.json` passed
- `git diff --check` passed

### Related
- Fixes https://github.com/charles-openclaw/charles-microbounties/issues/1204