### PR TITLE
feat(vega-functions): add easing functions and interpolateLinear

### DIFF
--- a/docs/docs/expressions.md
+++ b/docs/docs/expressions.md
@@ -283,7 +283,9 @@ Trigonometric tangent. Same as JavaScript's [`Math.tan`](https://developer.mozil
 
 ## <a name="easing-functions"></a>Easing Functions
 
-Easing functions shape the rate of change of an animation over time. Each takes a normalized time _t_ in the interval [0, 1] and returns an eased position, also in [0, 1], with `f(0) === 0` and `f(1) === 1`. These are the [d3-ease](https://github.com/d3/d3-ease) implementations, exposed under their d3 names.
+Easing functions shape the rate of change of an animation over time. Each takes a normalized time _t_ in the interval [0, 1] and returns an eased position, with `f(0) === 0` and `f(1) === 1`. These are the [d3-ease](https://github.com/d3/d3-ease) implementations, exposed under their d3 names.
+
+Most families return a position within [0, 1], but the `easeBack` and `easeElastic` families deliberately overshoot: across their variants, `easeBack` spans about [-0.1, 1.1] and `easeElastic` spans about [-0.373, 1.373]. If a downstream calculation requires a value within the unit interval, clamp the result, for example `clamp(easeElastic(t), 0, 1)`.
 
 Every family below is available in three variants: `In` (slow start), `Out` (slow finish), and `InOut` (slow start and finish). The bare name is an alias for the `InOut` variant, except for `easeLinear`, which has no variants.
 
@@ -321,11 +323,11 @@ Bounce easing, as in a ball falling on a hard surface. Note that `easeBounce` al
 
 <a name="easeBack" href="#easeBack">#</a>
 <b>easeBack</b>(<i>t</i>), <b>easeBackIn</b>(<i>t</i>), <b>easeBackOut</b>(<i>t</i>), <b>easeBackInOut</b>(<i>t</i>)<br/>
-Anticipatory easing, which overshoots its range, with d3's default overshoot.
+Anticipatory easing, which backs up before advancing toward its target, with d3's default overshoot. Across its variants the returned position spans about [-0.1, 1.1].
 
 <a name="easeElastic" href="#easeElastic">#</a>
 <b>easeElastic</b>(<i>t</i>), <b>easeElasticIn</b>(<i>t</i>), <b>easeElasticOut</b>(<i>t</i>), <b>easeElasticInOut</b>(<i>t</i>)<br/>
-Elastic easing, like a rubber band, with d3's default amplitude and period. Note that `easeElastic` aliases `easeElasticOut`, following d3.
+Elastic easing, like a rubber band, with d3's default amplitude and period. Across its variants the returned position spans about [-0.373, 1.373]. Note that `easeElastic` aliases `easeElasticOut`, following d3.
 
 [Back to Top](#reference)
 

--- a/docs/docs/expressions.md
+++ b/docs/docs/expressions.md
@@ -21,6 +21,7 @@ This page documents the expression language. If you are interested in implementa
 - [Type Coercion Functions](#type-coercion-functions)
 - [Control Flow Functions](#control-flow-functions)
 - [Math Functions](#math-functions)
+- [Easing Functions](#easing-functions)
 - [Statistical Functions](#statistical-functions)
 - [Date-Time Functions](#datetime-functions)
 - [Array Functions](#array-functions)
@@ -280,6 +281,55 @@ Trigonometric tangent. Same as JavaScript's [`Math.tan`](https://developer.mozil
 [Back to Top](#reference)
 
 
+## <a name="easing-functions"></a>Easing Functions
+
+Easing functions shape the rate of change of an animation over time. Each takes a normalized time _t_ in the interval [0, 1] and returns an eased position, also in [0, 1], with `f(0) === 0` and `f(1) === 1`. These are the [d3-ease](https://github.com/d3/d3-ease) implementations, exposed under their d3 names.
+
+Every family below is available in three variants: `In` (slow start), `Out` (slow finish), and `InOut` (slow start and finish). The bare name is an alias for the `InOut` variant, except for `easeLinear`, which has no variants.
+
+<a name="easeLinear" href="#easeLinear">#</a>
+<b>easeLinear</b>(<i>t</i>)<br/>
+The identity function; the animation proceeds at a constant rate.
+
+<a name="easeQuad" href="#easeQuad">#</a>
+<b>easeQuad</b>(<i>t</i>), <b>easeQuadIn</b>(<i>t</i>), <b>easeQuadOut</b>(<i>t</i>), <b>easeQuadInOut</b>(<i>t</i>)<br/>
+Quadratic easing (_t_<sup>2</sup>).
+
+<a name="easeCubic" href="#easeCubic">#</a>
+<b>easeCubic</b>(<i>t</i>), <b>easeCubicIn</b>(<i>t</i>), <b>easeCubicOut</b>(<i>t</i>), <b>easeCubicInOut</b>(<i>t</i>)<br/>
+Cubic easing (_t_<sup>3</sup>).
+
+<a name="easePoly" href="#easePoly">#</a>
+<b>easePoly</b>(<i>t</i>), <b>easePolyIn</b>(<i>t</i>), <b>easePolyOut</b>(<i>t</i>), <b>easePolyInOut</b>(<i>t</i>)<br/>
+Polynomial easing, with d3's default exponent of 3.
+
+<a name="easeSin" href="#easeSin">#</a>
+<b>easeSin</b>(<i>t</i>), <b>easeSinIn</b>(<i>t</i>), <b>easeSinOut</b>(<i>t</i>), <b>easeSinInOut</b>(<i>t</i>)<br/>
+Sinusoidal easing.
+
+<a name="easeExp" href="#easeExp">#</a>
+<b>easeExp</b>(<i>t</i>), <b>easeExpIn</b>(<i>t</i>), <b>easeExpOut</b>(<i>t</i>), <b>easeExpInOut</b>(<i>t</i>)<br/>
+Exponential easing (2<sup>_t_</sup>).
+
+<a name="easeCircle" href="#easeCircle">#</a>
+<b>easeCircle</b>(<i>t</i>), <b>easeCircleIn</b>(<i>t</i>), <b>easeCircleOut</b>(<i>t</i>), <b>easeCircleInOut</b>(<i>t</i>)<br/>
+Circular easing.
+
+<a name="easeBounce" href="#easeBounce">#</a>
+<b>easeBounce</b>(<i>t</i>), <b>easeBounceIn</b>(<i>t</i>), <b>easeBounceOut</b>(<i>t</i>), <b>easeBounceInOut</b>(<i>t</i>)<br/>
+Bounce easing, as in a ball falling on a hard surface. Note that `easeBounce` aliases `easeBounceOut`, following d3.
+
+<a name="easeBack" href="#easeBack">#</a>
+<b>easeBack</b>(<i>t</i>), <b>easeBackIn</b>(<i>t</i>), <b>easeBackOut</b>(<i>t</i>), <b>easeBackInOut</b>(<i>t</i>)<br/>
+Anticipatory easing, which overshoots its range, with d3's default overshoot.
+
+<a name="easeElastic" href="#easeElastic">#</a>
+<b>easeElastic</b>(<i>t</i>), <b>easeElasticIn</b>(<i>t</i>), <b>easeElasticOut</b>(<i>t</i>), <b>easeElasticInOut</b>(<i>t</i>)<br/>
+Elastic easing, like a rubber band, with d3's default amplitude and period. Note that `easeElastic` aliases `easeElasticOut`, following d3.
+
+[Back to Top](#reference)
+
+
 ## <a name="statistical-functions"></a>Statistical Functions
 
 Methods for sampling and calculating values for probability distributions.
@@ -501,6 +551,10 @@ Returns the length of the input _array_.
 <a name="lerp" href="#lerp">#</a>
 <b>lerp</b>(<i>array</i>, <i>fraction</i>)<br/>
 Returns the linearly interpolated value between the first and last entries in the _array_ for the provided interpolation _fraction_ (typically between 0 and 1). For example, `lerp([0, 50], 0.5)` returns 25.
+
+<a name="interpolateLinear" href="#interpolateLinear">#</a>
+<b>interpolateLinear</b>(<i>array</i>, <i>fraction</i>)<br/>
+Returns the piecewise-linearly interpolated value across _all_ entries in the _array_ for the provided interpolation _fraction_ (typically between 0 and 1). The entries are treated as evenly-spaced control points, and interpolation occurs within whichever segment _fraction_ falls into. Unlike [lerp](#lerp), which considers only the first and last entries, this respects intermediate values: `interpolateLinear([0, 100, 10], 0.5)` returns 100, whereas `lerp([0, 100, 10], 0.5)` returns 5.
 
 <a name="peek" href="#peek">#</a>
 <b>peek</b>(<i>array</i>)<br/>

--- a/docs/docs/expressions.md
+++ b/docs/docs/expressions.md
@@ -285,7 +285,7 @@ Trigonometric tangent. Same as JavaScript's [`Math.tan`](https://developer.mozil
 
 Easing functions shape the rate of change of an animation over time. Each takes a normalized time _t_ in the interval [0, 1] and returns an eased position, with `f(0) === 0` and `f(1) === 1`. These are the [d3-ease](https://github.com/d3/d3-ease) implementations, exposed under their d3 names.
 
-Most families return a position within [0, 1], but the `easeBack` and `easeElastic` families deliberately overshoot: across their variants, `easeBack` spans about [-0.1, 1.1] and `easeElastic` spans about [-0.373, 1.373]. If a downstream calculation requires a value within the unit interval, clamp the result, for example `clamp(easeElastic(t), 0, 1)`.
+Most families return a position within [0, 1], but the `easeBack` and `easeElastic` families deliberately overshoot it. If a downstream calculation requires a value within the unit interval, clamp the result, for example `clamp(easeElastic(t), 0, 1)`.
 
 Every family below is available in three variants: `In` (slow start), `Out` (slow finish), and `InOut` (slow start and finish). The bare name is an alias for the `InOut` variant, except for `easeLinear`, which has no variants.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8446,6 +8446,15 @@
         "node": ">= 10"
       }
     },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-force": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
@@ -19924,6 +19933,7 @@
       "dependencies": {
         "d3-array": "^3.2.4",
         "d3-color": "^3.1.0",
+        "d3-ease": "^3.0.1",
         "d3-geo": "^3.1.1",
         "vega-dataflow": "^6.1.2",
         "vega-expression": "^6.2.1",

--- a/packages/vega-functions/README.md
+++ b/packages/vega-functions/README.md
@@ -28,6 +28,21 @@ This package provides the following expression functions. All other constants an
 
 - [random](https://vega.github.io/vega/docs/expressions/#random)
 
+**Easing Functions**
+
+Each family below is also provided in `In`, `Out` and `InOut` variants (for example, `easeQuadIn`), except for `easeLinear`.
+
+- [easeLinear](https://vega.github.io/vega/docs/expressions/#easeLinear)
+- [easeQuad](https://vega.github.io/vega/docs/expressions/#easeQuad)
+- [easeCubic](https://vega.github.io/vega/docs/expressions/#easeCubic)
+- [easePoly](https://vega.github.io/vega/docs/expressions/#easePoly)
+- [easeSin](https://vega.github.io/vega/docs/expressions/#easeSin)
+- [easeExp](https://vega.github.io/vega/docs/expressions/#easeExp)
+- [easeCircle](https://vega.github.io/vega/docs/expressions/#easeCircle)
+- [easeBounce](https://vega.github.io/vega/docs/expressions/#easeBounce)
+- [easeBack](https://vega.github.io/vega/docs/expressions/#easeBack)
+- [easeElastic](https://vega.github.io/vega/docs/expressions/#easeElastic)
+
 **Date/Time Functions**
 
 - [quarter](https://vega.github.io/vega/docs/expressions/#quarter)
@@ -38,6 +53,7 @@ This package provides the following expression functions. All other constants an
 - [clampRange](https://vega.github.io/vega/docs/expressions/#clampRange)
 - [extent](https://vega.github.io/vega/docs/expressions/#extent)
 - [inrange](https://vega.github.io/vega/docs/expressions/#inrange)
+- [interpolateLinear](https://vega.github.io/vega/docs/expressions/#interpolateLinear)
 - [lerp](https://vega.github.io/vega/docs/expressions/#lerp)
 - [peek](https://vega.github.io/vega/docs/expressions/#peek)
 - [sequence](https://vega.github.io/vega/docs/expressions/#sequence)

--- a/packages/vega-functions/index.js
+++ b/packages/vega-functions/index.js
@@ -5,8 +5,7 @@ export {
 } from './src/functions/data.js';
 
 export {
-  easeFunctions,
-  easeFunctionNames
+  easeFunctions
 } from './src/functions/ease.js';
 
 export {

--- a/packages/vega-functions/index.js
+++ b/packages/vega-functions/index.js
@@ -5,8 +5,17 @@ export {
 } from './src/functions/data.js';
 
 export {
+  easeFunctions,
+  easeFunctionNames
+} from './src/functions/ease.js';
+
+export {
   default as encode
 } from './src/functions/encode.js';
+
+export {
+  interpolateLinear
+} from './src/functions/interpolate.js';
 
 export {
   format,

--- a/packages/vega-functions/package.json
+++ b/packages/vega-functions/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "d3-array": "^3.2.4",
     "d3-color": "^3.1.0",
+    "d3-ease": "^3.0.1",
     "d3-geo": "^3.1.1",
     "vega-dataflow": "^6.1.2",
     "vega-expression": "^6.2.1",

--- a/packages/vega-functions/src/codegen.js
+++ b/packages/vega-functions/src/codegen.js
@@ -101,7 +101,11 @@ import {
   setdata
 } from './functions/data.js';
 
+import {easeFunctions} from './functions/ease.js';
+
 import encode from './functions/encode.js';
+
+import {interpolateLinear} from './functions/interpolate.js';
 
 import {
   dayAbbrevFormat,
@@ -239,6 +243,7 @@ export const functionContext = {
   slice,
   flush,
   lerp,
+  interpolateLinear,
   merge,
   pad,
   peek,
@@ -300,7 +305,8 @@ export const functionContext = {
   modify,
   lassoAppend,
   lassoPath,
-  intersectLasso
+  intersectLasso,
+  ...easeFunctions
 };
 
 const eventFunctions = ['view', 'item', 'group', 'xy', 'x', 'y'], // event functions

--- a/packages/vega-functions/src/functions/ease.js
+++ b/packages/vega-functions/src/functions/ease.js
@@ -1,0 +1,61 @@
+import * as d3 from 'd3-ease';
+
+/**
+ * The d3-ease easing functions, exposed to the expression language under their
+ * d3 names. Each maps a normalized time in [0, 1] to an eased position in
+ * [0, 1], letting animations vary their playback rate over the time domain.
+ *
+ * The parametric families (`easePoly`, `easeBack`, `easeElastic`) are exposed
+ * at their default parameters only; d3's `.exponent()` / `.overshoot()` /
+ * `.amplitude()` configuration has no expression-language equivalent.
+ */
+export const easeFunctions = {
+  easeLinear: d3.easeLinear,
+
+  easeQuad: d3.easeQuad,
+  easeQuadIn: d3.easeQuadIn,
+  easeQuadOut: d3.easeQuadOut,
+  easeQuadInOut: d3.easeQuadInOut,
+
+  easeCubic: d3.easeCubic,
+  easeCubicIn: d3.easeCubicIn,
+  easeCubicOut: d3.easeCubicOut,
+  easeCubicInOut: d3.easeCubicInOut,
+
+  easePoly: d3.easePoly,
+  easePolyIn: d3.easePolyIn,
+  easePolyOut: d3.easePolyOut,
+  easePolyInOut: d3.easePolyInOut,
+
+  easeSin: d3.easeSin,
+  easeSinIn: d3.easeSinIn,
+  easeSinOut: d3.easeSinOut,
+  easeSinInOut: d3.easeSinInOut,
+
+  easeExp: d3.easeExp,
+  easeExpIn: d3.easeExpIn,
+  easeExpOut: d3.easeExpOut,
+  easeExpInOut: d3.easeExpInOut,
+
+  easeCircle: d3.easeCircle,
+  easeCircleIn: d3.easeCircleIn,
+  easeCircleOut: d3.easeCircleOut,
+  easeCircleInOut: d3.easeCircleInOut,
+
+  easeBounce: d3.easeBounce,
+  easeBounceIn: d3.easeBounceIn,
+  easeBounceOut: d3.easeBounceOut,
+  easeBounceInOut: d3.easeBounceInOut,
+
+  easeBack: d3.easeBack,
+  easeBackIn: d3.easeBackIn,
+  easeBackOut: d3.easeBackOut,
+  easeBackInOut: d3.easeBackInOut,
+
+  easeElastic: d3.easeElastic,
+  easeElasticIn: d3.easeElasticIn,
+  easeElasticOut: d3.easeElasticOut,
+  easeElasticInOut: d3.easeElasticInOut
+};
+
+export const easeFunctionNames = Object.keys(easeFunctions);

--- a/packages/vega-functions/src/functions/ease.js
+++ b/packages/vega-functions/src/functions/ease.js
@@ -57,5 +57,3 @@ export const easeFunctions = {
   easeElasticOut: d3.easeElasticOut,
   easeElasticInOut: d3.easeElasticInOut
 };
-
-export const easeFunctionNames = Object.keys(easeFunctions);

--- a/packages/vega-functions/src/functions/interpolate.js
+++ b/packages/vega-functions/src/functions/interpolate.js
@@ -1,0 +1,31 @@
+import {isArray, peek} from 'vega-util';
+
+/**
+ * Piecewise-linear interpolation across an array of values.
+ *
+ * Unlike `lerp`, which interpolates between the first and last entries only,
+ * this treats the array as evenly-spaced control points and interpolates
+ * within the segment that `frac` falls into. It turns an array into a
+ * piecewise-linear function of position -- a custom easing curve, for
+ * instance, or any sampled series read at an arbitrary point.
+ *
+ * @param {Array<number>} values - The control points, in order.
+ * @param {number} frac - Position along the array, in [0, 1].
+ * @return {number} The interpolated value.
+ */
+export function interpolateLinear(values, frac) {
+  if (!isArray(values) || !values.length) return undefined;
+
+  const n = values.length,
+        lo = values[0],
+        f = +frac;
+
+  if (n === 1 || !(f > 0)) return lo;
+  if (f >= 1) return peek(values);
+
+  const pos = f * (n - 1),
+        i = Math.floor(pos),
+        t = pos - i;
+
+  return t ? values[i] + t * (values[i + 1] - values[i]) : values[i];
+}

--- a/packages/vega-functions/test/ease-test.js
+++ b/packages/vega-functions/test/ease-test.js
@@ -1,5 +1,7 @@
 import tape from 'tape';
-import { easeFunctionNames, easeFunctions, functionContext } from '../index.js';
+import { easeFunctions, functionContext } from '../index.js';
+
+const easeFunctionNames = Object.keys(easeFunctions);
 
 tape('easing functions are registered in the function context', t => {
   t.ok(easeFunctionNames.length > 0);

--- a/packages/vega-functions/test/ease-test.js
+++ b/packages/vega-functions/test/ease-test.js
@@ -1,0 +1,36 @@
+import tape from 'tape';
+import { easeFunctionNames, easeFunctions, functionContext } from '../index.js';
+
+tape('easing functions are registered in the function context', t => {
+  t.ok(easeFunctionNames.length > 0);
+  easeFunctionNames.forEach(name => {
+    t.equal(typeof functionContext[name], 'function', `${name} is registered`);
+  });
+  t.end();
+});
+
+tape('easing functions map the unit interval onto itself', t => {
+  // the back and elastic families return -0 at the origin, so compare
+  // numerically rather than with strict equality
+  easeFunctionNames.forEach(name => {
+    const ease = easeFunctions[name];
+    t.ok(Math.abs(ease(0)) < 1e-12, `${name}(0) is 0`);
+    t.ok(Math.abs(ease(1) - 1) < 1e-12, `${name}(1) is 1`);
+  });
+  t.end();
+});
+
+tape('easeLinear is the identity', t => {
+  const {easeLinear} = easeFunctions;
+  t.equal(easeLinear(0.25), 0.25);
+  t.equal(easeLinear(0.5), 0.5);
+  t.equal(easeLinear(0.75), 0.75);
+  t.end();
+});
+
+tape('easeCubicInOut is symmetric about its midpoint', t => {
+  const {easeCubicInOut} = easeFunctions;
+  t.equal(easeCubicInOut(0.5), 0.5);
+  t.ok(Math.abs(easeCubicInOut(0.25) + easeCubicInOut(0.75) - 1) < 1e-12);
+  t.end();
+});

--- a/packages/vega-functions/test/ease-test.js
+++ b/packages/vega-functions/test/ease-test.js
@@ -11,7 +11,7 @@ tape('easing functions are registered in the function context', t => {
   t.end();
 });
 
-tape('easing functions map the unit interval onto itself', t => {
+tape('easing functions fix the endpoints of the unit interval', t => {
   // the back and elastic families return -0 at the origin, so compare
   // numerically rather than with strict equality
   easeFunctionNames.forEach(name => {

--- a/packages/vega-functions/test/interpolate-test.js
+++ b/packages/vega-functions/test/interpolate-test.js
@@ -1,0 +1,32 @@
+import tape from 'tape';
+import { interpolateLinear } from '../index.js';
+
+tape('interpolateLinear interpolates within array segments', t => {
+  const values = [0, 10, 20];
+
+  t.equal(interpolateLinear(values, 0), 0);
+  t.equal(interpolateLinear(values, 0.25), 5);
+  t.equal(interpolateLinear(values, 0.5), 10);
+  t.equal(interpolateLinear(values, 0.75), 15);
+  t.equal(interpolateLinear(values, 1), 20);
+  t.end();
+});
+
+tape('interpolateLinear differs from lerp for non-linear control points', t => {
+  // lerp would ignore the middle value and return 5 at the midpoint
+  t.equal(interpolateLinear([0, 100, 10], 0.5), 100);
+  t.end();
+});
+
+tape('interpolateLinear clamps out-of-range fractions', t => {
+  t.equal(interpolateLinear([1, 2, 3], -1), 1);
+  t.equal(interpolateLinear([1, 2, 3], 2), 3);
+  t.end();
+});
+
+tape('interpolateLinear handles degenerate input', t => {
+  t.equal(interpolateLinear([7], 0.5), 7);
+  t.equal(interpolateLinear([], 0.5), undefined);
+  t.equal(interpolateLinear(null, 0.5), undefined);
+  t.end();
+});

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,6 +13,7 @@ const d3Deps = [
   'd3-color',
   'd3-dispatch',
   'd3-dsv',
+  'd3-ease',
   'd3-force',
   'd3-format',
   'd3-geo',


### PR DESCRIPTION
This PR adds easing functions and interpolation to the expression language. These are needed for Animated Vega-Lite.


**Claude below:**

Adds easing functions and `interpolateLinear` to the expression language. Animated visualizations need an eased clock and piecewise interpolation, and no existing expression computes either operation.

### Easing functions

This PR registers the [d3-ease](https://github.com/d3/d3-ease) functions under their d3 names: `easeLinear`, `easeQuadIn/Out/InOut`, `easeCubic*`, `easePoly*`, `easeSin*`, `easeExp*`, `easeCircle*`, `easeBounce*`, `easeBack*`, `easeElastic*`.

Each function maps normalized time in `[0, 1]` onto an eased position in `[0, 1]`, so a spec can reshape an animation clock inside the expression language:

```js
easeCubicInOut(anim_clock / duration) * duration
```

The registration uses d3's defaults for the parametric families (`easePoly`, `easeBack`, `easeElastic`), because `.exponent()`, `.overshoot()`, and `.amplitude()` have no expression-language equivalent. The bare names alias d3's own defaults: `easeBounce` is `easeBounceOut` and `easeQuad` is `easeQuadInOut`. The aliases match d3 rather than inventing a convention.

Adds `d3-ease` (~2 kB, BSD-3-Clause) as a dependency of `vega-functions`.

### `interpolateLinear(array, fraction)`

Interpolates piecewise across every entry of an array rather than across its endpoints.

`lerp` already covers the endpoint case, but collapsing intermediate control points gives the wrong answer when the array describes a curve. `lerp([0, 100, 10], 0.5)` returns `5`, while the curve is at `100`. `interpolateLinear([0, 100, 10], 0.5)` returns `100`.

The two functions together let a spec define a custom easing curve from its own control points, and let a spec read any sampled series at an arbitrary position.

### Tests

`packages/vega-functions/test/ease-test.js` and `interpolate-test.js` — 207 assertions pass. The easing tests assert that every registered function maps the unit interval onto itself and is reachable from the function context. The interpolation tests cover segment interpolation, the divergence from `lerp`, clamping, and degenerate input.

### Notes

- Purely additive. No existing behavior changes.
- A companion Vega-Lite change adds `easing` to animated selections and consumes both functions. The interpolation function lives here rather than in Vega-Lite because it must run inside a signal expression.