### PR TITLE
test(vega): load basemap's topojson from local test data

### DIFF
--- a/packages/vega/test/specs-valid/basemap.vg.json
+++ b/packages/vega/test/specs-valid/basemap.vg.json
@@ -31,7 +31,7 @@
     },
     {
       "name": "source_0",
-      "url": "https://cdn.jsdelivr.net/npm/vega-datasets@v1.29.0/data/world-110m.json",
+      "url": "data/world-110m.json",
       "format": {"feature": "countries", "type": "topojson"},
       "transform": [
         {


### PR DESCRIPTION
fixing test flakiness in basemap, which was messing up CI in https://github.com/vega/vega/pull/4061.

claude says:

> basemap was the only one of the 116 valid specs that fetched its data from a third-party CDN at test time. When that request fails on a CI runner -- rate limiting, a transient outage -- vega-dataflow logs a warning and pulses an empty dataset rather than throwing, so the spec still renders, just with none of its 177 country shapes. The scene test then fails at the sceneEqual comparison with nothing in the output pointing at the network.
> 
> The suite only started comparing scenegraphs in #4305; before that it regenerated them, so this dependency never had a chance to bite.
> 
> vega-datasets' world-110m.json is already vendored in test/data and is byte for byte identical to the pinned CDN copy, so just load it from there like every other spec does. The golden is unchanged.
> 
> The OpenStreetMap tile URLs in the spec are left alone: they are built by a formula into image mark urls, and image marks only load through a renderer, so they are never fetched under renderer: 'none'.
> 
> With this the scene suite passes 115/115 with all outbound network calls blocked; without it, basemap fails.
>
> **Note**: A failed load stays invisible in these tests. If it bites again, the clean fix is probably raising the default log level for the whole suite rather than filtering individual messages.