### PR TITLE
perf: Optimize Symbol Bounds Calculation

### DIFF
--- a/packages/vega-scenegraph/src/marks/markItemPath.js
+++ b/packages/vega-scenegraph/src/marks/markItemPath.js
@@ -6,14 +6,14 @@ import {pickPath} from '../util/canvas/pick.js';
 import {rotateItem} from '../util/svg/transform.js';
 import {DegToRad} from '../util/constants.js';
 
-export default function(type, shape, isect) {
+export default function(type, shape, isect, bound) {
 
   function attr(emit, item) {
     emit('transform', rotateItem(item));
     emit('d', shape(null, item));
   }
 
-  function bound(bounds, item) {
+  function defaultBound(bounds, item) {
     shape(context(bounds, item.angle), item);
     return boundStroke(bounds, item, true).translate(item.x || 0, item.y || 0);
   }
@@ -36,7 +36,7 @@ export default function(type, shape, isect) {
     tag:    'path',
     nested: false,
     attr:   attr,
-    bound:  bound,
+    bound:  bound || defaultBound,
     draw:   drawAll(draw),
     pick:   pickPath(draw),
     isect:  isect || intersectPath(draw)

--- a/packages/vega-scenegraph/src/marks/symbol.js
+++ b/packages/vega-scenegraph/src/marks/symbol.js
@@ -1,5 +1,28 @@
-import {symbol} from '../path/shapes.js';
-import {intersectPoint} from '../util/intersect.js';
-import markItemPath from './markItemPath.js';
+const unitBounds = Object.create(null);
 
-export default markItemPath('symbol', symbol, intersectPoint);
+function unitBox(shape) {
+  let box = unitBounds[shape];
+
+  if (box === undefined) {
+    // Size 4 gives a scale of 1.
+    const b = new Bounds();
+    symbol(boundContext(b, 0), {shape, size: 4});
+    box = unitBounds[shape] = [b.x1, b.y1, b.x2, b.y2];
+  }
+
+  return box;
+}
+
+function bound(bounds, item) {
+  if (item.angle) {
+    // Rotated shapes need their bounds recalculated.
+    symbol(boundContext(bounds, item.angle), item);
+  } else {
+    const u = unitBox(item.shape || 'circle'),
+          r = Math.sqrt(item.size != null ? item.size : 64) / 2;
+
+    bounds.set(u[0] * r, u[1] * r, u[2] * r, u[3] * r);
+  }
+
+  return boundStroke(bounds, item, true).translate(item.x || 0, item.y || 0);
+}

--- a/packages/vega-scenegraph/src/marks/symbol.js
+++ b/packages/vega-scenegraph/src/marks/symbol.js
@@ -1,12 +1,21 @@
+import { symbol } from '../path/shapes.js';
+import { intersectPoint } from '../util/intersect.js';
+import markItemPath from './markItemPath.js';
+
 const unitBounds = Object.create(null);
+
+/** Size used to construct unit bounds, resulting in a scale factor of 1. */
+const UNIT_SYMBOL_SIZE = 4;
+
+/** Fallback symbol size used when no size is specified. Results in radius of 4. */
+const FALLBACK_SYMBOL_SIZE = 64;
 
 function unitBox(shape) {
   let box = unitBounds[shape];
 
   if (box === undefined) {
-    // Size 4 gives a scale of 1.
     const b = new Bounds();
-    symbol(boundContext(b, 0), {shape, size: 4});
+    symbol(boundContext(b, 0), { shape, size: UNIT_SYMBOL_SIZE });
     box = unitBounds[shape] = [b.x1, b.y1, b.x2, b.y2];
   }
 
@@ -18,8 +27,9 @@ function bound(bounds, item) {
     // Rotated shapes need their bounds recalculated.
     symbol(boundContext(bounds, item.angle), item);
   } else {
-    const u = unitBox(item.shape || 'circle'),
-          r = Math.sqrt(item.size != null ? item.size : 64) / 2;
+    const u = unitBox(item.shape || 'circle');
+    const size = item.size ?? FALLBACK_SYMBOL_SIZE;
+    const r = Math.sqrt(size) / 2;
 
     bounds.set(u[0] * r, u[1] * r, u[2] * r, u[3] * r);
   }

--- a/packages/vega-scenegraph/src/marks/symbol.js
+++ b/packages/vega-scenegraph/src/marks/symbol.js
@@ -7,15 +7,12 @@ import markItemPath from './markItemPath.js';
 
 const unitBounds = Object.create(null);
 
-/** Size used to construct unit bounds, resulting in a scale factor of 1. */
-const UNIT_SYMBOL_SIZE = 4;
-
 function unitBox(shape) {
   let box = unitBounds[shape];
 
   if (box === undefined) {
     const b = new Bounds();
-    symbol(boundContext(b, 0), {shape, size: UNIT_SYMBOL_SIZE});
+    symbol(boundContext(b, 0), {shape, size: 4}); // sqrt(4) / 2 = 1, a unit box
     box = unitBounds[shape] = [b.x1, b.y1, b.x2, b.y2];
   }
 

--- a/packages/vega-scenegraph/src/marks/symbol.js
+++ b/packages/vega-scenegraph/src/marks/symbol.js
@@ -1,7 +1,7 @@
 import Bounds from '../Bounds.js';
 import boundContext from '../bound/boundContext.js';
 import boundStroke from '../bound/boundStroke.js';
-import {symbol} from '../path/shapes.js';
+import {DefaultSymbolSize, symbol} from '../path/shapes.js';
 import {intersectPoint} from '../util/intersect.js';
 import markItemPath from './markItemPath.js';
 
@@ -10,15 +10,12 @@ const unitBounds = Object.create(null);
 /** Size used to construct unit bounds, resulting in a scale factor of 1. */
 const UNIT_SYMBOL_SIZE = 4;
 
-/** Fallback symbol size used when no size is specified. Results in radius of 4. */
-const FALLBACK_SYMBOL_SIZE = 64;
-
 function unitBox(shape) {
   let box = unitBounds[shape];
 
   if (box === undefined) {
     const b = new Bounds();
-    symbol(boundContext(b, 0), { shape, size: UNIT_SYMBOL_SIZE });
+    symbol(boundContext(b, 0), {shape, size: UNIT_SYMBOL_SIZE});
     box = unitBounds[shape] = [b.x1, b.y1, b.x2, b.y2];
   }
 
@@ -26,21 +23,22 @@ function unitBox(shape) {
 }
 
 function bound(bounds, item) {
-  if (item.angle) {
-    // Rotated shapes need their bounds recalculated.
+  const shape = item.shape || 'circle';
+
+  if (item.angle && shape !== 'circle') {
     symbol(boundContext(bounds, item.angle), item);
   } else {
-    const u = unitBox(item.shape || 'circle');
-    const size = item.size ?? FALLBACK_SYMBOL_SIZE;
-    const r = Math.sqrt(size) / 2;
+    const u = unitBox(shape);
+    const r = Math.sqrt(item.size ?? DefaultSymbolSize) / 2;
 
-    bounds.set(u[0] * r, u[1] * r, u[2] * r, u[3] * r);
+    if (r >= 0) {
+      bounds.set(u[0] * r, u[1] * r, u[2] * r, u[3] * r);
+    } else {
+      bounds.clear();
+    }
   }
 
   return boundStroke(bounds, item, true).translate(item.x || 0, item.y || 0);
 }
 
-export default {
-  ...markItemPath('symbol', symbol, intersectPoint),
-  bound
-};
+export default markItemPath('symbol', symbol, intersectPoint, bound);

--- a/packages/vega-scenegraph/src/marks/symbol.js
+++ b/packages/vega-scenegraph/src/marks/symbol.js
@@ -1,5 +1,8 @@
-import { symbol } from '../path/shapes.js';
-import { intersectPoint } from '../util/intersect.js';
+import Bounds from '../Bounds.js';
+import boundContext from '../bound/boundContext.js';
+import boundStroke from '../bound/boundStroke.js';
+import {symbol} from '../path/shapes.js';
+import {intersectPoint} from '../util/intersect.js';
 import markItemPath from './markItemPath.js';
 
 const unitBounds = Object.create(null);
@@ -36,3 +39,8 @@ function bound(bounds, item) {
 
   return boundStroke(bounds, item, true).translate(item.x || 0, item.y || 0);
 }
+
+export default {
+  ...markItemPath('symbol', symbol, intersectPoint),
+  bound
+};

--- a/packages/vega-scenegraph/src/path/shapes.js
+++ b/packages/vega-scenegraph/src/path/shapes.js
@@ -11,6 +11,8 @@ import {
   symbol as d3_symbol
 } from 'd3-shape';
 
+export const DefaultSymbolSize = 64;
+
 function value(a, b) {
   return a != null ? a : b;
 }
@@ -31,7 +33,7 @@ const x =  item => item.x || 0,
       tr = item => value(item.cornerRadiusTopRight, item.cornerRadius) || 0,
       br = item => value(item.cornerRadiusBottomRight, item.cornerRadius) || 0,
       bl = item => value(item.cornerRadiusBottomLeft, item.cornerRadius) || 0,
-      sz = item => value(item.size, 64),
+      sz = item => value(item.size, DefaultSymbolSize),
       ts = item => item.size || 1,
       def = item => !(item.defined === false),
       type = item => symbols(item.shape || 'circle');

--- a/packages/vega-scenegraph/test/symbol-bound-test.js
+++ b/packages/vega-scenegraph/test/symbol-bound-test.js
@@ -1,0 +1,71 @@
+import tape from 'tape';
+import {Bounds, Marks, boundContext, boundStroke} from '../index.js';
+import {symbol} from '../src/path/shapes.js';
+
+const EPSILON = 1e-10;
+
+const shapes = [
+  'circle', 'cross', 'diamond', 'square', 'arrow', 'wedge', 'stroke',
+  'triangle', 'triangle-up', 'triangle-down', 'triangle-right', 'triangle-left',
+  'M-1,-1 L1,-0.5 L0.25,1 Z'
+];
+
+// Use the generic path bound as the reference implementation.
+function replayBound(item) {
+  const b = new Bounds();
+  symbol(boundContext(b, item.angle), item);
+  return boundStroke(b, item, true).translate(item.x || 0, item.y || 0);
+}
+
+function boundEqual(t, item, msg) {
+  const a = replayBound(item),
+        b = Marks.symbol.bound(new Bounds(), item);
+  t.ok(
+    Math.abs(b.x1 - a.x1) < EPSILON &&
+    Math.abs(b.y1 - a.y1) < EPSILON &&
+    Math.abs(b.x2 - a.x2) < EPSILON &&
+    Math.abs(b.y2 - a.y2) < EPSILON,
+    msg + ' -- expected [' + [a.x1, a.y1, a.x2, a.y2] + '], got [' + [b.x1, b.y1, b.x2, b.y2] + ']'
+  );
+}
+
+tape('symbol bound should match the path it replaces', t => {
+  shapes.forEach(shape => {
+    [undefined, 1, 10, 64, 100, 400, 2500].forEach(size => {
+      boundEqual(t, {x: 0, y: 0, size, shape}, shape + ' size ' + size + ' at origin');
+      boundEqual(t, {x: 137.25, y: -42.5, size, shape}, shape + ' size ' + size + ' translated');
+    });
+  });
+  t.end();
+});
+
+tape('symbol bound should match with a stroke', t => {
+  ['circle', 'square', 'triangle-up', 'wedge'].forEach(shape => {
+    [undefined, 0.5, 1, 3].forEach(strokeWidth => {
+      [undefined, 'round', 'bevel'].forEach(strokeJoin => {
+        [undefined, 'square'].forEach(strokeCap => {
+          boundEqual(t,
+            {x: 5, y: 7, size: 100, shape, stroke: 'red', strokeWidth, strokeJoin, strokeCap},
+            shape + ' width ' + strokeWidth + ' join ' + strokeJoin + ' cap ' + strokeCap);
+        });
+      });
+    });
+    boundEqual(t, {x: 5, y: 7, size: 100, shape, stroke: 'red', strokeWidth: 4, opacity: 0},
+      shape + ' zero opacity');
+    boundEqual(t, {x: 5, y: 7, size: 100, shape, stroke: 'red', strokeWidth: 4, strokeOpacity: 0},
+      shape + ' zero stroke opacity');
+    boundEqual(t, {x: 5, y: 7, size: 100, shape, strokeWidth: 4},
+      shape + ' stroke width without a stroke');
+  });
+  t.end();
+});
+
+tape('symbol bound should match when rotated', t => {
+  ['circle', 'square', 'triangle-up', 'wedge', 'stroke'].forEach(shape => {
+    [30, 45, 90, 180, -17.5].forEach(angle => {
+      boundEqual(t, {x: 3, y: -9, size: 400, shape, angle, stroke: 'red', strokeWidth: 2},
+        shape + ' angle ' + angle);
+    });
+  });
+  t.end();
+});

--- a/packages/vega-scenegraph/test/symbol-bound-test.js
+++ b/packages/vega-scenegraph/test/symbol-bound-test.js
@@ -31,7 +31,7 @@ function boundEqual(t, item, msg) {
 
 tape('symbol bound should match the path it replaces', t => {
   shapes.forEach(shape => {
-    [undefined, 1, 10, 64, 100, 400, 2500].forEach(size => {
+    [undefined, null, 0, 1, 10, 64, 100, 400, 2500, -100, NaN].forEach(size => {
       boundEqual(t, {x: 0, y: 0, size, shape}, shape + ' size ' + size + ' at origin');
       boundEqual(t, {x: 137.25, y: -42.5, size, shape}, shape + ' size ' + size + ' translated');
     });


### PR DESCRIPTION
While developing the WebGPU renderer ([vega-webgpu](https://github.com/KaNaDaAT/vega-webgpu)), I noticed that in some benchmarks a large share of the computing cost comes from calculating symbol bounds rather than the actual rendering.

Every symbol draws the same design, just scaled by `sqrt(size) / 2`. This means we can measure the design's bounding box once and scale it for each symbol, instead of replaying the path for every item on every frame.

Here are some of the results from the benchmarks:

| Spec | Symbols | Before | After | Improvement |
|---|---:|---:|---:|---:|
| splom-outer-50k | 800,003 | 144 ms | 16 ms | **9.0x** |
| splom-outer | 5,475 | 1.10 ms | 0.22 ms | **5.0x** |
| scatter-plot-panzoom | 396 | 0.14 ms | 0.04 ms | — |
| contour-scatter | 392 | 0.14 ms | 0.08 ms | — |

I also tested this with the [benchmark animation](https://kanadaat.github.io/vega-webgpu/test/?spec=benchmark&renderer=webgpu), where the number of symbols can be changed interactively:

| Symbols | Frame | Vega dataflow | Our `renderAsync` |
|---:|---:|---:|---:|
| 10k | 4.5 ms | 3.5 ms | 1.0 ms |
| 50k | 17.7 ms | 15.8 ms | 1.9 ms |
| 100k | 34.4 ms | 31.9 ms | 2.5 ms |
| 300k | 96.4 ms | 89.4 ms | 7.0 ms |

Rotated symbols are a little more complicated since their axis-aligned bounding box changes with the angle, so their bounds still need to be recalculated when the rotation changes.
Maybe we can find a way to improve this as well?