### PR TITLE
fix(vega-util): restore generic mergeConfig and writeConfig signatures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20148,7 +20148,7 @@
       }
     },
     "packages/vega-util": {
-      "version": "2.1.1",
+      "version": "2.1.2",
       "license": "BSD-3-Clause"
     },
     "packages/vega-view": {

--- a/packages/vega-util/package.json
+++ b/packages/vega-util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vega-util",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "JavaScript utilities for Vega.",
   "keywords": [
     "vega",

--- a/packages/vega-util/src/mergeConfig.ts
+++ b/packages/vega-util/src/mergeConfig.ts
@@ -35,9 +35,12 @@ type RecurseStrategy = Record<string, unknown> | boolean | null;
 
 /** Merges Vega config objects. Signals merged by name (source takes precedence),
  * legend.layout recursively merged, style fully recursive, others shallow.
- * Return type is compatible with vega-typings Config. */
-export function mergeConfig(...configs: Partial<VegaConfig>[]): VegaConfig {
-  return configs.reduce((out, source) => {
+ *
+ * The signature is generic because declared interfaces such as the vega-typings
+ * and vega-lite `Config` types have no implicit index signature and would not be
+ * assignable to the internal structural types. */
+export function mergeConfig<C extends object>(...configs: C[]): C {
+  return (configs as Partial<VegaConfig>[]).reduce((out, source) => {
     for (const key in source) {
       if (key === 'signals') {
         // for signals, we merge the signals arrays
@@ -56,31 +59,33 @@ export function mergeConfig(...configs: Partial<VegaConfig>[]): VegaConfig {
       }
     }
     return out;
-  }, {} as VegaConfig);
+  }, {} as VegaConfig) as C;
 }
 
-/** Writes config value to output with optional recursion, rejecting illegal keys that could be used to modify the prototype chain */
-export function writeConfig(
-  output: ConfigObject,
+/** Writes config value to output with optional recursion, rejecting illegal keys that could be used to modify the prototype chain.
+ * Generic for the same reason as mergeConfig. */
+export function writeConfig<C extends object>(
+  output: C,
   key: string,
-  value: ConfigValue,
-  recurse?: RecurseStrategy
+  value: unknown,
+  recurse?: boolean | object | null
 ): void {
   if (!isLegalKey(key)) return;
 
+  const out = output as ConfigObject;
   let k: string, o: ConfigObject;
   if (isObject(value) && !isArray(value)) {
     const valueObj = value as ConfigObject;
-    o = (isObject(output[key]) ? output[key] : (output[key] = {})) as ConfigObject;
+    o = (isObject(out[key]) ? out[key] : (out[key] = {})) as ConfigObject;
     for (k in valueObj) {
-      if (recurse && (recurse === true || recurse[k])) {
+      if (recurse && (recurse === true || (recurse as Record<string, unknown>)[k])) {
         writeConfig(o, k, valueObj[k]);
       } else if (isLegalKey(k)) {
         o[k] = valueObj[k];
       }
     }
   } else {
-    output[key] = value;
+    out[key] = value as ConfigValue;
   }
 }
 

--- a/packages/vega-util/src/mergeConfig.ts
+++ b/packages/vega-util/src/mergeConfig.ts
@@ -36,11 +36,12 @@ type RecurseStrategy = Record<string, unknown> | boolean | null;
 /** Merges Vega config objects. Signals merged by name (source takes precedence),
  * legend.layout recursively merged, style fully recursive, others shallow.
  *
- * The signature is generic because declared interfaces such as the vega-typings
- * and vega-lite `Config` types have no implicit index signature and would not be
- * assignable to the internal structural types. */
-export function mergeConfig<C extends object>(...configs: C[]): C {
-  return (configs as Partial<VegaConfig>[]).reduce((out, source) => {
+ * The public signature is generic because declared interfaces such as the
+ * vega-typings and vega-lite `Config` types have no implicit index signature
+ * and would not be assignable to the internal structural types. */
+export function mergeConfig<C extends object>(...configs: C[]): C;
+export function mergeConfig(...configs: Partial<VegaConfig>[]): VegaConfig {
+  return configs.reduce<VegaConfig>((out, source) => {
     for (const key in source) {
       if (key === 'signals') {
         // for signals, we merge the signals arrays
@@ -59,13 +60,12 @@ export function mergeConfig<C extends object>(...configs: C[]): C {
       }
     }
     return out;
-  }, {} as VegaConfig) as C;
+  }, {});
 }
 
-/** Writes config value to output with optional recursion, rejecting illegal keys that could be used to modify the prototype chain.
- * Generic for the same reason as mergeConfig. */
-export function writeConfig<C extends object>(
-  output: C,
+/** Writes config value to output with optional recursion, rejecting illegal keys that could be used to modify the prototype chain */
+export function writeConfig(
+  output: object,
   key: string,
   value: unknown,
   recurse?: boolean | object | null


### PR DESCRIPTION
## Problem

vega-util 2.1.1 (published with the v6.3.x wave) shipped the TypeScript-migrated `mergeConfig` for the first time. The migration (#4218) replaced the previous hand-written generic declaration

```ts
export function mergeConfig<C extends object>(...c: C[]): C;
```

with a signature based on the implementation's internal structural types:

```ts
export function mergeConfig(...configs: Partial<VegaConfig>[]): VegaConfig;
// where VegaConfig / NamedSignal require [key: string]: ConfigValue index signatures
```

The internal types claim to be "compatible with vega-typings Config", but they are not: **declared interfaces have no implicit index signature in TypeScript**, so the vega-typings `Config`, `InitSignal`, `NewSignal` and vega-lite `Config` interfaces are not assignable to them. Every real-world call now fails to compile:

```
error TS2345: Argument of type 'Config' is not assignable to parameter of type 'Partial<VegaConfig>'.
  ...
    Index signature for type 'string' is missing in type 'InitSignal'.
```

This broke the Vega editor build on upgrade, and will break vega-embed / vega-themes / any TS consumer that merges configs the way our docs recommend.

## Fix

- `mergeConfig`: restore the generic public signature via an overload; the implementation signature keeps the structural types, so the body needs no casts and only the generic overload is emitted to the `.d.ts`:

  ```ts
  export function mergeConfig<C extends object>(...configs: C[]): C;
  export function mergeConfig(...configs: Partial<VegaConfig>[]): VegaConfig { ... }
  ```

- `writeConfig`: `output: object` (the old generic `<C extends object>(output: C, ...)` was only referenced by that one parameter, so it accepted the identical argument set).

Types-only change — no runtime impact. `debounce` is intentionally left with its new, stricter typing: unlike the old `F extends Function → F` declaration, it correctly documents that the wrapper forwards only a single argument.

## Alternatives considered (and verified with tsc)

- Structural constraint `<C extends {signals?: readonly {name: string}[]}>` — rejects any config type without a `signals` member (weak-type rule), and adds almost no checking: bad signal literals are already caught via contextual typing when another argument supplies the signal type.
- `...configs: Partial<C>[]` — breaks heterogeneous calls (e.g. vega-embed's `VgConfig | VlConfig` union), and reverse-mapped inference strips optionality, producing an all-required return type.
- Intersection return (`UnionToIntersection`) — collapses to `never` on conflicting property types and claims merged properties that runtime overwrites.

The generic signature accepts exactly the historical set of callers, including the union-typed configs vega-embed produces.

## Release

Bumps vega-util to **2.1.2** so this can go out as a single-package patch release (`lerna publish from-package` will publish only vega-util; all dependents use `^2.1.x` ranges and pick it up automatically).

## Testing

- `npm test` in vega-util passes
- Verified the emitted `.d.ts` and type-checked the previously-failing patterns against vega-typings:

```ts
declare const vgConfig: Config;
const merged: Config = mergeConfig({}, vgConfig, vgConfig);           // ✅ compiles again
const withSignals: Config = mergeConfig(vgConfig, {signals});          // ✅ (InitSignal | NewSignal)[]
writeConfig(vgConfig, 'legend', {layout: {}}, {layout: 1});            // ✅
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)