### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/packages/vega-time/package.json
+++ b/packages/vega-time/package.json
@@ -1,6 +1,10 @@
 {
   "name": "vega-time",
   "version": "3.1.0",
+  "homepage": "https://github.com/vega/vega",
+  "bugs": {
+    "url": "https://github.com/vega/vega/issues"
+  },
   "description": "JavaScript date/time utilities for Vega.",
   "keywords": [
     "vega",


### PR DESCRIPTION
Adds missing `bugs, homepage` metadata to `packages/vega-time/package.json`.

Fixes npm tooling unable to resolve package metadata.