### PR TITLE
fix(vega-scenegraph): update canvas style size when devicePixelRatio is 1

### DIFF
--- a/packages/vega-scenegraph/src/util/canvas/resize.js
+++ b/packages/vega-scenegraph/src/util/canvas/resize.js
@@ -16,7 +16,7 @@ export default function(canvas, width, height, origin, scaleFactor, opt) {
     context[key] = opt[key];
   }
 
-  if (inDOM && ratio !== 1) {
+  if (inDOM) {
     canvas.style.width = width + 'px';
     canvas.style.height = height + 'px';
   }

--- a/packages/vega-scenegraph/test/canvas-renderer-test.js
+++ b/packages/vega-scenegraph/test/canvas-renderer-test.js
@@ -76,6 +76,35 @@ tape('CanvasRenderer should use DOM if available', t => {
   t.end();
 });
 
+tape('CanvasRenderer should update canvas style size when devicePixelRatio returns to 1', t => {
+  const dom = new jsdom.JSDOM();
+  global.document = dom.window.document;
+  global.window = dom.window;
+  global.HTMLElement = dom.window.HTMLElement;
+  const setDPR = value =>
+    Object.defineProperty(dom.window, 'devicePixelRatio', {value, configurable: true});
+
+  const r = new Renderer().initialize(document.body, 450, 300);
+  const canvas = r.canvas();
+
+  setDPR(2);
+  r.resize(450, 300);
+  t.strictEqual(canvas.width, 900);
+  t.strictEqual(canvas.style.width, '450px');
+  t.strictEqual(canvas.style.height, '300px');
+
+  setDPR(1);
+  r.resize(650, 400);
+  t.strictEqual(canvas.width, 650);
+  t.strictEqual(canvas.style.width, '650px');
+  t.strictEqual(canvas.style.height, '400px');
+
+  delete global.document;
+  delete global.window;
+  delete global.HTMLElement;
+  t.end();
+});
+
 tape('CanvasRenderer should render scenegraph to canvas', t => {
   const scene = loadScene('scenegraph-rect.json');
   const image = render(scene, 400, 200);


### PR DESCRIPTION
Fixes #4307.

`resize()` writes `canvas.style.width/height` only when the pixel ratio ≠ 1. Since `devicePixelRatio` can change during a canvas's lifetime (window moved between monitors of different densities, browser zoom), a style written at ratio 2 goes stale after a later resize at ratio 1: the bitmap attributes update but the CSS box keeps the old size, so the chart renders smaller than its container. Details, screenshots, and a self-contained repro are in #4307.

The fix makes the style write unconditional on `inDOM` — at ratio 1 it writes the value the browser would infer anyway, so static-DPR behavior is unchanged.

The added regression test drives `CanvasRenderer.resize()` through a 2 → 1 ratio transition under jsdom; it fails without the fix (style stuck at the ratio-2 values) and passes with it. Full vega-scenegraph suite passes (694 tests).
