### PR TITLE
fix: clamp negative variance deviation from streaming removes

### DIFF
--- a/packages/vega-transforms/src/util/AggregateOps.js
+++ b/packages/vega-transforms/src/util/AggregateOps.js
@@ -55,7 +55,7 @@ export const AggregateOps = {
   },
   variance: {
     init:  m => m.dev = 0,
-    value: m => m.valid > 1 ? m.dev / (m.valid - 1) : undefined,
+    value: m => m.valid > 1 ? Math.max(0, m.dev) / (m.valid - 1) : undefined,
     add:  (m, v) => m.dev += m.mean_d * (v - m.mean),
     rem:  (m, v) => m.dev -= m.mean_d * (v - m.mean),
     req:  ['mean'], idx: 1
@@ -65,7 +65,7 @@ export const AggregateOps = {
     req:  ['variance'], idx: 2
   },
   stdev: {
-    value: m => m.valid > 1 ? Math.sqrt(m.dev / (m.valid - 1)) : undefined,
+    value: m => m.valid > 1 ? Math.sqrt(Math.max(0, m.dev) / (m.valid - 1)) : undefined,
     req:  ['variance'], idx: 2
   },
   stdevp: {
@@ -73,7 +73,7 @@ export const AggregateOps = {
     req:  ['variance'], idx: 2
   },
   stderr: {
-    value: m => m.valid > 1 ? Math.sqrt(m.dev / (m.valid * (m.valid - 1))) : undefined,
+    value: m => m.valid > 1 ? Math.sqrt(Math.max(0, m.dev) / (m.valid * (m.valid - 1))) : undefined,
     req:  ['variance'], idx: 2
   },
   distinct: {

--- a/packages/vega-transforms/test/aggregate-test.js
+++ b/packages/vega-transforms/test/aggregate-test.js
@@ -412,3 +412,27 @@ tape('Aggregate handles streaming population variance and stdev', t => {
 
   t.end();
 });
+
+tape('Aggregate handles streaming sample variance, stdev and stderr', t => {
+  const data = [{v: 5}, {v: 100000.123}, {v: 5}, {v: -99999.456}];
+
+  var v = field('v'),
+      df = new Dataflow(),
+      col = df.add(Collect),
+      agg = df.add(Aggregate, {
+        fields: [v, v, v],
+        ops: ['variance', 'stdev', 'stderr'],
+        as: ['variance', 'stdev', 'stderr'],
+        pulse: col
+      }),
+      out = df.add(Collect, {pulse: agg});
+
+  df.pulse(col, changeset().insert(data)).run();
+  df.pulse(col, changeset().remove([data[1], data[3]])).run();
+  const d = out.value[0];
+  t.ok(d.variance >= 0, 'variance is non-negative');
+  t.equal(d.stdev, 0);
+  t.equal(d.stderr, 0);
+
+  t.end();
+});


### PR DESCRIPTION
## Summary

#4296 clamped the shared `m.dev` Welford accumulator for the population ops (`variancep`, `stdevp`). The sample ops in the same file — `variance`, `stdev`, `stderr` — read the very same accumulator but were left unclamped, and they share the same failure mode: after a mix of streaming adds and removes, floating-point residue in the incremental Welford update can leave `m.dev` slightly negative, so `variance` returns a negative number and `stdev`/`stderr` return `NaN`.

## Repro

Insert `[5, 100000.123, 5, -99999.456]`, then remove the two outliers (`100000.123` and `-99999.456`). The two remaining values are both `5`, so all variance-family stats should be exactly `0` — but the accumulator is left at `dev = -9.5367431640625e-7`, giving:

- `variance` → `-9.5e-7` (negative)
- `stdev` / `stderr` → `NaN` (sqrt of a negative)

This is unreachable in add-only usage — d3's add-only Welford accumulation can never go negative — which is why it went unnoticed; it only surfaces via streaming removes.

## Fix

Apply the same `Math.max(0, m.dev)` clamp to the three sample ops, keeping their `m.valid > 1` guards (sample stats are correctly undefined for n < 2). This completes the clamp #4296 applied to the population ops, so all five variance-family ops now treat accumulator residue uniformly.

Adds a streaming regression test mirroring the existing population-op streaming test: it asserts `variance >= 0` and `stdev === 0` / `stderr === 0` after the insert/remove sequence above, and fails without the clamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)