### PR TITLE
fix(vega-interpreter): re-create global regexp literals per evaluation

### DIFF
--- a/packages/vega-interpreter/src/interpret.js
+++ b/packages/vega-interpreter/src/interpret.js
@@ -17,7 +17,7 @@ if (typeof setImmediate === 'function') DisallowedMethods.add(setImmediate);
 const Visitors = {
   // global and sticky regexps carry lastIndex across calls, so hand out a
   // fresh instance per evaluation, as the generated code path does
-  Literal: ($, n) => n.regex && (n.value.global || n.value.sticky)
+  Literal: ($, n) => n.regex && n.value && (n.value.global || n.value.sticky)
     ? new RegExp(n.regex.pattern, n.regex.flags)
     : n.value,
 

--- a/packages/vega-interpreter/src/interpret.js
+++ b/packages/vega-interpreter/src/interpret.js
@@ -15,7 +15,11 @@ const DisallowedMethods = new Set([
 if (typeof setImmediate === 'function') DisallowedMethods.add(setImmediate);
 
 const Visitors = {
-  Literal: ($, n) => n.value,
+  // global and sticky regexps carry lastIndex across calls, so hand out a
+  // fresh instance per evaluation, as the generated code path does
+  Literal: ($, n) => n.regex && (n.value.global || n.value.sticky)
+    ? new RegExp(n.regex.pattern, n.regex.flags)
+    : n.value,
 
   Identifier: ($, n) => {
     const id = n.name;

--- a/packages/vega-interpreter/test/interpret-test.js
+++ b/packages/vega-interpreter/test/interpret-test.js
@@ -1,0 +1,79 @@
+import tape from 'tape';
+import * as vega from 'vega';
+import * as interp from '../index.js';
+import interpret from '../src/interpret.js';
+
+const names = ['Alpha', 'Alfa', 'Anna', 'Ajax', 'Amber'];
+const data = names.map(name => ({name}));
+
+// evaluate an expression once per datum, the way a transform does
+function evaluate(expr) {
+  const ast = vega.parseExpression(expr);
+  return data.map(datum => interpret(ast, {}, {}, datum));
+}
+
+tape('Interpreter evaluates a regexp literal independently per datum', t => {
+  t.deepEqual(
+    evaluate('test(/^A/, datum.name)'),
+    [true, true, true, true, true],
+    'plain regexp literal'
+  );
+  t.deepEqual(
+    evaluate('test(/^A/g, datum.name)'),
+    [true, true, true, true, true],
+    'global regexp literal'
+  );
+  t.deepEqual(
+    evaluate('test(/^A/y, datum.name)'),
+    [true, true, true, true, true],
+    'sticky regexp literal'
+  );
+  t.deepEqual(
+    evaluate('test(/^A/g, datum.name) && test(/a$/g, datum.name)'),
+    [true, true, true, false, false],
+    'two global regexp literals in one expression'
+  );
+
+  t.end();
+});
+
+tape('Interpreter matches generated code for regexp literals', t => {
+  const expr = 'test(/^A/g, datum.name)';
+  const codegen = vega.codegenExpression({
+    allowed: ['datum'],
+    globalvar: 'global',
+    fieldvar: 'datum'
+  });
+  const {code} = codegen(vega.parseExpression(expr));
+  const generated = new Function('datum', 'global', `return (${code});`);
+
+  t.deepEqual(
+    evaluate(expr),
+    data.map(datum => generated(datum, {})),
+    'same result as the generated function'
+  );
+
+  t.end();
+});
+
+tape('Interpreter filters a dataset with a global regexp literal', async t => {
+  const spec = {
+    $schema: 'https://vega.github.io/schema/vega/v6.json',
+    data: [{
+      name: 'table',
+      values: data,
+      transform: [{type: 'filter', expr: 'test(/^A/g, datum.name)'}]
+    }]
+  };
+
+  const runtime = vega.parse(spec, null, {ast: true});
+  const view = new vega.View(runtime, {
+    expr: interp.expressionInterpreter,
+    renderer: 'none'
+  }).finalize();
+
+  await view.runAsync();
+
+  t.deepEqual(view.data('table').map(d => d.name), names, 'all rows pass the filter');
+  t.end();
+});

--- a/packages/vega-interpreter/test/interpret-test.js
+++ b/packages/vega-interpreter/test/interpret-test.js
@@ -58,7 +58,6 @@ tape('Interpreter matches generated code for regexp literals', t => {
 
 tape('Interpreter filters a dataset with a global regexp literal', async t => {
   const spec = {
-    $schema: 'https://vega.github.io/schema/vega/v6.json',
     data: [{
       name: 'table',
       values: data,


### PR DESCRIPTION
## Problem

Under the CSP interpreter, a regexp literal carrying the `g` or `y` flag is shared by every
evaluation of the expression, so `lastIndex` leaks from one datum to the next. A filter that
should keep every row silently drops some of them:

```js
const spec = {
  data: [{
    name: 'table',
    values: [{name: 'Alpha'}, {name: 'Alfa'}, {name: 'Anna'}, {name: 'Ajax'}, {name: 'Amber'}],
    transform: [{type: 'filter', expr: 'test(/^A/g, datum.name)'}]
  }]
};

const runtime = vega.parse(spec, null, {ast: true});
const view = new vega.View(runtime, {expr: expressionInterpreter, renderer: 'none'});
await view.runAsync();
view.data('table').map(d => d.name);
```

| evaluator | rows kept |
| --- | --- |
| generated code (default) | `Alpha, Alfa, Anna, Ajax, Amber` |
| `expressionInterpreter` | `Alpha, Anna, Amber` |

All five names match `/^A/`. The interpreter drops two of them. Sticky literals can go the other
way and produce false positives: with `/a/y`, `"ba"` is reported as a match when a previous datum
left `lastIndex` at 1.

## Cause

The parser builds the `RegExp` once and stores it on the AST node (`finishLiteral` takes
`node.value` from `scanRegExp`). The interpreter's `Literal` visitor returns that node value
directly, so one `RegExp` instance is shared by every evaluation — and, since one parsed runtime
can back several views, by every view built from it.

The generated-code path does not have this problem: codegen emits the literal's raw source
(`n.raw`), and a regexp literal in JavaScript source produces a **new** object each time it is
evaluated. So the two evaluators disagree, although the package README presents the interpreter
as a drop-in that only "can incur a performance penalty", and the expression docs define
`test(regexp, string)` without reference to flags.

`test()` is where it surfaces: `RegExp.prototype.test` on a global or sticky regexp advances
`lastIndex` on a match and only resets it on a failure, so results cycle with the match length.
That also makes it self-masking — any non-matching row in between resets `lastIndex` and restores
correct behaviour, so it looks data-dependent rather than reproducible.

## Fix

Hand out a fresh `RegExp` per evaluation, which is what the generated code does.

Only global and sticky literals need it — for every other flag combination `lastIndex` is never
written, so the shared instance is unobservable and can keep being returned as-is.

## Verification

**New tests.** `packages/vega-interpreter/test/interpret-test.js`. Against unpatched
`src/interpret.js`, 5 of its 6 assertions fail; the non-global literal is the control that should
keep passing:

```
ok 3 plain regexp literal
not ok 4 global regexp literal
    expected: [ true, true, true, true, true ]
    actual:   [ true, false, true, false, true ]
not ok 5 sticky regexp literal
not ok 6 two global regexp literals in one expression
not ok 7 same result as the generated function
not ok 8 all rows pass the filter
    expected: [ 'Alpha', 'Alfa', 'Anna', 'Ajax', 'Amber' ]
    actual:   [ 'Alpha', 'Anna', 'Amber' ]
# tests 122  # pass 117  # fail 5
```

With the fix, `npm test` in `packages/vega-interpreter` gives `# tests 122  # pass 122`, so the
117 existing golden-scenegraph tests are unaffected.

**Parity sweep.** 9 patterns x 8 flag combinations x 6 expression shapes (`test`, `replace`,
`split`, a conditional, one literal used twice, and stringification), each evaluated repeatedly
against 9 data values, comparing the interpreter with the generated function for the same
expression:

| | divergences |
| --- | --- |
| before | 210 in 3240 repeated evaluations |
| after | 0 in 3240 repeated evaluations |

**Full gate**, Node 22.12 (the `engines` floor):

```
npm test          -> exit 0   (8240 assertions across all packages, 0 failures; includes lint)
npm run typecheck -> exit 0
```

## Cost

Timing the changed operation in isolation, 300k iterations, 7 rounds, medians:

| | |
| --- | --- |
| cached object (current behaviour) | 11.5 ms (11.3-11.6) |
| gated, non-global literal — stays cached | 13.1 ms (12.9-13.2) |
| gated, global literal — fresh instance | 27.3 ms (27.2-27.4) |
| fresh instance unconditionally | 26.7 ms (26.2-27.3) |

So the gate is what keeps the common non-global case off the allocating path. Through the whole
interpreter the difference is not measurable on this machine — 200k evaluations came out at a
median of 1131 ms before and 1154 ms after, with each variant spanning roughly 1.0-1.9 s across
runs, so the spreads overlap entirely.

## Noticed while checking parity, not fixed here

`hypot` is in the codegen function table (`vega-expression/src/functions.js`) but not in the
interpreter's (`vega-interpreter/src/functions.js`), so `hypot(3, 4)` returns `5` with generated
code and throws `TypeError: Cannot read properties of undefined (reading 'apply')` under the
interpreter. It is the only remaining name callable through one evaluator and not the other. I
left it out to keep this diff to one thing — happy to send it as its own one-line PR, or to fold
it in here if you would rather have both together.
