### PR TITLE
fix(vega-util): include then in disallowed object properties

### DIFF
--- a/packages/vega-expression/test/codegen-test.js
+++ b/packages/vega-expression/test/codegen-test.js
@@ -340,3 +340,22 @@ tape('Codegen rejects Object.prototype keys whether quoted or not', t => {
 
   t.end();
 });
+
+tape('Codegen rejects then as an object key', t => {
+  const codegen = vega.codegenExpression({ globalvar: 'global' });
+  const compile = str => () => codegen(vega.parseExpression(str));
+
+  // `then` is not an Object.prototype member, so it is not covered by the derived
+  // set and is listed explicitly. It is rejected quoted and unquoted alike.
+  t.throws(compile('{then: 1}'), /Illegal property/);
+  t.throws(compile('{"then": 1}'), /Illegal property/);
+
+  // Also rejected when it is not the first key.
+  t.throws(compile('{a: 1, then: 2}'), /Illegal property/);
+
+  // Similarly named keys are unaffected.
+  t.doesNotThrow(compile('{then_: 1}'));
+  t.doesNotThrow(compile('{thenable: 1}'));
+
+  t.end();
+});

--- a/packages/vega-util/src/interpreter.ts
+++ b/packages/vega-util/src/interpreter.ts
@@ -1,9 +1,15 @@
 /** Utilities common to vega-interpreter and vega-expression for evaluating expresions */
 
-/** JSON authors are not allowed to set these properties, as these are built-in to the JS Object Prototype and should not be overridden. */
+/**
+ * JSON authors are not allowed to set these properties. Most are function-valued members of the JS
+ * Object prototype and should not be overridden; `__proto__` and `then` are listed explicitly
+ * because they are not, but are still given special treatment by the language (`__proto__` as an
+ * accessor for the prototype, `then` by the thenable protocol during promise resolution).
+ */
 export const DisallowedObjectProperties = new Set(
   [...Object.getOwnPropertyNames(Object.prototype)
     .filter(name => typeof Object.prototype[name as keyof typeof Object.prototype] === 'function'),
-  '__proto__'
+  '__proto__',
+  'then'
   ]
 );

--- a/packages/vega-util/src/interpreter.ts
+++ b/packages/vega-util/src/interpreter.ts
@@ -1,10 +1,9 @@
 /** Utilities common to vega-interpreter and vega-expression for evaluating expresions */
 
 /**
- * JSON authors are not allowed to set these properties. Most are function-valued members of the JS
- * Object prototype and should not be overridden; `__proto__` and `then` are listed explicitly
- * because they are not, but are still given special treatment by the language (`__proto__` as an
- * accessor for the prototype, `then` by the thenable protocol during promise resolution).
+ * Properties JSON authors may not set. Most are function-valued members of
+ * Object.prototype; `__proto__` and `then` are listed explicitly because they
+ * are not, but the language still treats them specially.
  */
 export const DisallowedObjectProperties = new Set(
   [...Object.getOwnPropertyNames(Object.prototype)


### PR DESCRIPTION
`then` is handled specially by the language during promise resolution but isn't an `Object.prototype` member, so it isn't covered by the derived set. Adds it explicitly alongside `__proto__` for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)