### PR TITLE
fix: respect CSS transforms when computing event points

### DIFF
--- a/packages/vega-scenegraph/src/util/point.js
+++ b/packages/vega-scenegraph/src/util/point.js
@@ -1,7 +1,33 @@
 export default function(event, el) {
-  const rect = el.getBoundingClientRect();
+  if (el.getScreenCTM) {
+    const p = ctmPoint(event, el.getScreenCTM());
+    if (p) return p;
+  }
+  return rectPoint(event, el, el.getBoundingClientRect());
+}
+
+// map a client point to element coordinates by inverting the screen CTM,
+// compensating for any CSS transforms on ancestor elements
+export function ctmPoint(event, ctm) {
+  if (!ctm) return null;
+  const det = ctm.a * ctm.d - ctm.b * ctm.c;
+  if (!det) return null;
+  const x = event.clientX - ctm.e,
+        y = event.clientY - ctm.f;
   return [
-    event.clientX - rect.left - (el.clientLeft || 0),
-    event.clientY - rect.top - (el.clientTop || 0)
+    (ctm.d * x - ctm.c * y) / det,
+    (ctm.a * y - ctm.b * x) / det
+  ];
+}
+
+// map a client point to element coordinates using bounding rect geometry,
+// unscaling (bounding rect size over untransformed layout size) to
+// compensate for CSS transforms before subtracting layout-unit borders
+export function rectPoint(event, el, rect) {
+  const sx = el.offsetWidth ? rect.width / el.offsetWidth : 1,
+        sy = el.offsetHeight ? rect.height / el.offsetHeight : 1;
+  return [
+    (event.clientX - rect.left) / sx - (el.clientLeft || 0),
+    (event.clientY - rect.top) / sy - (el.clientTop || 0)
   ];
 }

--- a/packages/vega-scenegraph/test/point-test.js
+++ b/packages/vega-scenegraph/test/point-test.js
@@ -1,0 +1,92 @@
+import tape from 'tape';
+import point, {ctmPoint, rectPoint} from '../src/util/point.js';
+
+function element(rect, props) {
+  return {
+    getBoundingClientRect: () => rect,
+    ...props
+  };
+}
+
+tape('point maps untransformed elements identically to rect math', t => {
+  const el = element(
+    {left: 10, top: 20, width: 100, height: 50},
+    {offsetWidth: 100, offsetHeight: 50, clientLeft: 0, clientTop: 0}
+  );
+  t.deepEqual(point({clientX: 60, clientY: 45}, el), [50, 25]);
+  t.deepEqual(point({clientX: 10, clientY: 20}, el), [0, 0]);
+  t.end();
+});
+
+tape('point compensates for CSS scale via rect vs offset size', t => {
+  const el = element(
+    {left: 10, top: 20, width: 50, height: 25},
+    {offsetWidth: 100, offsetHeight: 50, clientLeft: 0, clientTop: 0}
+  );
+  t.deepEqual(point({clientX: 35, clientY: 30}, el), [50, 20]);
+  t.deepEqual(point({clientX: 60, clientY: 45}, el), [100, 50]);
+  t.end();
+});
+
+tape('point falls back to unit scale for zero or undefined offset size', t => {
+  const rect = {left: 10, top: 20, width: 100, height: 50};
+  const zero = element(rect, {offsetWidth: 0, offsetHeight: 0, clientLeft: 0, clientTop: 0});
+  t.deepEqual(point({clientX: 60, clientY: 45}, zero), [50, 25]);
+
+  const undef = element(rect, {clientLeft: 0, clientTop: 0});
+  t.deepEqual(point({clientX: 60, clientY: 45}, undef), [50, 25]);
+  t.end();
+});
+
+tape('point subtracts borders after unscaling', t => {
+  const el = element(
+    {left: 10, top: 20, width: 50, height: 25},
+    {offsetWidth: 100, offsetHeight: 50, clientLeft: 2, clientTop: 3}
+  );
+  t.deepEqual(point({clientX: 35, clientY: 30}, el), [48, 17]);
+  t.end();
+});
+
+tape('point applies the inverse screen CTM for SVG elements', t => {
+  const el = element(
+    {left: 0, top: 0, width: 0, height: 0},
+    {getScreenCTM: () => ({a: 2, b: 0, c: 0, d: 2, e: 10, f: 20})}
+  );
+  t.deepEqual(point({clientX: 110, clientY: 120}, el), [50, 50]);
+
+  const translated = element(
+    {left: 0, top: 0, width: 0, height: 0},
+    {getScreenCTM: () => ({a: 0.5, b: 0, c: 0, d: 0.25, e: 8, f: 6})}
+  );
+  t.deepEqual(point({clientX: 33, clientY: 16}, translated), [50, 40]);
+  t.end();
+});
+
+tape('point falls back to rect math for null or singular CTM', t => {
+  const rect = {left: 10, top: 20, width: 100, height: 50};
+  const nullCTM = element(rect, {
+    offsetWidth: 100, offsetHeight: 50, clientLeft: 0, clientTop: 0,
+    getScreenCTM: () => null
+  });
+  t.deepEqual(point({clientX: 60, clientY: 45}, nullCTM), [50, 25]);
+
+  const singular = element(rect, {
+    offsetWidth: 100, offsetHeight: 50, clientLeft: 0, clientTop: 0,
+    getScreenCTM: () => ({a: 0, b: 0, c: 0, d: 0, e: 0, f: 0})
+  });
+  t.deepEqual(point({clientX: 60, clientY: 45}, singular), [50, 25]);
+  t.end();
+});
+
+tape('ctmPoint returns null for missing or singular matrices', t => {
+  t.equal(ctmPoint({clientX: 0, clientY: 0}, null), null);
+  t.equal(ctmPoint({clientX: 0, clientY: 0}, {a: 1, b: 2, c: 2, d: 4, e: 0, f: 0}), null);
+  t.end();
+});
+
+tape('rectPoint uses a caller-provided rect', t => {
+  const el = {offsetWidth: 200, offsetHeight: 100, clientLeft: 1, clientTop: 1};
+  const rect = {left: 5, top: 5, width: 100, height: 50};
+  t.deepEqual(rectPoint({clientX: 55, clientY: 30}, el, rect), [99, 49]);
+  t.end();
+});


