### PR TITLE
fix(parser): ignore unknown scale spec keys

### DIFF
--- a/packages/vega-parser/src/parsers/scale.js
+++ b/packages/vega-parser/src/parsers/scale.js
@@ -5,12 +5,19 @@ import {aggrField, isSignal, keyFieldRef, ref} from '../util.js';
 
 import {isDiscrete, isQuantile, isValidScaleType} from 'vega-scale';
 import {
-  error, extend, hasOwnProperty, isArray, isObject, isString, stringValue
+  error, extend, hasOwnProperty, isArray, isObject, isString, stringValue, toSet
 } from 'vega-util';
 
 let FIELD_REF_ID = 0;
 
 const MULTIDOMAIN_SORT_OPS  = {min: 'min', max: 'max', count: 'sum'};
+
+const SCALE_PROPERTIES = toSet([
+  'align', 'base', 'bins', 'clamp', 'constant', 'domain', 'domainImplicit',
+  'domainMax', 'domainMid', 'domainMin', 'domainRaw', 'exponent', 'interpolate',
+  'name', 'nice', 'padding', 'paddingInner', 'paddingOuter', 'range', 'reverse',
+  'round', 'type', 'zero'
+]);
 
 export function initScale(spec, scope) {
   const type = spec.type || 'linear';
@@ -48,7 +55,7 @@ export function parseScale(spec, scope) {
   }
 
   for (key in spec) {
-    if (hasOwnProperty(params, key) || key === 'name') continue;
+    if (hasOwnProperty(params, key) || key === 'name' || !SCALE_PROPERTIES[key]) continue;
     params[key] = parseLiteral(spec[key], scope);
   }
 }

--- a/packages/vega-parser/test/scale-test.js
+++ b/packages/vega-parser/test/scale-test.js
@@ -69,6 +69,28 @@ tape('Parser parses Vega specs with scales', t => {
   t.end();
 });
 
+tape('Parser ignores unknown scale spec properties', t => {
+  const spec = {
+    'scales': [
+      {
+        'name': 'xscale',
+        'type': 'linear',
+        'domain': [0, 1],
+        'range': [0, 1],
+        'description': 'annotation',
+        '_description': {'note': 'annotation'}
+      }
+    ]
+  };
+
+  const dfs = parse(spec);
+  const scale = dfs.operators.find(o => o.type === 'scale');
+
+  t.equal(scale.params.description, undefined);
+  t.equal(scale.params._description, undefined);
+  t.end();
+});
+
 tape('Parser parses Vega specs with multi-domain scales', t => {
   const spec = {
     'data': [


### PR DESCRIPTION
Fixes #4329.

## Description

Filters scale specifications against known scale properties before forwarding parameters into the runtime scale operator. This prevents extension or unknown spec keys from reaching `Scale` and emitting spurious `Unsupported scale property` warnings.

## Testing

- `npx tape packages/vega-parser/test/scale-test.js`
- `npx lerna run build --scope vega-transforms --include-dependencies`
- `npm test --workspace vega-parser`
- `git diff --check`
