### PR TITLE
fix(interpreter): add missing hypot function

### DIFF
--- a/packages/vega-interpreter/src/functions.js
+++ b/packages/vega-interpreter/src/functions.js
@@ -25,6 +25,7 @@ export default {
   cos:       Math.cos,
   exp:       Math.exp,
   floor:     Math.floor,
+  hypot:     Math.hypot,
   log:       Math.log,
   max:       Math.max,
   min:       Math.min,

--- a/packages/vega-interpreter/test/functions-test.js
+++ b/packages/vega-interpreter/test/functions-test.js
@@ -8,25 +8,21 @@ tape('Date', t => {
   t.end();
 });
 
-// The two lists below record the *known intentional* divergences between the
-// code generator's function table and the interpreter's. Do not add a name here
-// just to make this test pass: a new divergence means one path can evaluate an
-// expression the other cannot, which is a bug unless you can justify otherwise.
+// Known intentional divergences between the two function tables. Don't add a
+// name here just to make this test pass — a divergence means one path can
+// evaluate an expression the other can't.
 
-// Functions the code generator provides but the interpreter deliberately omits.
-// 'if' is special-cased in interpret.js so that only one branch is evaluated.
+// Special-cased in interpret.js so only one branch is evaluated.
 const CODEGEN_ONLY = ['if'];
 
-// Functions the interpreter lists but the code generator does not. These are
-// legacy entries: vega-functions' functionContext supplies all of them to both
-// paths and always shadows these definitions, so they are never reached.
+// Legacy entries, always shadowed by vega-functions' functionContext.
 const INTERPRETER_ONLY = [
   'join', 'indexof', 'lastindexof', 'slice', 'reverse', 'sort', 'replace'
 ];
 
 tape('Function tables agree with vega-expression', t => {
-  // the codegen table is a factory taking a codegen callback; it is only
-  // invoked when a generated function runs, so a stub suffices to list names.
+  // the codegen table is a factory; its callback only runs for generated
+  // code, so a stub suffices to list names
   const codegen = Object.keys(codegenFunctions(String));
   const interp = Object.keys(functions);
 

--- a/packages/vega-interpreter/test/functions-test.js
+++ b/packages/vega-interpreter/test/functions-test.js
@@ -1,8 +1,51 @@
 import tape from 'tape';
 import functions from '../src/functions.js';
+import {functions as codegenFunctions} from '../../vega-expression/index.js';
 
 tape('Date', t => {
   t.equal(functions.datetime(2025).getDate(), new Date(2025, 0, 1, 0, 0, 0, 0).getDate());
   t.equal(functions.datetime('2005-08-01T00:00:00').getDate(), new Date(2025, 8, 1, 0, 0, 0, 0).getDate());
+  t.end();
+});
+
+// The two lists below record the *known intentional* divergences between the
+// code generator's function table and the interpreter's. Do not add a name here
+// just to make this test pass: a new divergence means one path can evaluate an
+// expression the other cannot, which is a bug unless you can justify otherwise.
+
+// Functions the code generator provides but the interpreter deliberately omits.
+// 'if' is special-cased in interpret.js so that only one branch is evaluated.
+const CODEGEN_ONLY = ['if'];
+
+// Functions the interpreter lists but the code generator does not. These are
+// legacy entries: vega-functions' functionContext supplies all of them to both
+// paths and always shadows these definitions, so they are never reached.
+const INTERPRETER_ONLY = [
+  'join', 'indexof', 'lastindexof', 'slice', 'reverse', 'sort', 'replace'
+];
+
+tape('Function tables agree with vega-expression', t => {
+  // the codegen table is a factory taking a codegen callback; it is only
+  // invoked when a generated function runs, so a stub suffices to list names.
+  const codegen = Object.keys(codegenFunctions(String));
+  const interp = Object.keys(functions);
+
+  t.deepEqual(
+    codegen.filter(name => !interp.includes(name)).sort(),
+    CODEGEN_ONLY.slice().sort(),
+    'every codegen function has an interpreter implementation'
+  );
+
+  t.deepEqual(
+    interp.filter(name => !codegen.includes(name)).sort(),
+    INTERPRETER_ONLY.slice().sort(),
+    'the interpreter adds no undocumented functions'
+  );
+
+  t.end();
+});
+
+tape('Math', t => {
+  t.equal(functions.hypot(3, 4), 5);
   t.end();
 });


### PR DESCRIPTION
`hypot` is in the code generator's function table but was missing from the CSP-safe interpreter's, so `hypot(3, 4)` returns `5` on the default path and throws under `expressionInterpreter`.

Adds the missing entry, plus a test asserting the two tables agree so they can't drift again.

Closes #4328

### Why the scene tests missed it

`dimpvis.vg.json` is in the interpreter's test corpus and calls `hypot` four times — but every call sits inside an `isActive ? … : …` branch not taken on the initial static render, and conditionals are lazily evaluated. Reachable by the corpus, invisible without interaction.

### Divergence audit

Both tables, diffed in both directions:

| Name | Only in | Verdict |
|---|---|---|
| `hypot` | codegen | **Bug** — fixed here |
| `if` | codegen | Intentional — special-cased in `interpret.js` for short-circuiting |
| `join`, `indexof`, `lastindexof`, `slice`, `reverse`, `sort`, `replace` | interpreter | Inert — always shadowed by vega-functions' `functionContext` |

`hypot` was the only real bug.

---

Unrelated, noticed while editing this file: the existing `Date` test is vacuous — it compares `datetime('2005-08-01T00:00:00')` against `new Date(2025, 8, 1, …)` but only asserts `.getDate()`, so it reduces to `1 === 1`. Left alone here.
