### PR TITLE
feat(schema): add description property to data, transform, scale, projection

### DIFF
--- a/packages/vega-schema/src/data.js
+++ b/packages/vega-schema/src/data.js
@@ -60,6 +60,7 @@ const dataFormat = anyOf(
 
 const dataProps = {
   _name_: stringType,
+  description: stringType,
   transform: array(transformRef),
   on: onTriggerRef
 };

--- a/packages/vega-schema/src/projection.js
+++ b/packages/vega-schema/src/projection.js
@@ -9,6 +9,7 @@ const extent = orSignal(array(array2, {minItems: 2, maxItems: 2}));
 
 const projection = object({
   _name_: stringType,
+  description: stringType,
   type: stringOrSignal,
   clipAngle: numberOrSignal,
   clipExtent: extent,

--- a/packages/vega-schema/src/scale.js
+++ b/packages/vega-schema/src/scale.js
@@ -143,6 +143,7 @@ const scaleData = oneOf(
 );
 
 const scaleDomainProps = {
+  description: stringType,
   _name_: stringType,
   domain: oneOf(arrayAllTypes, scaleDataRef, signalRef),
   domainMin: numberOrSignal,

--- a/packages/vega-schema/src/transform.js
+++ b/packages/vega-schema/src/transform.js
@@ -33,6 +33,7 @@ function transformSchema(name, def) {
 
   const props = {
     _type_: enums([name]),
+    description: stringType,
     signal: stringType
   };
 


### PR DESCRIPTION
## Summary

Adds a `description?: string` property to the JSON schema for **data**, **transform**, **scale**, and **projection** objects. Mirrors the pattern already used by `mark`, `signal`, `axis`, and `legend`. Annotation-only — does not affect runtime behavior, just lets spec authors document complex Vega specifications.

Closes the schema side of the FastLane bounty at https://github.com/vega/vega/discussions/4234 ($30).

## Changes

- `packages/vega-schema/src/data.js` — adds `description: stringType` to `dataProps` (4 variants)
- `packages/vega-schema/src/transform.js` — adds `description: stringType` to `transformSchema` props (51 transform variants)
- `packages/vega-schema/src/scale.js` — adds `description: stringType` to `scaleDomainProps` (12 scale variants)
- `packages/vega-schema/src/projection.js` — adds `description: stringType` to projection

Each addition is a single line.

## Verification

- `vega-schema`'s `npm test` regenerates `vega-schema.json` cleanly.
- Probe confirms `description` lands on 4/4 data variants, 12/12 scale variants, 1/1 projection, 51/51 transforms.
- No runtime changes.

## Follow-ups

1. Runtime preservation in `vega-parser` (description survives in parsed items) — happy to send as a separate PR.
2. Docs additions in `docs/docs/{data,transforms,scales,projections}.md` — easy follow-up.

## Notes

Picking this up under the FastLane pilot at discussion #4234. Payout Venmo / PayPal / GitHub Sponsors — whichever is easiest. Will update the discussion thread once the PR is open.