### PR TITLE
feat: expose projection translation

### DIFF
--- a/docs/docs/expressions.md
+++ b/docs/docs/expressions.md
@@ -865,6 +865,10 @@ Returns the projected planar centroid (typically in pixels) for the specified Ge
 <b>geoScale</b>(<i>projection</i>[, <i>group</i>])<br/>
 Returns the scale value for the named _projection_. The optional _group_ argument takes a scenegraph group mark item to indicate the specific scope in which to look up the projection.
 
+<a name="geoTranslate" href="#geoTranslate">#</a>
+<b>geoTranslate</b>(<i>projection</i>[, <i>group</i>])<br/>
+Returns the two-element translation array for the named _projection_. The optional _group_ argument takes a scenegraph group mark item to indicate the specific scope in which to look up the projection.
+
 [Back to Top](#reference)
 
 

--- a/packages/vega-functions/README.md
+++ b/packages/vega-functions/README.md
@@ -103,6 +103,7 @@ This package provides the following expression functions. All other constants an
 - [geoBounds](https://vega.github.io/vega/docs/expressions/#geoBounds)
 - [geoCentroid](https://vega.github.io/vega/docs/expressions/#geoCentroid)
 - [geoScale](https://vega.github.io/vega/docs/expressions/#geoScale)
+- [geoTranslate](https://vega.github.io/vega/docs/expressions/#geoTranslate)
 
 **Shape Functions**
 

--- a/packages/vega-functions/index.js
+++ b/packages/vega-functions/index.js
@@ -24,7 +24,8 @@ export {
   geoArea,
   geoBounds,
   geoCentroid,
-  geoScale
+  geoScale,
+  geoTranslate
 } from './src/functions/geo.js';
 
 export {

--- a/packages/vega-functions/src/codegen.js
+++ b/packages/vega-functions/src/codegen.js
@@ -119,7 +119,8 @@ import {
   geoArea,
   geoBounds,
   geoCentroid,
-  geoScale
+  geoScale,
+  geoTranslate
 } from './functions/geo.js';
 
 import inScope from './functions/inscope.js';
@@ -362,6 +363,7 @@ expressionFunction('geoBounds', geoBounds, scaleVisitor);
 expressionFunction('geoCentroid', geoCentroid, scaleVisitor);
 expressionFunction('geoShape', geoShape, scaleVisitor);
 expressionFunction('geoScale', geoScale, scaleVisitor);
+expressionFunction('geoTranslate', geoTranslate, scaleVisitor);
 expressionFunction('indata', indata, indataVisitor);
 expressionFunction('data', data, dataVisitor);
 expressionFunction('treePath', treePath, dataVisitor);

--- a/packages/vega-functions/src/functions/geo.js
+++ b/packages/vega-functions/src/functions/geo.js
@@ -26,3 +26,8 @@ export function geoScale(projection, group) {
   const p = getScale(projection, (group || this).context);
   return p && p.scale();
 }
+
+export function geoTranslate(projection, group) {
+  const p = getScale(projection, (group || this).context);
+  return p && p.translate();
+}

--- a/packages/vega-functions/test/geo-test.js
+++ b/packages/vega-functions/test/geo-test.js
@@ -1,0 +1,22 @@
+import tape from 'tape';
+import { registerScale } from 'vega-scale';
+import { geoScale, geoTranslate } from '../index.js';
+
+tape('geoScale and geoTranslate return projection parameters', t => {
+  const projection = registerScale(() => {});
+  projection.scale = () => 150;
+  projection.translate = () => [320, 180];
+
+  const context = {
+    context: {
+      scales: {
+        projection: { value: projection }
+      }
+    }
+  };
+
+  t.equal(geoScale.call(context, 'projection'), 150);
+  t.deepEqual(geoTranslate.call(context, 'projection'), [320, 180]);
+  t.equal(geoTranslate.call(context, 'missing'), undefined);
+  t.end();
+});

--- a/packages/vega-typings/tests/spec/valid/basemap.ts
+++ b/packages/vega-typings/tests/spec/valid/basemap.ts
@@ -68,6 +68,7 @@ export const spec: Spec = {
   ],
   signals: [
     { name: 'projection_scale', update: "geoScale('projection')" },
+    { name: 'projection_translate', update: "geoTranslate('projection')" },
     {
       name: 'base_tile_size',
       update: '(2 * PI * projection_scale) / pow(2, zoom_level)'

--- a/packages/vega/test/specs-valid/basemap.vg.json
+++ b/packages/vega/test/specs-valid/basemap.vg.json
@@ -60,6 +60,7 @@
   ],
   "signals": [
     {"name": "projection_scale", "update": "geoScale('projection')"},
+    {"name": "projection_translate", "update": "geoTranslate('projection')"},
     {
       "name": "base_tile_size",
       "update": "(2 * PI * projection_scale) / pow(2, zoom_level)"


### PR DESCRIPTION
This PR aims to unblock https://github.com/vega/vega-lite/pull/9835 and add pan and zoom to maps in Vega-Lite. The change is pretty small and just adds a `geoTranslate()` expression function that returns the effective translation of a named geographic projection. The API mirrors the existing `geoScale()` expression function (added in https://github.com/vega/vega/pull/3767): `geoTranslate("projection")`. It returns the projection translation as a two-element [x, y] array. An optional scenegraph group argument can be supplied to resolve projections in nested scopes.

This is needed when handing an automatically fitted projection over to signal-driven interaction. Vega projections using fit internally calculate both a scale and a translation. The fitted scale is available through geoScale(), but there is currently no corresponding way to read the fitted translation.

Consumers such as Vega-Lite therefore cannot preserve the complete fitted projection state when enabling pan and zoom. Replacing the fitted translation with an approximation such as `[width / 2, height / 2]` can cause a visible jump on the first interaction as seen in https://github.com/vega/vega-lite/pull/9835.

For example, a fitted Mercator projection in an 800 × 450 view may have:

```
scale:     74.59322491656901
translate: [400, 215.65847259433917]
```

Using `[400, 225]` when disabling fit moves the map by approximately 9 pixels. With geoTranslate(), clients can capture both fitted parameters before handing control to interaction signals:

```json
{
  "name": "panAnchor",
  "on": [
    {
      "events": "pointerdown",
      "update": "{scale: geoScale('projection'), translate: geoTranslate('projection')}"
    }
  ]
}
```


The following Vega chart captures the yanky behavior before the PR,  which is the same as in the gif in https://github.com/vega/vega-lite/pull/9835:  [Open the Chart in the Vega Editor](https://vega.github.io/editor/#/url/vega/N4IgJAzgxgFgpgWwIYgFwhgF0wBwqgegIDc4BzJAOjIEtMYBXAI0poHsDp5kTykSAbJQBWENgDsQAGhAATONABONHJnaT0AJTg5FbWQygKABPTjGAZnUxxZAWl1thcKGonGcScQQBebNgjGwgwIOMYA7nQwbAyYxmRwbAAqil4QADZINpTSIJGy9GgAHAAMJTLwNGRYaAAsAKzlIEixbBA0PnBoIOISXTLtZOJI6RBoANqgwwhd6I7OruoAYnS5NOKr6LJZSAAUAOThbIrpsvsAlLkSE6BwpOKYY6igg8Pp3Z7iACJw6ZgoAF8ZAwcNsbN1xAx0u8gbd7o80C8qm9un4Aj8-oDgaCsrMelCYVI4XAHk85Ex0lB0jQoABrXIgsF4sF7Q7HU4XEAAgC6sJ6SBmHz0Czc4gAylARv0QMQRgxZgBGGTXVCTEB3EkIuZsdY2RSyNjhSTYpndBJsCVSg7zFyizl8jWkxEgV4jVH+BAY-5ck2490BACC4lgx0o0ClxgIxjRnt+3p5fOmeJtiwkKTSmXBMll6XlE1qZSkACYi-VucqNGrHVqkUM3XMvF6sSBGX70ONPkGQ4pKJhUuIMrjxiVucY7B5G3GqAAPKQT8Rd6I9vsZocK0fjz5NygAT25PuJTueLuR9ZAMabPpbOPB7Zji9D0+MAGpjLt78Gl73+4ObMON9GHoPj207nJGgHolOc4ft2u4vm+MFfiuA6ZnA4zrmOEEIMBu5gVGF5TvuCZEvygoNgun7HLkOZ5se05oE0O4MTIyG-rMw5SCOQIgCqVbwmSOA6g8cD6oaxrXqa6DANOqDGNOuznHOO6yTuClzqxqGySmorpihuIAlyvIkUmHyTpi1FyrMoD0agjEMdxvGHlqIAdkJeoGkac6ROIHmoIJuoiSCo4AHwROsvn+cJigIGwpAAIQMjeeLSVpXg4U+47yYpxjKfOOE7phqnnAZxFTAKeKIVR2aWc6Nl2bZAySukiosT+qETOUXEVjc6r8d04TwL8CW+reIApXJak5Spk3hs1snmpazXWsKtrqBc6ltbiWkram4i6WxJVGWVZHnh6l7VbmLU8ZWTlkgNcBDbkFjHEYaB9vKI3JoauwKpQZRKsY1aUPImIAJrGAAVB430KgIc5AyD-wALL6HA5yXAm5ZyDsPUmegRwnLIDInN0WC4PgRCkBQ1BRMwrAcFTSB2CyEBwI8BAsgQBOnHYCoKiUCAiGI4nPdFWTOpgO44HimBsIJojXDIFhwFkDCKHiUAxA8ygKFyPIyNp6hPGqeMgIbisgJL0vdDMiiSrLii5O0nTOq67ztvk9BzpU1SYERSubLWKJzDtoorJgV6zVZJ51u7Zuh+oi1dNxGltkHZ7m3tm3ggC+sgMgii0sboBW3iEAwEg1tK3oCDOiy-XskT3FUiob2KB96rBqjzqaiJzpWNCzo0XiADEsjK0Usj1JHfZsLS0fD90I8AOwWEUUDL82ECz-PADqNAFDAQ81bZlD1LnKc-qLteqiXUt4ua5eV9KmdCk4q3XJjAJAA)

The updated spec after this PR that uses `geoTranslate` to create smooth pan and zoom would look like this:

<details><summary>Click to view spec</summary>


```json
{
  "$schema": "https://vega.github.io/schema/vega/v6.json",
  "description": "A fitted world map with smooth pan and zoom using geoTranslate.",
  "width": 800,
  "height": 450,
  "autosize": "none",
  "signals": [
    {
      "name": "projectionFit",
      "init": "data('world')",
      "on": [
        {
          "events": {"signal": "panDelta"},
          "update": "null"
        },
        {
          "events": {"signal": "zoomDelta"},
          "update": "null"
        },
        {
          "events": "dblclick",
          "update": "data('world')"
        }
      ]
    },
    {
      "name": "projectionScale",
      "value": 1,
      "on": [
        {
          "events": "pointerdown",
          "update": "geoScale('projection')"
        },
        {
          "events": {"signal": "zoomDelta"},
          "update": "zoomAnchor.scale / zoomDelta"
        }
      ]
    },
    {
      "name": "projectionTranslate",
      "value": [400, 225],
      "on": [
        {
          "events": {"signal": "panDelta"},
          "update": "[panAnchor.translate[0] - panDelta.x, panAnchor.translate[1] - panDelta.y]"
        },
        {
          "events": {"signal": "zoomDelta"},
          "update": "[zoomAnchor.x + (zoomAnchor.translate[0] - zoomAnchor.x) / zoomDelta, zoomAnchor.y + (zoomAnchor.translate[1] - zoomAnchor.y) / zoomDelta]"
        }
      ]
    },
    {
      "name": "panAnchor",
      "value": {
        "x": 0,
        "y": 0,
        "translate": [0, 0]
      },
      "on": [
        {
          "events": "pointerdown",
          "update": "{x: x(), y: y(), translate: geoTranslate('projection')}"
        }
      ]
    },
    {
      "name": "panDelta",
      "value": {
        "x": 0,
        "y": 0
      },
      "on": [
        {
          "events": "[pointerdown, window:pointerup] > window:pointermove!",
          "update": "{x: panAnchor.x - x(), y: panAnchor.y - y()}"
        }
      ]
    },
    {
      "name": "zoomAnchor",
      "value": {
        "x": 0,
        "y": 0,
        "scale": 1,
        "translate": [0, 0]
      },
      "on": [
        {
          "events": "wheel!",
          "update": "{x: x(), y: y(), scale: geoScale('projection'), translate: geoTranslate('projection')}"
        }
      ]
    },
    {
      "name": "zoomDelta",
      "value": 1,
      "on": [
        {
          "events": "wheel!",
          "force": true,
          "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
        }
      ]
    },
    {
      "name": "actualScale",
      "update": "geoScale('projection')"
    },
    {
      "name": "actualTranslate",
      "update": "geoTranslate('projection')"
    }
  ],
  "data": [
    {
      "name": "world",
      "url": "https://vega.github.io/vega-datasets/data/world-110m.json",
      "format": {
        "type": "topojson",
        "feature": "countries"
      }
    }
  ],
  "projections": [
    {
      "name": "projection",
      "type": "mercator",
      "size": {
        "signal": "[width, height]"
      },
      "fit": {
        "signal": "projectionFit"
      },
      "scale": {
        "signal": "projectionScale"
      },
      "translate": {
        "signal": "projectionTranslate"
      }
    }
  ],
  "marks": [
    {
      "type": "shape",
      "from": {
        "data": "world"
      },
      "clip": true,
      "encode": {
        "enter": {
          "fill": {
            "value": "#dfe8d5"
          },
          "stroke": {
            "value": "#7f8c7a"
          },
          "strokeWidth": {
            "value": 0.5
          }
        }
      },
      "transform": [
        {
          "type": "geoshape",
          "projection": "projection"
        }
      ]
    }
  ]
}

```

</details>