### PR TITLE
chore: add name to root package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,10 @@
 {
-  "name": "release",
+  "name": "vega",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "vega",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "vega",
   "private": true,
   "license": "BSD-3-Clause",
   "type": "module",


### PR DESCRIPTION
The root `package.json` has no `name`, so npm derives `package-lock.json`'s root `"name"` from whichever directory `npm install` runs in. `main` currently says `"release"`, leaked from a release once prepared in a directory of that name. Anyone installing from a differently-named checkout rewrites that line, and it will recur every release.

Adds `"name": "vega"` and refreshes the lockfile. The root package is `private: true`, so this has no publishing implications.

Verified: `npm install` from a directory named `root-name` now produces `"name": "vega"`, so the lockfile no longer tracks the directory; `npm ci` succeeds (manifest and lockfile in sync); `npm ls --depth=0` still resolves workspaces, with `vega@6.4.0 -> ./packages/vega` linking to the workspace rather than the root despite the shared name; `npx lerna list` finds all 34 packages; `npm run build` and `TZ=America/Los_Angeles npm run test` both pass (32 projects + vega-typings + lint). Checked the things that read a package name — the root `rollup.config.js` resolves `./package.json` per-package and uses only `exports`/`jsdelivr`/`dependencies`, `scripts/build-editor-preview.sh` reads only `packages/*/package.json`, and no workflow depends on the root name.