### PR TITLE
fix(parser): resolve signals in unioned scale domains

### DIFF
--- a/packages/vega-parser/src/parsers/scale.js
+++ b/packages/vega-parser/src/parsers/scale.js
@@ -1,7 +1,7 @@
 import {
   Aggregate, Collect, MultiExtent, MultiValues, Sieve, Values
 } from '../transforms.js';
-import {aggrField, keyFieldRef, ref} from '../util.js';
+import {aggrField, isSignal, keyFieldRef, ref} from '../util.js';
 
 import {isDiscrete, isQuantile, isValidScaleType} from 'vega-scale';
 import {
@@ -118,10 +118,13 @@ function fieldRef(data, scope) {
   const name = '_:vega:_' + (FIELD_REF_ID++),
         coll = Collect({});
 
-  if (isArray(data)) {
+  if (isArray(data) && !data.some(isSignal)) {
     coll.value = {$ingest: data};
-  } else if (data.signal) {
-    const code = 'setdata(' + stringValue(name) + ',' + data.signal + ')';
+  } else {
+    const values = isArray(data)
+      ? '[' + data.map(v => isSignal(v) ? v.signal : stringValue(v)).join(',') + ']'
+      : data.signal;
+    const code = 'setdata(' + stringValue(name) + ',' + values + ')';
     coll.params.input = scope.signalRef(code);
   }
   scope.addDataPipeline(name, [coll, Sieve({})]);

--- a/packages/vega-parser/test/scale-test.js
+++ b/packages/vega-parser/test/scale-test.js
@@ -144,3 +144,74 @@ tape('Parser parses Vega specs with multi-domain scales', t => {
 
   t.end();
 });
+
+tape('Parser parses multi-domain scales with signal values', t => {
+  const spec = {
+    'signals': [
+      {'name': 'lo', 'value': 2},
+      {'name': 'hi', 'value': 8}
+    ],
+    'data': [
+      {'name': 'table', 'values': [{'x': 0}, {'x': 5}]}
+    ],
+    'scales': [
+      {
+        'name': 'xscale',
+        'type': 'linear',
+        'range': [0, 1],
+        'domain': {
+          'fields': [
+            [{'signal': 'lo'}, {'signal': 'hi'}],
+            {'data': 'table', 'field': 'x'}
+          ]
+        }
+      }
+    ]
+  };
+
+  const dfs = parse(spec);
+  const setdata = dfs.operators.filter(o => o.update && o.update.code.includes('setdata'));
+
+  t.equal(setdata.length, 1);
+  t.ok(/^this\.setdata\("(_:vega:_\d+)",\[_\["\$lo"\],_\["\$hi"\]\]\)$/.test(setdata[0].update.code));
+  t.deepEqual(Object.keys(setdata[0].params), ['$lo', '$hi']);
+
+  const name = setdata[0].update.code.match(/"(_:vega:_\d+)"/)[1];
+  const coll = dfs.operators.find(o => o.data && o.data[name]);
+
+  t.equal(coll.value, undefined);
+  t.equal(coll.params.input.$ref, setdata[0].id);
+
+  t.end();
+});
+
+tape('Parser parses multi-domain scales with literal values', t => {
+  const spec = {
+    'data': [
+      {'name': 'table', 'values': [{'x': 0}, {'x': 5}]}
+    ],
+    'scales': [
+      {
+        'name': 'xscale',
+        'type': 'linear',
+        'range': [0, 1],
+        'domain': {
+          'fields': [
+            [2, 8],
+            {'data': 'table', 'field': 'x'}
+          ]
+        }
+      }
+    ]
+  };
+
+  const dfs = parse(spec);
+
+  t.equal(dfs.operators.filter(o => o.update && o.update.code.includes('setdata')).length, 0);
+  t.deepEqual(
+    dfs.operators.filter(o => o.value && o.value.$ingest).map(o => o.value.$ingest),
+    [[{'x': 0}, {'x': 5}], [2, 8]]
+  );
+
+  t.end();
+});

--- a/packages/vega-schema/src/scale.js
+++ b/packages/vega-schema/src/scale.js
@@ -133,7 +133,7 @@ const scaleData = oneOf(
     _fields_: array(
       oneOf(
         object({_data_: stringType, _field_: stringOrSignal}),
-        array(oneOf(stringType, numberType, booleanType)),
+        array(oneOf(stringType, numberType, booleanType, signalRef)),
         signalRef
       ),
       {minItems: 1}

--- a/packages/vega-typings/types/spec/scale.d.ts
+++ b/packages/vega-typings/types/spec/scale.d.ts
@@ -90,7 +90,7 @@ export interface ScaleDataRef {
 }
 
 export interface ScaleMultiDataRef {
-  fields: ((string | number | boolean)[] | ScaleDataRef | SignalRef)[];
+  fields: ((string | number | boolean | SignalRef)[] | ScaleDataRef | SignalRef)[];
 }
 
 export interface ScaleMultiFieldsRef {


### PR DESCRIPTION
A value array nested inside `domain.fields` never had its signals evaluated, while the exact same syntax at the top level of `domain` does. It failed silently — no warning, no error, just a wrong domain.

## Repro

```js
const spec = {
  width: 100, height: 100,
  signals: [{name: 'lo', value: 2}, {name: 'hi', value: 8}],
  data: [{name: 't', values: [{v: 0}, {v: 5}]}],
  scales: [{
    name: 'y', type: 'linear', zero: false,
    domain: {fields: [[{signal: 'lo'}, {signal: 'hi'}], {data: 't', field: 'v'}]},
    range: 'height'
  }]
};
// before: y domain [0,5]   <-- the signal array contributed nothing
// after:  y domain [0,8]   (union of [2,8] and the data extent [0,5])
```

Control — the same literal-array syntax at the top level was, and still is, resolved correctly:

```js
spec.scales[0].domain = [{signal: 'lo'}, {signal: 'hi'}];  // -> [2,8], before and after
```

## Root cause

`multipleDomain` routes an array entry of `domain.fields` to `fieldRef`, which ingested it as a raw value array:

```js
if (isArray(data)) {
  coll.value = {$ingest: data};        // {signal: 'lo'} ingested as a literal object
} else if (data.signal) {
  const code = 'setdata(' + stringValue(name) + ',' + data.signal + ')';
  coll.params.input = scope.signalRef(code);   // this branch was correct
}
```

So `{signal: 'lo'}` became a tuple with no `data` property, contributing nothing to the extent — silently dropped. The sibling `data.signal` branch (`{fields: [{signal: '[lo, hi]'}]}`) already did the right thing, and `explicitDomain` at the top level resolves each entry with `parseLiteral`.

## Fix

An array that contains at least one signal now takes the same `setdata` expression path as the `{signal: ...}` branch, composing the expression from the element signals and `stringValue`-quoted literals:

```js
setdata("_:vega:_0",[lo,hi])
```

I chose the expression path over patching signal refs into `$ingest` because `$ingest` is a static value in the serialized dataflow — a `SignalRef` cannot be embedded in it, and the resulting domain would not track signal updates. Going through `setdata` reuses the mechanism the parser already has for signal-valued domain fields, and the domain now updates reactively when `lo`/`hi` change (verified below).

Arrays with no signals keep `coll.value = {$ingest: data}` verbatim, so existing specs produce a byte-identical dataflow.

The contract is widened to match: `ScaleMultiDataRef.fields` in vega-typings, and the corresponding `array(oneOf(stringType, numberType, booleanType))` in the (hand-written) `vega-schema` source. The generated `vega-schema.json` picks this up from `packages/vega-schema/src/scale.js`; no generated file was hand-edited.

## Note on error handling (not changed)

`parseLiteral` errors on an object without `.signal`; inside a `fields` value array such an object is still ingested silently. Making it an error would reject specs that parse today, so I left it alone — flagging it in case you want that consistency in a major.

## Verification

- Repro: `union [0,8]`, `control [2,8]`, `literal array [0,9]` (unchanged), `ordinal strings ["a","b",0,5]` (unchanged), reactive update `[0,8] -> [0,20]` after `view.signal('hi', 20)`.
- Parsed the 116 specs in `packages/vega/test/specs-valid` plus the 93 in `docs/examples` with the parser before and after the change: **dataflow JSON identical for all 209**.
- New parser tests fail on `main` (`not ok 15` — no `setdata` operator is emitted) and pass with the fix. The second test pins that a signal-free array still emits `{$ingest: [2, 8]}` and no `setdata`.
- `npm test` at the repo root (full suite + `eslint`): `Successfully ran target test for 32 projects`, exit 0, zero `not ok` lines.
- The only other `fieldRef` in this file is `scope.fieldRef`; the module-local `fieldRef` changed here has exactly one caller, `multipleDomain` (`grep -rn fieldRef packages/vega-parser/src`).
- JSON schema: the union spec is rejected by the schema built from `main` and accepted by the schema built from this branch.
- No `npm install` that touches the lockfile was run; `git diff main -- package-lock.json` is empty. (I did install the lockfile's `typescript@5.9.3` with `--no-save` because the shared `node_modules` had TypeScript 6 left over from another branch, which made `vega-util`'s build fail on an unrelated `TS5107` deprecation error; the lockfile is unmodified.)

## Relationship to vega-lite

Vega-Lite was emitting the nested-signal form and hitting exactly this — a unioned domain silently resolving to the wrong extent. It now emits a single `{signal: "[lo, hi]"}` instead (vega/vega-lite#9922).

That is worth keeping rather than reverting once this lands, and it isn't a workaround for this bug: the nested form was never permitted by this schema or by `ScaleMultiDataRef`, so vega-lite was emitting out-of-contract input. The `{signal: ...}` form is valid and resolves correctly on released Vega 6.x — I ran both forms against the published 6.0.0 and 6.3.1 bundles: `{signal: "[lo, hi]"}` gives `[0,8]` on both, the nested form gives `[0,5]` on both — so the nested form is wrong on 6.0.0–6.3.x regardless of what this PR does. Since a compiled Vega spec is rendered by whatever runtime the consumer has, vega-lite emitting the portable form matters independently of its peer-dependency range.

What this PR changes is that the nested form now works too, instead of being silently mis-ingested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
