### PR TITLE
chore: bump prettier to 3.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "deps-update",
+  "name": "prettier",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -34,7 +34,7 @@
         "lerna": "^9.0.7",
         "lint-staged": "^16.4.0",
         "pngjs": "^7.0.0",
-        "prettier": "^3.6.2",
+        "prettier": "^3.9.5",
         "rollup": "^4.62.2",
         "rollup-plugin-bundle-size": "^1.0.3",
         "serve": "^14.2.6",
@@ -16018,9 +16018,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
-      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
+      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "lerna": "^9.0.7",
     "lint-staged": "^16.4.0",
     "pngjs": "^7.0.0",
-    "prettier": "^3.6.2",
+    "prettier": "^3.9.5",
     "rollup": "^4.62.2",
     "rollup-plugin-bundle-size": "^1.0.3",
     "serve": "^14.2.6",

--- a/packages/vega-typings/types/runtime/runtime.d.ts
+++ b/packages/vega-typings/types/runtime/runtime.d.ts
@@ -370,7 +370,7 @@ export type Stream = {
   consume?: true;
 } & (
   | // from parsers/stream.js:eventStream -> scope.event
-  {
+    {
       source: 'timer';
       type: number;
     }

--- a/packages/vega-typings/types/spec/config.d.ts
+++ b/packages/vega-typings/types/spec/config.d.ts
@@ -38,13 +38,11 @@ export type KeepSignal<T> = T extends SignalRef ? SignalRef : never;
  */
 export type ExcludeMappedValueRef<T> = {
   [P in keyof T]:
-    | Exclude<T[P], ScaledValueRef<any> | NumericValueRef | ColorValueRef>
-    | KeepSignal<T[P]>;
+    Exclude<T[P], ScaledValueRef<any> | NumericValueRef | ColorValueRef> | KeepSignal<T[P]>;
 };
 
 export interface Config
-  extends Partial<Record<MarkConfigKeys, MarkConfig>>,
-    Partial<Record<AxisConfigKeys, AxisConfig>> {
+  extends Partial<Record<MarkConfigKeys, MarkConfig>>, Partial<Record<AxisConfigKeys, AxisConfig>> {
   autosize?: AutoSize | SignalRef;
   background?: null | Color | SignalRef;
   padding?: Padding | SignalRef;
@@ -78,8 +76,7 @@ export interface Config
  *  The defaults object should have a single property: either "prevent" (to indicate which events should have default behavior suppressed) or "allow" (to indicate only those events whose default behavior should be allowed).
  */
 export type DefaultsConfig =
-  | Record<'prevent', boolean | EventType[]>
-  | Record<'allow', boolean | EventType[]>;
+  Record<'prevent', boolean | EventType[]> | Record<'allow', boolean | EventType[]>;
 
 export type MarkConfigKeys = 'mark' | Mark['type'];
 
@@ -512,14 +509,7 @@ export type Cursor =
   | 'grabbing';
 
 export type AxisConfigKeys =
-  | 'axis'
-  | 'axisX'
-  | 'axisY'
-  | 'axisTop'
-  | 'axisRight'
-  | 'axisBottom'
-  | 'axisLeft'
-  | 'axisBand';
+  'axis' | 'axisX' | 'axisY' | 'axisTop' | 'axisRight' | 'axisBottom' | 'axisLeft' | 'axisBand';
 
 export type AxisConfig = ExcludeMappedValueRef<BaseAxis>;
 

--- a/packages/vega-typings/types/spec/encode.d.ts
+++ b/packages/vega-typings/types/spec/encode.d.ts
@@ -397,19 +397,7 @@ export type TextBaseline = 'alphabetic' | Baseline | 'line-top' | 'line-bottom';
 export type TextDirection = 'ltr' | 'rtl';
 
 export type FontWeight =
-  | 'normal'
-  | 'bold'
-  | 'lighter'
-  | 'bolder'
-  | 100
-  | 200
-  | 300
-  | 400
-  | 500
-  | 600
-  | 700
-  | 800
-  | 900;
+  'normal' | 'bold' | 'lighter' | 'bolder' | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900;
 
 // see https://developer.mozilla.org/en-US/docs/Web/CSS/font-style#Values
 export type FontStyle = 'normal' | 'italic' | 'oblique' | string;
@@ -445,10 +433,4 @@ export interface Encodable<T> {
 export type Encode<T> = Partial<Record<EncodeEntryName, T>>;
 
 export type EncodeEntryName =
-  | 'enter'
-  | 'update'
-  | 'exit'
-  | 'hover'
-  | 'leave'
-  | 'select'
-  | 'release';
+  'enter' | 'update' | 'exit' | 'hover' | 'leave' | 'select' | 'release';

--- a/packages/vega-typings/types/spec/scale.d.ts
+++ b/packages/vega-typings/types/spec/scale.d.ts
@@ -2,14 +2,7 @@ import { SignalRef } from '../index.js';
 import { ColorScheme } from './scheme.js';
 
 export type RangeEnum =
-  | 'width'
-  | 'height'
-  | 'symbol'
-  | 'category'
-  | 'ordinal'
-  | 'ramp'
-  | 'diverging'
-  | 'heatmap';
+  'width' | 'height' | 'symbol' | 'category' | 'ordinal' | 'ramp' | 'diverging' | 'heatmap';
 
 export type RangeRawArray = (number | SignalRef)[];
 export type RangeRaw = (null | boolean | string | number | SignalRef | RangeRawArray)[];
@@ -82,14 +75,7 @@ export interface ScaleBinParams {
 export type ScaleBins = (number | SignalRef)[] | SignalRef | ScaleBinParams;
 
 export type ScaleInterpolateEnum =
-  | 'rgb'
-  | 'lab'
-  | 'hcl'
-  | 'hsl'
-  | 'hsl-long'
-  | 'hcl-long'
-  | 'cubehelix'
-  | 'cubehelix-long';
+  'rgb' | 'lab' | 'hcl' | 'hsl' | 'hsl-long' | 'hcl-long' | 'cubehelix' | 'cubehelix-long';
 
 export interface ScaleInterpolateParams {
   type: 'rgb' | 'cubehelix' | 'cubehelix-long' | SignalRef;
@@ -116,14 +102,7 @@ export type ScaleData = (ScaleDataRef | ScaleMultiDataRef | ScaleMultiFieldsRef)
   sort?: SortField;
 };
 export type QuantScaleType =
-  | 'linear'
-  | 'pow'
-  | 'sqrt'
-  | 'log'
-  | 'symlog'
-  | 'time'
-  | 'utc'
-  | 'sequential';
+  'linear' | 'pow' | 'sqrt' | 'log' | 'symlog' | 'time' | 'utc' | 'sequential';
 export type DiscreteScaleType = 'ordinal' | 'band' | 'point';
 export type DiscretizingScaleType = 'quantile' | 'quantize' | 'threshold' | 'bin-ordinal';
 export type ScaleType = QuantScaleType | DiscreteScaleType | DiscretizingScaleType | 'identity';
@@ -175,14 +154,7 @@ export interface SequentialScale extends NumericScale {
   type: 'sequential';
 }
 export type TimeInterval =
-  | 'millisecond'
-  | 'second'
-  | 'minute'
-  | 'hour'
-  | 'day'
-  | 'week'
-  | 'month'
-  | 'year';
+  'millisecond' | 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'year';
 
 export interface TimeIntervalStep {
   interval: TimeInterval;

--- a/packages/vega-typings/types/spec/scheme.d.ts
+++ b/packages/vega-typings/types/spec/scheme.d.ts
@@ -340,8 +340,4 @@ export type Diverging =
 export type Cyclical = 'rainbow' | 'sinebow';
 
 export type ColorScheme =
-  | Categorical
-  | SequentialSingleHue
-  | SequentialMultiHue
-  | Diverging
-  | Cyclical;
+  Categorical | SequentialSingleHue | SequentialMultiHue | Diverging | Cyclical;


### PR DESCRIPTION
Replaces #4229.

Dependabot's bare bump of prettier fails CI because prettier 3.7+ changed its default formatting (notably, union types that fit within the print width are now collapsed onto a single line), and `vega-typings` runs `prettier --check` in CI. This PR ships the bump together with the required reformat, split into two commits for reviewability:

1. `chore: bump prettier to 3.9` — bumps `prettier` to `^3.9.5` in `package.json` + lockfile.
2. `style: reformat for prettier 3.9` — the mechanical reformat, produced by running the repo's own `npm run format` script in `packages/vega-typings`. Reviewers can safely skip this commit.

Reformatted files:

- `packages/vega-typings/types/runtime/runtime.d.ts`
- `packages/vega-typings/types/spec/config.d.ts`
- `packages/vega-typings/types/spec/encode.d.ts`
- `packages/vega-typings/types/spec/scale.d.ts`
- `packages/vega-typings/types/spec/scheme.d.ts`

Verified locally: prettier check passes, `npm run lint` passes, and the full test suite (`npm run test:no-lint`) passes.

Note: the open `dom/eslint10` branch also touches `package.json`/`package-lock.json`, so whichever of the two PRs merges second will hit a trivial lockfile conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
