### PR TITLE
fix: apply DisallowedObjectProperties to quoted object keys in codegen

### DIFF
--- a/packages/vega-expression/src/codegen.js
+++ b/packages/vega-expression/src/codegen.js
@@ -100,7 +100,9 @@ export default function(opt) {
     ObjectExpression: n => {
       // If any keys would override Object prototype methods, throw error
       for (const prop of n.properties) {
-        const keyName = prop.key.name;
+          const keyName = prop.key.type === 'Literal'
+            ? String(prop.key.value)
+            : prop.key.name;
 
         if (DisallowedObjectProperties.has(keyName)) {
           error('Illegal property: ' + keyName);

--- a/packages/vega-expression/test/codegen-test.js
+++ b/packages/vega-expression/test/codegen-test.js
@@ -317,3 +317,26 @@ tape('Evaluate expressions with white list', t => {
 
   t.end();
 });
+
+tape('Codegen rejects Object.prototype keys whether quoted or not', t => {
+  const codegen = vega.codegenExpression({ globalvar: 'global' });
+  const compile = str => () => codegen(vega.parseExpression(str));
+
+  // Unquoted keys that would shadow Object.prototype members are rejected.
+  t.throws(compile('{toString: 1}'), /Illegal property/);
+  t.throws(compile('{constructor: 1}'), /Illegal property/);
+
+  // Quoted keys must be rejected too. Their key node is a Literal, not an Identifier,
+  // so reading prop.key.name alone (undefined for a Literal) let these bypass the
+  // DisallowedObjectProperties check and compile.
+  t.throws(compile('{"toString": 1}'), /Illegal property/);
+  t.throws(compile('{"constructor": 1}'), /Illegal property/);
+  t.throws(compile('{"__proto__": 1}'), /Illegal property/);
+
+  // Ordinary keys still compile, including numeric literal keys.
+  t.doesNotThrow(compile('{a: 1}'));
+  t.doesNotThrow(compile('{"b": 2}'));
+  t.doesNotThrow(compile('{0: 1}'));
+
+  t.end();
+});


### PR DESCRIPTION
The ObjectExpression deny-list check read the key from prop.key.name, which is undefined for a quoted (Literal) key, so keys like {"toString": 1} skipped the DisallowedObjectProperties check that the unquoted {toString: 1} hits. Resolve the name from prop.key.value for Literal keys, which matches the interpreter
(interpret.js already evaluates the key). String() keeps numeric keys like {0: 1} working.