### PR TITLE
docs: update "vega__latest" version (in docs) to 6.4.0

### DIFF
--- a/docs/_data/versions.yml
+++ b/docs/_data/versions.yml
@@ -1,4 +1,4 @@
-vega__latest: "6.1.2"
+vega__latest: "6.4.0"
 schema: "6"
 vega: "6"
 interpreter: "1"


### PR DESCRIPTION
Noticed that this version isn't necessarily linked in the public docs; this value updates the version listed on the Vega docs homepage.