### PR DESCRIPTION
Fixes #3475
Addresses #3600

Closes #3978 — credit to @letelete for diagnosing the root cause (event coordinates ignore ancestor CSS `transform: scale(...)`, e.g. in Quarto/RevealJS slides) and for the canvas-path approach of comparing the bounding rect against the untransformed layout size. This PR keeps that idea but avoids the review concerns from #3978: no DOM injection into the renderer-owned SVG, no mutation of element styles, no per-event `querySelector`, and no measurement in viewBox units for the canvas path.

## Design

`vega-scenegraph`'s `point(event, el)` now has two paths:

- **SVG path**: if `el.getScreenCTM` is available (i.e. `el` is the SVG element returned by `SVGRenderer.canvas()`), the client point is mapped through the inverse of the screen CTM. The browser's own coordinate mapping accounts for every ancestor transform, the element's borders/padding, and the viewBox mapping — no injected probe elements needed. If the CTM is `null` (detached/hidden element, jsdom) or singular, we fall back to the rect-based path, preserving current behavior.
- **Canvas path** (and SVG fallback): values from a **single** `getBoundingClientRect()` call are compared against the untransformed layout size: `scaleX = rect.width / el.offsetWidth` (analog for Y). The point is unscaled first, then `clientLeft`/`clientTop` borders (which are layout px) are subtracted. When `offsetWidth`/`offsetHeight` is `0` or `undefined` (jsdom, `display: none`), the scale is 1 and the math reduces exactly to the previous implementation.

## Behavior notes

- **Untransformed charts with default settings are unchanged.** With no ancestor transform, `scaleFactor: 1`, and no CSS resizing, both the CTM path and the rect path produce the same element-relative CSS pixel coordinates as before (the SVG's viewBox units coincide with CSS px because `SVGRenderer.resize` sets `width = _width * _scale`, `height = _height * _scale`, `viewBox = 0 0 _width _height`).
- **Intentional behavior change (SVG only):** when viewBox units and CSS px *diverge* — renderer `scaleFactor ≠ 1`, or responsive CSS sizing of the SVG (e.g. `width: 100%`) — the CTM inverse returns viewBox units, which are the scenegraph's coordinate units that `Handler`/`events-extend` origin subtraction and hit-testing expect. The old rect-based math returned CSS px in those cases, which was incorrect. So the SVG path also fixes event coordinates for scaled/responsively-sized SVG renderers, not just CSS transforms. The canvas path is unchanged in those scenarios (canvas CSS sizing was and remains 1:1 with its layout size unless externally styled).

## Performance

Per event: one `getBoundingClientRect()` + one `offsetWidth`/`offsetHeight` read on the canvas/fallback path, or one `getScreenCTM()` call on the SVG path — at most one layout read more than main, and no per-event `querySelector` or DOM mutation (unlike #3978).

## Manual verification checklist

- [ ] #3475 repro: chart inside a `<div style="transform: scale(0.5)">` wrapper — hover/tooltip/signals track the cursor correctly with `renderer: "canvas"`
- [ ] same with `renderer: "svg"`
- [ ] #3600 repro: Quarto/RevealJS-style nested transforms (scale on a non-immediate ancestor) — both renderers
- [ ] untransformed charts: hover/click/drag behavior identical to current release, both renderers
- [ ] SVG renderer with `scaleFactor: 2`: events now map correctly (previously off by 2×)

🤖 Generated with [Claude Code](https://claude.com/claude-code)